### PR TITLE
Add Custom Filters

### DIFF
--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -186,6 +186,34 @@ export async function unlinkDiscord(
   return new MonkeyResponse("Discord account unlinked");
 }
 
+export async function getResultFilters(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const res = await UserDAL.getResultFilters(uid);
+  return new MonkeyResponse("Found Result filters", res);
+}
+
+export async function addResultFilter(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const filter = req.body;
+
+  const createdId = await UserDAL.addResultFilter(uid, filter);
+  return new MonkeyResponse("Created Result Filter", createdId);
+}
+
+export async function removeResultFilter(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const { filterId } = req.params;
+
+  const result = await UserDAL.removeResultFilter(uid, filterId);
+  return new MonkeyResponse("Result filter deleted", result);
+}
+
 export async function addTag(
   req: MonkeyTypes.Request
 ): Promise<MonkeyResponse> {

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -10,6 +10,7 @@ import {
 import * as RateLimit from "../../middlewares/rate-limit";
 import apeRateLimit from "../../middlewares/ape-rate-limit";
 import { isUsernameValid } from "../../utils/validation";
+import filterSchema from "../schemas/filter-schema";
 
 const router = Router();
 
@@ -166,6 +167,35 @@ router.delete(
   RateLimit.userClearPB,
   authenticateRequest(),
   asyncHandler(UserController.clearPb)
+);
+
+router.get(
+  "/resultFilters",
+  RateLimit.userCustomFilterGet,
+  authenticateRequest(),
+  asyncHandler(UserController.getResultFilters)
+);
+
+router.post(
+  "/resultFilters",
+  RateLimit.userCustomFilterAdd,
+  authenticateRequest(),
+  validateRequest({
+    body: filterSchema,
+  }),
+  asyncHandler(UserController.addResultFilter)
+);
+
+router.delete(
+  "/resultFilters/:filterId",
+  RateLimit.userCustomFilterRemove,
+  authenticateRequest(),
+  validateRequest({
+    params: {
+      filterId: joi.string().required(),
+    },
+  }),
+  asyncHandler(UserController.removeResultFilter)
 );
 
 router.get(

--- a/backend/src/api/schemas/filter-schema.ts
+++ b/backend/src/api/schemas/filter-schema.ts
@@ -1,0 +1,74 @@
+import joi from "joi";
+
+const FILTER_SCHEMA = {
+  _id: joi.string().required(),
+  name: joi.string().required(),
+  difficulty: joi
+    .object({
+      normal: joi.bool().required(),
+      expert: joi.bool().required(),
+      master: joi.bool().required(),
+    })
+    .required(),
+  mode: joi
+    .object({
+      words: joi.bool().required(),
+      time: joi.bool().required(),
+      quote: joi.bool().required(),
+      zen: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  words: joi
+    .object({
+      10: joi.bool().required(),
+      25: joi.bool().required(),
+      50: joi.bool().required(),
+      100: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  time: joi
+    .object({
+      15: joi.bool().required(),
+      30: joi.bool().required(),
+      60: joi.bool().required(),
+      120: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  quoteLength: joi
+    .object({
+      short: joi.bool().required(),
+      medium: joi.bool().required(),
+      long: joi.bool().required(),
+      thicc: joi.bool().required(),
+    })
+    .required(),
+  punctuation: joi
+    .object({
+      on: joi.bool().required(),
+      off: joi.bool().required(),
+    })
+    .required(),
+  numbers: joi
+    .object({
+      on: joi.bool().required(),
+      off: joi.bool().required(),
+    })
+    .required(),
+  date: joi
+    .object({
+      last_day: joi.bool().required(),
+      last_week: joi.bool().required(),
+      last_month: joi.bool().required(),
+      last_3months: joi.bool().required(),
+      all: joi.bool().required(),
+    })
+    .required(),
+  tags: joi.object().required(),
+  language: joi.object().required(),
+  funbox: joi.object().required(),
+};
+
+export default FILTER_SCHEMA;

--- a/backend/src/dal/user.ts
+++ b/backend/src/dal/user.ts
@@ -150,6 +150,47 @@ export async function isDiscordIdAvailable(
   return _.isNil(user);
 }
 
+export async function addResultFilter(
+  uid: string,
+  filter: MonkeyTypes.ResultFilters
+): Promise<ObjectId> {
+  const _id = new ObjectId();
+  await getUsersCollection().updateOne(
+    { uid },
+    { $push: { customFilters: { ...filter, _id } } }
+  );
+  return _id;
+}
+
+export async function getResultFilters(
+  uid: string
+): Promise<MonkeyTypes.ResultFilters[]> {
+  const user = await getUser(uid, "get result filters");
+  return user.customFilters ?? [];
+}
+
+export async function removeResultFilter(
+  uid: string,
+  _id: string
+): Promise<UpdateResult> {
+  const user = await getUser(uid, "remove result filter");
+  const filterId = new ObjectId(_id);
+  if (
+    user.customFilters === undefined ||
+    user.customFilters.filter((t) => t._id.toHexString() === _id).length === 0
+  ) {
+    throw new MonkeyError(404, "Custom filter not found");
+  }
+
+  return await getUsersCollection().updateOne(
+    {
+      uid,
+      "customFilters._id": filterId,
+    },
+    { $pull: { customFilters: { _id: filterId } } }
+  );
+}
+
 export async function addTag(
   uid: string,
   name: string

--- a/backend/src/middlewares/rate-limit.ts
+++ b/backend/src/middlewares/rate-limit.ts
@@ -249,6 +249,27 @@ export const userClearPB = rateLimit({
   handler: customHandler,
 });
 
+export const userCustomFilterGet = rateLimit({
+  windowMs: ONE_HOUR,
+  max: 60 * REQUEST_MULTIPLIER,
+  keyGenerator: getAddress,
+  handler: customHandler,
+});
+
+export const userCustomFilterAdd = rateLimit({
+  windowMs: ONE_HOUR,
+  max: 60 * REQUEST_MULTIPLIER,
+  keyGenerator: getAddress,
+  handler: customHandler,
+});
+
+export const userCustomFilterRemove = rateLimit({
+  windowMs: ONE_HOUR,
+  max: 60 * REQUEST_MULTIPLIER,
+  keyGenerator: getAddress,
+  handler: customHandler,
+});
+
 export const userTagsGet = rateLimit({
   windowMs: ONE_HOUR,
   max: 60 * REQUEST_MULTIPLIER,

--- a/backend/src/types/types.d.ts
+++ b/backend/src/types/types.d.ts
@@ -93,6 +93,69 @@ declare namespace MonkeyTypes {
     needsToChangeName?: boolean;
     discordAvatar?: string;
     badgeIds?: number[];
+    customFilters?: ResultFilters[];
+  }
+
+  interface ResultFilters {
+    _id: ObjectId;
+    name: string;
+    difficulty: {
+      normal: boolean;
+      expert: boolean;
+      master: boolean;
+    };
+    mode: {
+      words: boolean;
+      time: boolean;
+      quote: boolean;
+      zen: boolean;
+      custom: boolean;
+    };
+    words: {
+      10: boolean;
+      25: boolean;
+      50: boolean;
+      100: boolean;
+      custom: boolean;
+    };
+    time: {
+      15: boolean;
+      30: boolean;
+      60: boolean;
+      120: boolean;
+      custom: boolean;
+    };
+    quoteLength: {
+      short: boolean;
+      medium: boolean;
+      long: boolean;
+      thicc: boolean;
+    };
+    punctuation: {
+      on: boolean;
+      off: boolean;
+    };
+    numbers: {
+      on: boolean;
+      off: boolean;
+    };
+    date: {
+      last_day: boolean;
+      last_week: boolean;
+      last_month: boolean;
+      last_3months: boolean;
+      all: boolean;
+    };
+    tags: {
+      [tagId: string]: boolean;
+    };
+    language: {
+      [language: string]: boolean;
+    };
+    funbox: {
+      none?: boolean;
+      [funbox: string]: boolean;
+    };
   }
 
   type UserQuoteRatings = Record<string, Record<string, number>>;

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -4,6 +4,8 @@ import Config from "../config";
 import * as Notifications from "../elements/notifications";
 
 export const defaultResultFilters: MonkeyTypes.ResultFilters = {
+  _id: "default-result-filters-id",
+  name: "default result filters",
   difficulty: {
     normal: true,
     expert: true,
@@ -150,6 +152,11 @@ type AboveChartDisplay = MonkeyTypes.PartialRecord<
 export function updateActive(): void {
   const aboveChartDisplay: AboveChartDisplay = {};
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     aboveChartDisplay[group] = {
       all: true,
       array: [],
@@ -355,6 +362,11 @@ $(
   const filter = $(e.target).attr("filter") as MonkeyTypes.Filter<typeof group>;
   if ($(e.target).hasClass("allFilters")) {
     (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+      // id and name field do not correspond to any ui elements, no need to update
+      if (group === "_id" || group === "name") {
+        return;
+      }
+
       (
         Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
       ).forEach((filter) => {
@@ -371,6 +383,11 @@ $(
     filters["date"]["all"] = true;
   } else if ($(e.target).hasClass("noFilters")) {
     (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+      // id and name field do not correspond to any ui elements, no need to update
+      if (group === "_id" || group === "name") {
+        return;
+      }
+
       if (group !== "date") {
         (
           Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
@@ -404,6 +421,11 @@ $(
 
 $(".pageAccount .topFilters .button.allFilters").on("click", () => {
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     (
       Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
     ).forEach((filter) => {
@@ -425,6 +447,11 @@ $(".pageAccount .topFilters .button.allFilters").on("click", () => {
 
 $(".pageAccount .topFilters .button.currentConfigFilter").on("click", () => {
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     (
       Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
     ).forEach((filter) => {

--- a/frontend/src/ts/ape/endpoints/users.ts
+++ b/frontend/src/ts/ape/endpoints/users.ts
@@ -64,6 +64,20 @@ export default class Users {
     return await this.httpClient.delete(`${BASE_PATH}/personalBests`);
   }
 
+  async getCustomFilters(): Ape.EndpointData {
+    return await this.httpClient.get(`${BASE_PATH}/resultFilters`);
+  }
+
+  async addCustomFilter(filter: MonkeyTypes.ResultFilters): Ape.EndpointData {
+    return await this.httpClient.post(`${BASE_PATH}/resultFilters`, {
+      payload: filter,
+    });
+  }
+
+  async removeCustomFilter(id: string): Ape.EndpointData {
+    return await this.httpClient.delete(`${BASE_PATH}/resultFilters/${id}`);
+  }
+
   async getTags(): Ape.EndpointData {
     return await this.httpClient.get(`${BASE_PATH}/tags`);
   }

--- a/frontend/src/ts/controllers/account-controller.ts
+++ b/frontend/src/ts/controllers/account-controller.ts
@@ -123,6 +123,7 @@ export async function getDataAndInit(): Promise<boolean> {
     });
     // filters = defaultResultFilters;
     ResultFilters.load();
+    ResultFilters.getCustomFilters();
   });
 
   if (snapshot.needsToChangeName) {

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1068,6 +1068,11 @@ $(".pageAccount .content .group.aboveHistory .exportCSV").on("click", () => {
   Misc.downloadResultsCSV(filteredResults);
 });
 
+$(".pageAccount .customFilterButtons .filter-btns").on("click", (e) => {
+  ResultFilters.setCustomFilter(e.target.id);
+  update();
+});
+
 export const page = new Page(
   "account",
   $(".page.pageAccount"),

--- a/frontend/src/ts/popups/new-custom-filter-popup.ts
+++ b/frontend/src/ts/popups/new-custom-filter-popup.ts
@@ -1,0 +1,81 @@
+// the function to call after name is inputed by user
+let callbackFunc: ((name: string) => void) | null = null;
+
+export function show(): void {
+  if ($("#newCustomFilterPopupWrapper").hasClass("hidden")) {
+    $("#newCustomFilterPopupWrapper")
+      .stop(true, true)
+      .css("opacity", 0)
+      .removeClass("hidden")
+      .animate({ opacity: 1 }, 100, () => {
+        $("#newCustomFilterPopup input").trigger("focus").select();
+      });
+  }
+}
+
+export function hide(): void {
+  if (!$("#newCustomFilterPopupWrapper").hasClass("hidden")) {
+    $("#newCustomFilterPopupWrapper")
+      .stop(true, true)
+      .css("opacity", 1)
+      .animate(
+        {
+          opacity: 0,
+        },
+        100,
+        () => {
+          $("#newCustomFilterPopupWrapper").addClass("hidden");
+        }
+      );
+  }
+}
+
+function apply(): void {
+  const name = $("#newCustomFilterPopup input").val() as string;
+  if (callbackFunc) {
+    callbackFunc(name);
+  }
+  hide();
+}
+
+$("#newCustomFilterPopupWrapper").on("click", (e) => {
+  if ($(e.target).attr("id") === "newCustomFilterPopupWrapper") {
+    hide();
+  }
+});
+
+$("#newCustomFilterPopup input").on("keypress", (e) => {
+  if (e.key === "Enter") {
+    apply();
+  }
+});
+
+$("#newCustomFilterPopup .button").on("click", () => {
+  apply();
+});
+
+// this function is called to display the popup,
+// it must specify the callback function to call once the name is selected
+export function showNewCustomFilterePopup(
+  callback: (name: string) => void
+): void {
+  callbackFunc = callback;
+  show();
+}
+
+$(document).on("click", "#top .config .wordCount .text-button", (e) => {
+  const wrd = $(e.currentTarget).attr("wordCount");
+  if (wrd == "custom") {
+    show();
+  }
+});
+
+$(document).on("keydown", (event) => {
+  if (
+    event.key === "Escape" &&
+    !$("#newCustomFilterPopupWrapper").hasClass("hidden")
+  ) {
+    hide();
+    event.preventDefault();
+  }
+});

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -476,6 +476,8 @@ declare namespace MonkeyTypes {
   };
 
   interface ResultFilters {
+    _id: string;
+    name: string;
     difficulty: {
       normal: boolean;
       expert: boolean;

--- a/frontend/static/html/pages/account.html
+++ b/frontend/static/html/pages/account.html
@@ -149,6 +149,7 @@
           <div class="button allFilters">all</div>
           <div class="button currentConfigFilter">current settings</div>
           <div class="button toggleAdvancedFilters">advanced</div>
+          <div class="button toggleCustomFilters">custom</div>
         </div>
       </div>
       <div
@@ -162,6 +163,15 @@
           <div class="button" filter="last_month">last month</div>
           <div class="button" filter="last_3months">last 3 months</div>
           <div class="button" filter="all">all time</div>
+        </div>
+      </div>
+    </div>
+    <div class="group customFilterButtons topFilters" style="display: none">
+      <div class="buttons filter-btns"></div>
+      <div class="buttons">
+        <div class="button" id="createCutomFilterBtn">New Filter</div>
+        <div class="button" id="deleteCutomFilterBtn" style="display: none">
+          Delete Filter
         </div>
       </div>
     </div>

--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -951,3 +951,10 @@
     <input type="text" class="input" placeholder="input" />
   </div>
 </div>
+<div id="newCustomFilterPopupWrapper" class="popupWrapper hidden">
+  <div id="newCustomFilterPopup">
+    <div class="title">New Filter Name</div>
+    <input type="text" value="new filter" />
+    <div class="button">ok</div>
+  </div>
+</div>


### PR DESCRIPTION

### Description

"As a user i would like to be able to save filter configurations to be able to generate mutiple reports"

This PR allows users to create custom filters, which are just `ResultFilter` instances.
Previously the front end would store the `ResultFilter` in the local storage on the browser, however this means only 1 filter can be saved, and it is constantly overriden.
This PR now stores these custom filters in the backend database.

# Creating a filter:
- The user can click on "new filter" at any time and this will create a new custom filter based on the current filters applied.
- The user will be prompted to name the filter

https://user-images.githubusercontent.com/26475724/172541220-47027be5-58a5-49a1-b5f8-36dd72f85b72.mp4


# Applying a custom filter:
- The front end gets all the user's triggers, and if the user clicks on one of them, the filter is applied.

https://user-images.githubusercontent.com/26475724/172541380-bf89229f-f025-4f6b-bec4-34294cc6c2f3.mp4


# Deleting a custom filter:
- When a user is selecting a custom filter, the delete button is dsiplayed
- The user can click this button to permanently delete a custom filter

https://user-images.githubusercontent.com/26475724/172541486-3a2cb819-e32c-4b3e-9f62-6519921123d8.mp4


