### PR TITLE
add tokyo_night theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1,5 +1,10 @@
 [
   {
+    "name": "tokyo_night",
+    "bgColor": "#1a1b26",
+    "mainColor": "#e0af68"
+  },
+  {
     "name": "dark",
     "bgColor": "#111",
     "mainColor": "#eee"

--- a/frontend/static/themes/tokyo_night.css
+++ b/frontend/static/themes/tokyo_night.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #1a1b26;
+  --main-color: #e0af68;
+  --caret-color: #e0af68;
+  --sub-color: #414868;
+  --sub-alt-color: #414868;
+  --text-color: #c0caf5;
+  --error-color: #f7768e;
+  --error-extra-color: #f7768e;
+  --colorful-error-color: #f7768e;
+  --colorful-error-extra-color: #f7768e;
+}


### PR DESCRIPTION
### Description

I have added the Tokyo Night Theme, based on a famous theme from vscode.

Official Tokyo Night Theme for vscode repo: https://github.com/enkia/tokyo-night-vscode-theme.

This is how it looks:

<img src="https://i.imgur.com/dG3jUyw.png" />

<img src="https://i.imgur.com/F5AwNTP.png" />


Also, thanks for making monkeytype, has been quite helpful to me.