### PR TITLE
Add docker-compose and instructions to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,17 +84,19 @@ Alternatively, if you use `nvm` then you can run `nvm install` and `nvm use` (yo
    - Click "Generate New Private Key"
    - Save as `serviceAccountKey.json` inside the `backend/credentials/` directory.
 
-#### Mongo Setup
+#### Backend (optional)
 
 Follow these steps if you want to work on anything involving the database/account system. Otherwise, you can skip this section.
 
-1. Install [MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/) and ensure that it is running
-
 1. Inside the backend folder, copy `example.env` to `.env` in the same directory.
 
-   1. If necessary, uncomment the lines in the `.env` file to use credentials to login to MongoDB.
+2. Setup the database server
 
-1. Optional - Install [MongoDB-compass](https://www.mongodb.com/try/download/compass?tck=docs_compass). This tool can be used to see and manipulate your data visually.
+| Local Server                                                                                                                            | Docker (recommended)                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Install [MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/) and ensure that it is running | <ol><li>Install [Docker](http://www.docker.io/gettingstarted/#h_installation) on your machine</li><li>Run `docker-compose up` from the `./backend` directory.</li></ol> |
+
+3. (Optional) Install [MongoDB-compass](https://www.mongodb.com/try/download/compass?tck=docs_compass). This tool can be used to see and manipulate your data visually.
    1. To connect, type `mongodb://localhost:27017` in the connection string box and press connect. The monkeytype database will be created and shown after the server is started.
 
 ## Building and Running Monkeytype

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+services:
+  monkeytype-redis:
+    container_name: monkeytype-redis
+    image: redis:6.2.6
+    ports:
+      - "${DOCKER_REDIS_PORT:-6379}:${DOCKER_REDIS_PORT:-6379}"
+    restart: on-failure
+    volumes:
+      - redis-data:/data
+    networks:
+      - test-network
+
+  monkeytype-mongodb:
+    container_name: monkeytype-mongodb
+    image: mongo:5.0.8
+    restart: on-failure
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - "${DOCKER_DB_PORT:-27017}:${DOCKER_DB_PORT:-27017}"
+    networks:
+      - test-network
+
+volumes:
+  mongo-data:
+  redis-data:
+networks:
+  test-network:

--- a/backend/example.env
+++ b/backend/example.env
@@ -1,5 +1,7 @@
 DB_NAME=monkeytype
+DOCKER_DB_PORT=27017
 DB_URI=mongodb://localhost:27017
+DOCKER_REDIS_PORT=6379
 REDIS_URI=redis://localhost:6379
 LOG_FOLDER_PATH=./logs/
 # Default log file max size is 10 MB

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "pr-check-language-json": "cd frontend && npx gulp pr-check-language-json",
     "pr-check-other-json": "cd frontend && npx gulp pr-check-other-json",
     "pr-check-ts": "cd frontend && npx gulp pr-check-ts",
-    "pr-check-build-be": "cd backend && npm run build"
+    "pr-check-build-be": "cd backend && npm run build",
+    "docker": "cd backend && docker-compose up"
   },
   "engines": {
     "npm": "8.1.2"


### PR DESCRIPTION
### Description

As discussed: Simple docker compose setup for running redis and mongoDb through docker. Running Redis and MongoDB locally is now as simple as running ``docker-compose up`` (assuming Docker is already installed).