### PR TITLE
Add get avatar endpoint

### DIFF
--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -197,7 +197,7 @@ export async function udpateDiscordAvatar(
   const { id, avatar } = await getDiscordUser(tokenType, accessToken);
   await UserDAL.updateDiscordAvatar(uid, id, avatar);
 
-  return new MonkeyResponse("Discord avatar retrieved", avatar);
+  return new MonkeyResponse("Discord avatar updated", avatar);
 }
 
 export async function addTag(

--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -183,7 +183,7 @@ export async function unlinkDiscord(
   return new MonkeyResponse("Discord account unlinked");
 }
 
-export async function udpateDiscordAvatar(
+export async function updateDiscordAvatar(
   req: MonkeyTypes.Request
 ): Promise<MonkeyResponse> {
   const { uid } = req.ctx.decodedToken;

--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -183,7 +183,7 @@ export async function unlinkDiscord(
   return new MonkeyResponse("Discord account unlinked");
 }
 
-export async function getDiscordAvatar(
+export async function udpateDiscordAvatar(
   req: MonkeyTypes.Request
 ): Promise<MonkeyResponse> {
   const { uid } = req.ctx.decodedToken;

--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -2,7 +2,7 @@ import * as UserDAL from "../../dal/user";
 import MonkeyError from "../../utils/error";
 import Logger from "../../utils/logger";
 import { MonkeyResponse } from "../../utils/monkey-response";
-import { linkAccount } from "../../utils/discord";
+import { getDiscordUser } from "../../utils/discord";
 import { buildAgentLog } from "../../utils/misc";
 import * as George from "../../tasks/george";
 import admin from "firebase-admin";
@@ -137,7 +137,10 @@ export async function linkDiscord(
     throw new MonkeyError(403, "Banned accounts cannot link with Discord");
   }
 
-  const { id: discordId, avatar } = await linkAccount(tokenType, accessToken);
+  const { id: discordId, avatar } = await getDiscordUser(
+    tokenType,
+    accessToken
+  );
 
   if (!discordId) {
     throw new MonkeyError(
@@ -178,6 +181,23 @@ export async function unlinkDiscord(
   Logger.logToDb("user_discord_unlinked", userInfo.discordId, uid);
 
   return new MonkeyResponse("Discord account unlinked");
+}
+
+export async function getDiscordAvatar(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const { tokenType, accessToken } = req.body;
+
+  const userInfo = await UserDAL.getUser(uid, "get discord avatar");
+  if (!userInfo.discordId) {
+    throw new MonkeyError(404, "User does not have a linked Discord account");
+  }
+
+  const { id, avatar } = await getDiscordUser(tokenType, accessToken);
+  await UserDAL.updateDiscordAvatar(uid, id, avatar);
+
+  return new MonkeyResponse("Discord avatar retrieved", avatar);
 }
 
 export async function addTag(

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -291,7 +291,7 @@ router.post(
   asyncHandler(UserController.unlinkDiscord)
 );
 
-router.get(
+router.put(
   "/discord/avatar",
   RateLimit.userDiscordLink,
   authenticateRequest(),
@@ -301,7 +301,7 @@ router.get(
       accessToken: joi.string().required(),
     },
   }),
-  asyncHandler(UserController.getDiscordAvatar)
+  asyncHandler(UserController.udpateDiscordAvatar)
 );
 
 router.get(

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -301,7 +301,7 @@ router.put(
       accessToken: joi.string().required(),
     },
   }),
-  asyncHandler(UserController.udpateDiscordAvatar)
+  asyncHandler(UserController.updateDiscordAvatar)
 );
 
 router.get(

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -292,6 +292,19 @@ router.post(
 );
 
 router.get(
+  "/discord/avatar",
+  RateLimit.userDiscordLink,
+  authenticateRequest(),
+  validateRequest({
+    body: {
+      tokenType: joi.string().required(),
+      accessToken: joi.string().required(),
+    },
+  }),
+  asyncHandler(UserController.getDiscordAvatar)
+);
+
+router.get(
   "/personalBests",
   RateLimit.userGet,
   authenticateRequest({

--- a/backend/src/dal/user.ts
+++ b/backend/src/dal/user.ts
@@ -408,6 +408,21 @@ export async function unlinkDiscord(uid: string): Promise<UpdateResult> {
   );
 }
 
+export async function updateDiscordAvatar(
+  uid: string,
+  discordId: string,
+  discordAvatar?: string
+): Promise<void> {
+  const updateResult = await getUsersCollection().updateOne(
+    { uid, discordId },
+    { $set: { discordAvatar } }
+  );
+
+  if (updateResult.matchedCount === 0) {
+    throw new MonkeyError(404, "User not found");
+  }
+}
+
 export async function incrementBananas(
   uid: string,
   wpm

--- a/backend/src/utils/discord.ts
+++ b/backend/src/utils/discord.ts
@@ -20,7 +20,7 @@ interface DiscordUser {
   public_flags?: number;
 }
 
-export async function linkAccount(
+export async function getDiscordUser(
   tokenType: string,
   accessToken: string
 ): Promise<DiscordUser> {

--- a/frontend/src/ts/ape/endpoints/users.ts
+++ b/frontend/src/ts/ape/endpoints/users.ts
@@ -142,6 +142,15 @@ export default class Users {
   async unlinkDiscord(): Ape.EndpointData {
     return await this.httpClient.post(`${BASE_PATH}/discord/unlink`);
   }
+  
+  async updateDiscordAvatar(
+    tokenType: string,
+    accessToken: string
+  ): Ape.EndpointData {
+    return await this.httpClient.post(`${BASE_PATH}/discord/avatar`, {
+      payload: { tokenType, accessToken },
+    });
+  }
 
   async addQuoteToFavorites(
     language: string,

--- a/frontend/src/ts/ape/endpoints/users.ts
+++ b/frontend/src/ts/ape/endpoints/users.ts
@@ -142,12 +142,12 @@ export default class Users {
   async unlinkDiscord(): Ape.EndpointData {
     return await this.httpClient.post(`${BASE_PATH}/discord/unlink`);
   }
-  
+
   async updateDiscordAvatar(
     tokenType: string,
     accessToken: string
   ): Ape.EndpointData {
-    return await this.httpClient.post(`${BASE_PATH}/discord/avatar`, {
+    return await this.httpClient.put(`${BASE_PATH}/discord/avatar`, {
       payload: { tokenType, accessToken },
     });
   }


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

- Adds an endpoint to get and update a user's associated discord avatar.
- Depends on the implicit OAuth2 grant flow

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
