### PR TITLE
Fixed a spelling error in Spanish 1k

### DIFF
--- a/frontend/static/languages/spanish_1k.json
+++ b/frontend/static/languages/spanish_1k.json
@@ -416,7 +416,7 @@
     "dirección",
     "papel",
     "demás",
-    "barcelona",
+    "Barcelona",
     "idea",
     "especial",
     "diferentes",


### PR DESCRIPTION
"Barcelona" is spelled with a capital B (such is the case of "Madrid").

