### PR TITLE
Fix punctuation and spelling mistakes on Morshu's quote.

### DIFF
--- a/frontend/static/quotes/english.json
+++ b/frontend/static/quotes/english.json
@@ -31376,7 +31376,7 @@
       "id": 5309
     },
     {
-      "text": "Lamp oil, rope, bombs, you want it? It's yours, my friend. As long as you have enough rupees... Sorry Link, I don't give credit. Come back when you're a little... hmm richer.",
+      "text": "Lamp oil, rope, bombs, you want it? It's yours, my friend, as long as you have enough rubies. Sorry Link, I can't give credit. Come back when you're a little... hmm richer!",
       "source": "Morshu, Link: The Faces of Evil",
       "length": 174,
       "id": 5310

--- a/frontend/static/quotes/english.json
+++ b/frontend/static/quotes/english.json
@@ -31378,7 +31378,7 @@
     {
       "text": "Lamp oil, rope, bombs, you want it? It's yours, my friend, as long as you have enough rubies. Sorry Link, I can't give credit. Come back when you're a little... hmm richer!",
       "source": "Morshu, Link: The Faces of Evil",
-      "length": 174,
+      "length": 172,
       "id": 5310
     },
     {


### PR DESCRIPTION
### Description

As per [this video](https://www.youtube.com/watch?v=X8HSnP1SiI0), Morshu said that Link should give him *rubies* and he "can't give credit."