### PR TITLE
added "tron_orange" theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -759,4 +759,9 @@
     "bgColor": "#ffffff",
     "mainColor": "#40d672"
   }
+  ,{
+    "name": "tron_orange",
+    "bgColor": "#0d1c1c",
+    "mainColor": "#f0e800"
+}
 ]

--- a/frontend/static/themes/tron_orange.css
+++ b/frontend/static/themes/tron_orange.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #0d1c1c;
+    --main-color: #f0e800;
+    --caret-color: #f0e800;
+    --sub-color: #ff6600;
+    --sub-alt-color: #9c9191;
+    --text-color: #ffffff;
+    --error-color: #ff0000;
+    --error-extra-color: #ff0000;
+    --colorful-error-color: #ff0000;
+    --colorful-error-extra-color: #ff0000;
+  }


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->
1. Created "tron_orange.css" file in ./frontend/static/themes/
2. Added corresponding hex codes for the theme in ./frontend/static/themes/_list.json

![img1](https://user-images.githubusercontent.com/86545748/171998835-74170a29-76b0-45ea-8894-13740c107c8b.JPG)
-flip test colors and colorful mode disabled
![img2](https://user-images.githubusercontent.com/86545748/171998897-92ec466b-93ab-4a1c-ba21-63c21eab94ba.JPG)
-flip test colors enabled only
![img3](https://user-images.githubusercontent.com/86545748/171998914-ff2e6ca7-7879-44d4-966f-2d0d7ee3ad6c.JPG)
-colorful mode enabled only
![img4](https://user-images.githubusercontent.com/86545748/171998921-3f573617-8181-4c63-90cc-2f88fb474430.JPG)
-flip test colors and colorful mode enabled


Closes #

