### PR TITLE
Changed dark magic girl caret color for visibility issues

### DIFF
--- a/frontend/static/themes/dark_magic_girl.css
+++ b/frontend/static/themes/dark_magic_girl.css
@@ -1,7 +1,7 @@
 :root {
   --bg-color: #091f2c;
   --main-color: #f5b1cc;
-  --caret-color: #93e8d3;
+  --caret-color: #a288d9;
   --sub-color: #93e8d3;
   --sub-alt-color: #071823;
   --text-color: #a288d9;


### PR DESCRIPTION
### Description

Since the caret color and the sub color of the theme "dark magic girl" is the same `#93e8d3`, the block caret made it impossible for the user to see the which character they are typing, so I have changed the caret color to the text color `#a288d9` so that the current character is visible again:

### BEFORE
<img width="512" alt="chrome_6763Fygx7v" src="https://user-images.githubusercontent.com/76851476/171048723-4e35f565-13d8-4d47-9fef-39b0b88a085b.png">

### AFTER
<img width="512" alt="chrome_foS7l9JCFh" src="https://user-images.githubusercontent.com/76851476/171048745-3741c9e9-32ea-4517-a15a-ca45870f4bd9.png">


