### PR TITLE
load challenge bug fix

### DIFF
--- a/frontend/src/ts/elements/commandline-lists.ts
+++ b/frontend/src/ts/elements/commandline-lists.ts
@@ -21,6 +21,7 @@ import * as ModesNotice from "../elements/modes-notice";
 import * as ConfigEvent from "../observables/config-event";
 import * as ShareTestSettingsPopup from "../popups/share-test-settings-popup";
 import { Auth } from "../firebase";
+import * as PageController from "../controllers/page-controller";
 
 export let current: MonkeyTypes.CommandsGroup[] = [];
 
@@ -2491,6 +2492,7 @@ Misc.getChallengeList().then((challenges) => {
       noIcon: true,
       display: challenge.display,
       exec: (): void => {
+        PageController.change("test");
         ChallengeController.setup(challenge.name);
         TestLogic.restart(false, true);
       },


### PR DESCRIPTION
Now, when user loads challenge, website navigate him to the test mode, so challenge loads properly now. Before that change, user could navigate to settings tab, load the challenge and then it would work weird. It was like typing test in settings. Now this function works good

Also, that will be good if somebody will test this cause I did changes in older website version so that works for me and idk if it will work now