### PR TITLE
Custom Filters [Backend]

### DIFF
--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -186,6 +186,31 @@ export async function unlinkDiscord(
   return new MonkeyResponse("Discord account unlinked");
 }
 
+export async function addResultFilter(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const filter = req.body;
+  const { maxFiltersPerUser } = req.ctx.configuration.customFilters;
+
+  const createdId = await UserDAL.addResultFilter(
+    uid,
+    filter,
+    maxFiltersPerUser
+  );
+  return new MonkeyResponse("Result filter created", createdId);
+}
+
+export async function removeResultFilter(
+  req: MonkeyTypes.Request
+): Promise<MonkeyResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const { filterId } = req.params;
+
+  await UserDAL.removeResultFilter(uid, filterId);
+  return new MonkeyResponse("Result filter deleted");
+}
+
 export async function addTag(
   req: MonkeyTypes.Request
 ): Promise<MonkeyResponse> {

--- a/backend/src/api/routes/users.ts
+++ b/backend/src/api/routes/users.ts
@@ -10,6 +10,7 @@ import {
 import * as RateLimit from "../../middlewares/rate-limit";
 import apeRateLimit from "../../middlewares/ape-rate-limit";
 import { isUsernameValid } from "../../utils/validation";
+import filterSchema from "../schemas/filter-schema";
 
 const router = Router();
 
@@ -166,6 +167,37 @@ router.delete(
   RateLimit.userClearPB,
   authenticateRequest(),
   asyncHandler(UserController.clearPb)
+);
+
+const requireResultFiltersEnabled = validateConfiguration({
+  criteria: (configuration) => {
+    return configuration.customFilters.enabled;
+  },
+  invalidMessage: "Custom Filters are not available at this time.",
+});
+
+router.post(
+  "/resultFilters",
+  RateLimit.userCustomFilterAdd,
+  requireResultFiltersEnabled,
+  authenticateRequest(),
+  validateRequest({
+    body: filterSchema,
+  }),
+  asyncHandler(UserController.addResultFilter)
+);
+
+router.delete(
+  "/resultFilters/:filterId",
+  RateLimit.userCustomFilterRemove,
+  requireResultFiltersEnabled,
+  authenticateRequest(),
+  validateRequest({
+    params: {
+      filterId: joi.string().required(),
+    },
+  }),
+  asyncHandler(UserController.removeResultFilter)
 );
 
 router.get(

--- a/backend/src/api/schemas/filter-schema.ts
+++ b/backend/src/api/schemas/filter-schema.ts
@@ -1,0 +1,74 @@
+import joi from "joi";
+
+const FILTER_SCHEMA = {
+  _id: joi.string().required(),
+  name: joi.string().required(),
+  difficulty: joi
+    .object({
+      normal: joi.bool().required(),
+      expert: joi.bool().required(),
+      master: joi.bool().required(),
+    })
+    .required(),
+  mode: joi
+    .object({
+      words: joi.bool().required(),
+      time: joi.bool().required(),
+      quote: joi.bool().required(),
+      zen: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  words: joi
+    .object({
+      10: joi.bool().required(),
+      25: joi.bool().required(),
+      50: joi.bool().required(),
+      100: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  time: joi
+    .object({
+      15: joi.bool().required(),
+      30: joi.bool().required(),
+      60: joi.bool().required(),
+      120: joi.bool().required(),
+      custom: joi.bool().required(),
+    })
+    .required(),
+  quoteLength: joi
+    .object({
+      short: joi.bool().required(),
+      medium: joi.bool().required(),
+      long: joi.bool().required(),
+      thicc: joi.bool().required(),
+    })
+    .required(),
+  punctuation: joi
+    .object({
+      on: joi.bool().required(),
+      off: joi.bool().required(),
+    })
+    .required(),
+  numbers: joi
+    .object({
+      on: joi.bool().required(),
+      off: joi.bool().required(),
+    })
+    .required(),
+  date: joi
+    .object({
+      last_day: joi.bool().required(),
+      last_week: joi.bool().required(),
+      last_month: joi.bool().required(),
+      last_3months: joi.bool().required(),
+      all: joi.bool().required(),
+    })
+    .required(),
+  tags: joi.object().required(),
+  language: joi.object().required(),
+  funbox: joi.object().required(),
+};
+
+export default FILTER_SCHEMA;

--- a/backend/src/constants/base-configuration.ts
+++ b/backend/src/constants/base-configuration.ts
@@ -42,6 +42,10 @@ export const BASE_CONFIGURATION: MonkeyTypes.Configuration = {
   discordIntegration: {
     enabled: false,
   },
+  customFilters: {
+    enabled: true,
+    maxFiltersPerUser: 0,
+  },
 };
 
 export const CONFIGURATION_FORM_SCHEMA = {
@@ -206,6 +210,21 @@ export const CONFIGURATION_FORM_SCHEMA = {
           type: "number",
           label: "Top Results To Announce",
           min: 1,
+        },
+      },
+    },
+    customFilters: {
+      type: "object",
+      label: "Custom Filters",
+      fields: {
+        enabled: {
+          type: "boolean",
+          label: "Enabled",
+        },
+        maxFiltersPerUser: {
+          type: "number",
+          label: "Max Filters per user",
+          min: 0,
         },
       },
     },

--- a/backend/src/middlewares/rate-limit.ts
+++ b/backend/src/middlewares/rate-limit.ts
@@ -249,6 +249,20 @@ export const userClearPB = rateLimit({
   handler: customHandler,
 });
 
+export const userCustomFilterAdd = rateLimit({
+  windowMs: ONE_HOUR,
+  max: 60 * REQUEST_MULTIPLIER,
+  keyGenerator: getAddress,
+  handler: customHandler,
+});
+
+export const userCustomFilterRemove = rateLimit({
+  windowMs: ONE_HOUR,
+  max: 60 * REQUEST_MULTIPLIER,
+  keyGenerator: getAddress,
+  handler: customHandler,
+});
+
 export const userTagsGet = rateLimit({
   windowMs: ONE_HOUR,
   max: 60 * REQUEST_MULTIPLIER,

--- a/backend/src/types/types.d.ts
+++ b/backend/src/types/types.d.ts
@@ -93,6 +93,69 @@ declare namespace MonkeyTypes {
     needsToChangeName?: boolean;
     discordAvatar?: string;
     badgeIds?: number[];
+    customFilters?: ResultFilters[];
+  }
+
+  interface ResultFilters {
+    _id: ObjectId;
+    name: string;
+    difficulty: {
+      normal: boolean;
+      expert: boolean;
+      master: boolean;
+    };
+    mode: {
+      words: boolean;
+      time: boolean;
+      quote: boolean;
+      zen: boolean;
+      custom: boolean;
+    };
+    words: {
+      10: boolean;
+      25: boolean;
+      50: boolean;
+      100: boolean;
+      custom: boolean;
+    };
+    time: {
+      15: boolean;
+      30: boolean;
+      60: boolean;
+      120: boolean;
+      custom: boolean;
+    };
+    quoteLength: {
+      short: boolean;
+      medium: boolean;
+      long: boolean;
+      thicc: boolean;
+    };
+    punctuation: {
+      on: boolean;
+      off: boolean;
+    };
+    numbers: {
+      on: boolean;
+      off: boolean;
+    };
+    date: {
+      last_day: boolean;
+      last_week: boolean;
+      last_month: boolean;
+      last_3months: boolean;
+      all: boolean;
+    };
+    tags: {
+      [tagId: string]: boolean;
+    };
+    language: {
+      [language: string]: boolean;
+    };
+    funbox: {
+      none?: boolean;
+      [funbox: string]: boolean;
+    };
   }
 
   type UserQuoteRatings = Record<string, Record<string, number>>;

--- a/backend/src/types/types.d.ts
+++ b/backend/src/types/types.d.ts
@@ -47,6 +47,10 @@ declare namespace MonkeyTypes {
     discordIntegration: {
       enabled: boolean;
     };
+    customFilters: {
+      enabled: boolean;
+      maxFiltersPerUser: number;
+    };
   }
 
   interface DecodedToken {


### PR DESCRIPTION
As recommended by @Bruception , This PR is for the Backend and will ovveride #3084 

### Description

"As a user i would like to be able to save filter configurations to be able to generate mutiple reports"

This PR allows users to create custom filters, which are just `ResultFilter` instances.
Previously the front end would store the `ResultFilter` in the local storage on the browser, however this means only 1 filter can be saved, and it is constantly overriden.
This PR now stores these custom filters in the backend database.

# Creating a filter:
- The user can click on "new filter" at any time and this will create a new custom filter based on the current filters applied.
- The user will be prompted to name the filter

https://user-images.githubusercontent.com/26475724/172541220-47027be5-58a5-49a1-b5f8-36dd72f85b72.mp4


# Applying a custom filter:
- The front end gets all the user's triggers, and if the user clicks on one of them, the filter is applied.

https://user-images.githubusercontent.com/26475724/172541380-bf89229f-f025-4f6b-bec4-34294cc6c2f3.mp4


# Deleting a custom filter:
- When a user is selecting a custom filter, the delete button is dsiplayed
- The user can click this button to permanently delete a custom filter

https://user-images.githubusercontent.com/26475724/172541486-3a2cb819-e32c-4b3e-9f62-6519921123d8.mp4


