### PR TITLE
Custom Filters [FrontEnd]

### DIFF
--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -52,7 +52,8 @@
     margin-top: 1rem;
   }
 
-  .topFilters .buttons {
+  .topFilters .buttons,
+  .presetFilterButtons .buttons {
     display: flex;
     justify-content: space-evenly;
     gap: 1rem;
@@ -295,6 +296,21 @@
 }
 
 .pageAccount {
+  .group.presetFilterButtons {
+    .buttons.filter-btns {
+      .filter-presets {
+        display: grid;
+        grid-area: buttons;
+        grid-auto-columns: 1fr;
+        grid-auto-flow: column;
+        grid-template-columns: 6fr 1fr;
+        margin-bottom: 0.5rem;
+        width: 100%;
+        gap: 0.5rem;
+      }
+    }
+  }
+
   .group.filterButtons {
     gap: 1rem;
     display: grid;

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -308,7 +308,6 @@
         grid-auto-columns: 1fr;
         grid-auto-flow: column;
         grid-template-columns: 1fr auto;
-        margin-bottom: 0.5rem;
         width: 100%;
         gap: 0.5rem;
       }

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -52,14 +52,19 @@
     margin-top: 1rem;
   }
 
-  .topFilters .buttons,
-  .presetFilterButtons .buttons {
+  .topFilters .buttons {
     display: flex;
     justify-content: space-evenly;
     gap: 1rem;
     .button {
       width: 100%;
     }
+  }
+
+  .presetFilterButtons .buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
   }
 
   .miniResultChartWrapper {
@@ -300,10 +305,9 @@
     .buttons.filter-btns {
       .filter-presets {
         display: grid;
-        grid-area: buttons;
         grid-auto-columns: 1fr;
         grid-auto-flow: column;
-        grid-template-columns: 6fr 1fr;
+        grid-template-columns: 1fr auto;
         margin-bottom: 0.5rem;
         width: 100%;
         gap: 0.5rem;

--- a/frontend/src/styles/popups.scss
+++ b/frontend/src/styles/popups.scss
@@ -1203,8 +1203,10 @@
   }
 }
 
-#tagsWrapper {
-  #tagsEdit {
+#tagsWrapper,
+#newResultFilterPresetPopupWrapper {
+  #tagsEdit,
+  #newResultFilterPresetPopup {
     background: var(--bg-color);
     border-radius: var(--roundness);
     padding: 2rem;

--- a/frontend/src/styles/z_media-queries.scss
+++ b/frontend/src/styles/z_media-queries.scss
@@ -248,6 +248,9 @@
 }
 
 @media only screen and (max-width: 700px) {
+  .pageAccount .presetFilterButtons .buttons {
+    grid-template-columns: 1fr;
+  }
   .pageAccount {
     .triplegroup {
       grid-template-columns: 1fr 1fr;

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -127,7 +127,7 @@ export async function updateFilterPresets(): Promise<void> {
         `<div class="filter-presets">
           <div class="select-filter-preset button" data-id="${filter._id}">${filter.name} </div>
           <div class="button delete-filter-preset" data-id="${filter._id}">
-            <i class="fas fa-trash"></i>
+            <i class="fas fa-fw fa-trash"></i>
           </div>
         </div>`
       );

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -115,9 +115,12 @@ export async function updateFilterPresets(): Promise<void> {
   // remove all previous filter preset buttons
   $(".pageAccount .presetFilterButtons .filter-btns").html("");
 
-  const filterPresets = DB.getSnapshot().filterPresets.map(
-    (filter) => (filter.name = filter.name.replace(/_/g, " "))
-  );
+  const filterPresets = DB.getSnapshot().filterPresets.map((filter) => {
+    filter.name = filter.name.replace(/_/g, " ");
+    return filter;
+  });
+
+  console.log(filterPresets);
 
   // if user has filter presets
   if (filterPresets.length > 0) {

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -4,6 +4,8 @@ import Config from "../config";
 import * as Notifications from "../elements/notifications";
 
 export const defaultResultFilters: MonkeyTypes.ResultFilters = {
+  _id: "default-result-filters-id",
+  name: "default result filters",
   difficulty: {
     normal: true,
     expert: true,
@@ -150,6 +152,11 @@ type AboveChartDisplay = MonkeyTypes.PartialRecord<
 export function updateActive(): void {
   const aboveChartDisplay: AboveChartDisplay = {};
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     aboveChartDisplay[group] = {
       all: true,
       array: [],
@@ -355,6 +362,11 @@ $(
   const filter = $(e.target).attr("filter") as MonkeyTypes.Filter<typeof group>;
   if ($(e.target).hasClass("allFilters")) {
     (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+      // id and name field do not correspond to any ui elements, no need to update
+      if (group === "_id" || group === "name") {
+        return;
+      }
+
       (
         Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
       ).forEach((filter) => {
@@ -371,6 +383,11 @@ $(
     filters["date"]["all"] = true;
   } else if ($(e.target).hasClass("noFilters")) {
     (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+      // id and name field do not correspond to any ui elements, no need to update
+      if (group === "_id" || group === "name") {
+        return;
+      }
+
       if (group !== "date") {
         (
           Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
@@ -404,6 +421,11 @@ $(
 
 $(".pageAccount .topFilters .button.allFilters").on("click", () => {
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     (
       Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
     ).forEach((filter) => {
@@ -425,6 +447,11 @@ $(".pageAccount .topFilters .button.allFilters").on("click", () => {
 
 $(".pageAccount .topFilters .button.currentConfigFilter").on("click", () => {
   (Object.keys(getFilters()) as MonkeyTypes.Group[]).forEach((group) => {
+    // id and name field do not correspond to any ui elements, no need to update
+    if (group === "_id" || group === "name") {
+      return;
+    }
+
     (
       Object.keys(getGroup(group)) as MonkeyTypes.Filter<typeof group>[]
     ).forEach((filter) => {

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -712,6 +712,6 @@ $(document).on(
   "click",
   ".pageAccount .group.presetFilterButtons .filter-btns .filter-presets .delete-filter-preset",
   (e) => {
-    deleteFilterPreset($(e.target).data("id"));
+    deleteFilterPreset($(e.currentTarget).data("id"));
   }
 );

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -3,6 +3,7 @@ import * as DB from "../db";
 import Config from "../config";
 import * as Notifications from "../elements/notifications";
 import Ape from "../ape/index";
+import * as Loader from "../elements/loader";
 import { showNewResultFilterPresetPopup } from "../popups/new-result-filter-preset-popup";
 
 export const defaultResultFilters: MonkeyTypes.ResultFilters = {
@@ -180,10 +181,13 @@ function addFilterPresetToSnapshot(filter: MonkeyTypes.ResultFilters): void {
 // callback function called by popup once user inputs name
 async function createFilterPresetCallback(name: string): Promise<void> {
   name = name.replace(/ /g, "_");
+  Loader.show();
   const result = await Ape.users.addResultFilterPreset({ ...filters, name });
+  Loader.hide();
   if (result.status === 200) {
     addFilterPresetToSnapshot({ ...filters, name, _id: result.data });
     updateFilterPresets();
+    Notifications.add("Filter preset created", 1);
   } else {
     Notifications.add("Error creating filter preset: " + result.message, -1);
     console.log("error creating filter preset: " + result.message);
@@ -210,11 +214,14 @@ function removeFilterPresetFromSnapshot(id: string): void {
 
 // deletes the currently selected filter preset
 export async function deleteFilterPreset(id: string): Promise<void> {
+  Loader.show();
   const result = await Ape.users.removeResultFilterPreset(id);
+  Loader.hide();
   if (result.status === 200) {
     removeFilterPresetFromSnapshot(id);
     updateFilterPresets();
     reset();
+    Notifications.add("Filter preset deleted", 1);
   } else {
     Notifications.add("Error deleting filter preset: " + result.message, -1);
     console.log("error deleting filter preset", result.message);

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -114,7 +114,9 @@ export async function updateFilterPresets(): Promise<void> {
   // remove all previous filter preset buttons
   $(".pageAccount .presetFilterButtons .filter-btns").html("");
 
-  const filterPresets = DB.getSnapshot().filterPresets;
+  const filterPresets = DB.getSnapshot().filterPresets.map(
+    (filter) => (filter.name = filter.name.replace(/_/g, " "))
+  );
 
   // if user has filter presets
   if (filterPresets.length > 0) {
@@ -177,6 +179,7 @@ function addFilterPresetToSnapshot(filter: MonkeyTypes.ResultFilters): void {
 
 // callback function called by popup once user inputs name
 async function createFilterPresetCallback(name: string): Promise<void> {
+  name = name.replace(/ /g, "_");
   const result = await Ape.users.addResultFilterPreset({ ...filters, name });
   if (result.status === 200) {
     addFilterPresetToSnapshot({ ...filters, name, _id: result.data });

--- a/frontend/src/ts/ape/endpoints/users.ts
+++ b/frontend/src/ts/ape/endpoints/users.ts
@@ -64,6 +64,20 @@ export default class Users {
     return await this.httpClient.delete(`${BASE_PATH}/personalBests`);
   }
 
+  async addResultFilterPreset(
+    filter: MonkeyTypes.ResultFilters
+  ): Ape.EndpointData {
+    return await this.httpClient.post(`${BASE_PATH}/resultFilterPresets`, {
+      payload: filter,
+    });
+  }
+
+  async removeResultFilterPreset(id: string): Ape.EndpointData {
+    return await this.httpClient.delete(
+      `${BASE_PATH}/resultFilterPresets/${id}`
+    );
+  }
+
   async getTags(): Ape.EndpointData {
     return await this.httpClient.get(`${BASE_PATH}/tags`);
   }

--- a/frontend/src/ts/constants/default-snapshot.ts
+++ b/frontend/src/ts/constants/default-snapshot.ts
@@ -24,4 +24,5 @@ export const defaultSnap: MonkeyTypes.Snapshot = {
   quoteRatings: undefined,
   quoteMod: false,
   favoriteQuotes: {},
+  filterPresets: [],
 };

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -89,6 +89,7 @@ export async function initSnapshot(): Promise<
     };
     if (userData.quoteMod === true) snap.quoteMod = true;
     snap.favoriteQuotes = userData.favoriteQuotes ?? {};
+    snap.filterPresets = userData.resultFilterPresets ?? [];
     snap.quoteRatings = userData.quoteRatings;
     snap.favouriteThemes =
       userData.favouriteThemes === undefined ? [] : userData.favouriteThemes;

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1068,6 +1068,11 @@ $(".pageAccount .content .group.aboveHistory .exportCSV").on("click", () => {
   Misc.downloadResultsCSV(filteredResults);
 });
 
+$(".pageAccount .customFilterButtons .filter-btns").on("click", (e) => {
+  ResultFilters.setCustomFilter(e.target.id);
+  update();
+});
+
 export const page = new Page(
   "account",
   $(".page.pageAccount"),

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1060,17 +1060,21 @@ $(document).on(
   }
 );
 
+$(document).on(
+  "click",
+  ".pageAccount .group.presetFilterButtons .filter-btns .filter-presets .select-filter-preset",
+  (e) => {
+    ResultFilters.setFilterPreset($(e.target).data("id"));
+    update();
+  }
+);
+
 $(".pageAccount .content .below .smoothing input").on("input", () => {
   applyHistorySmoothing();
 });
 
 $(".pageAccount .content .group.aboveHistory .exportCSV").on("click", () => {
   Misc.downloadResultsCSV(filteredResults);
-});
-
-$(".pageAccount .customFilterButtons .filter-btns").on("click", (e) => {
-  ResultFilters.setCustomFilter(e.target.id);
-  update();
 });
 
 export const page = new Page(

--- a/frontend/src/ts/popups/new-result-filter-preset-popup.ts
+++ b/frontend/src/ts/popups/new-result-filter-preset-popup.ts
@@ -1,0 +1,81 @@
+// the function to call after name is inputed by user
+let callbackFunc: ((name: string) => void) | null = null;
+
+export function show(): void {
+  if ($("#newResultFilterPresetPopupWrapper").hasClass("hidden")) {
+    $("#newResultFilterPresetPopupWrapper")
+      .stop(true, true)
+      .css("opacity", 0)
+      .removeClass("hidden")
+      .animate({ opacity: 1 }, 100, () => {
+        $("#newResultFilterPresetPopup input").trigger("focus").select();
+      });
+  }
+}
+
+export function hide(): void {
+  if (!$("#newResultFilterPresetPopupWrapper").hasClass("hidden")) {
+    $("#newResultFilterPresetPopupWrapper")
+      .stop(true, true)
+      .css("opacity", 1)
+      .animate(
+        {
+          opacity: 0,
+        },
+        100,
+        () => {
+          $("#newResultFilterPresetPopupWrapper").addClass("hidden");
+        }
+      );
+  }
+}
+
+function apply(): void {
+  const name = $("#newResultFilterPresetPopup input").val() as string;
+  if (callbackFunc) {
+    callbackFunc(name);
+  }
+  hide();
+}
+
+$("#newResultFilterPresetPopupWrapper").on("click", (e) => {
+  if ($(e.target).attr("id") === "newResultFilterPresetPopupWrapper") {
+    hide();
+  }
+});
+
+$("#newResultFilterPresetPopup input").on("keypress", (e) => {
+  if (e.key === "Enter") {
+    apply();
+  }
+});
+
+$("#newResultFilterPresetPopup .button").on("click", () => {
+  apply();
+});
+
+// this function is called to display the popup,
+// it must specify the callback function to call once the name is selected
+export function showNewResultFilterPresetPopup(
+  callback: (name: string) => void
+): void {
+  callbackFunc = callback;
+  show();
+}
+
+$(document).on("click", "#top .config .wordCount .text-button", (e) => {
+  const wrd = $(e.currentTarget).attr("wordCount");
+  if (wrd == "custom") {
+    show();
+  }
+});
+
+$(document).on("keydown", (event) => {
+  if (
+    event.key === "Escape" &&
+    !$("#newResultFilterPresetPopupWrapper").hasClass("hidden")
+  ) {
+    hide();
+    event.preventDefault();
+  }
+});

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -466,6 +466,7 @@ declare namespace MonkeyTypes {
     favoriteQuotes: FavoriteQuotes;
     needsToChangeName?: boolean;
     discordAvatar?: string;
+    filterPresets: ResultFilters[];
   }
 
   type FavoriteQuotes = Record<string, string[]>;

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -476,6 +476,8 @@ declare namespace MonkeyTypes {
   };
 
   interface ResultFilters {
+    _id: string;
+    name: string;
     difficulty: {
       normal: boolean;
       expert: boolean;

--- a/frontend/static/html/pages/account.html
+++ b/frontend/static/html/pages/account.html
@@ -135,6 +135,12 @@
 
     <div id="ad_account" class="hidden"></div>
 
+    <div class="group presetFilterButtons" style="display: none">
+      <div class="buttonsAndTitle">
+        <div class="title">filter presets</div>
+        <div class="buttons filter-btns" style="grid-column: 1/3"></div>
+      </div>
+    </div>
     <div class="group topFilters">
       <!-- <div
         class="button"
@@ -149,6 +155,10 @@
           <div class="button allFilters">all</div>
           <div class="button currentConfigFilter">current settings</div>
           <div class="button toggleAdvancedFilters">advanced</div>
+          <div class="button createFilterPresetBtn">
+            <i class="fas fa-save fa-fw"></i>
+            save as preset
+          </div>
         </div>
       </div>
       <div

--- a/frontend/static/html/pages/account.html
+++ b/frontend/static/html/pages/account.html
@@ -155,10 +155,7 @@
           <div class="button allFilters">all</div>
           <div class="button currentConfigFilter">current settings</div>
           <div class="button toggleAdvancedFilters">advanced</div>
-          <div class="button createFilterPresetBtn">
-            <i class="fas fa-save fa-fw"></i>
-            save as preset
-          </div>
+          <div class="button createFilterPresetBtn">save as preset</div>
         </div>
       </div>
       <div

--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -956,3 +956,10 @@
     <input type="text" class="input" placeholder="input" />
   </div>
 </div>
+<div id="newResultFilterPresetPopupWrapper" class="popupWrapper hidden">
+  <div id="newResultFilterPresetPopup">
+    <div class="title">New Filter Preset Name</div>
+    <input type="text" style="margin-top: 2rem" value="new_preset" />
+    <div class="button" style="margin-top: 2rem">ok</div>
+  </div>
+</div>

--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -958,8 +958,8 @@
 </div>
 <div id="newResultFilterPresetPopupWrapper" class="popupWrapper hidden">
   <div id="newResultFilterPresetPopup">
-    <div class="title">New Filter Preset Name</div>
-    <input type="text" style="margin-top: 2rem" value="new_preset" />
-    <div class="button" style="margin-top: 2rem">ok</div>
+    <div class="title">Add new filter preset</div>
+    <input type="text" style="margin-top: 2rem" value="new preset" />
+    <div class="button" style="margin-top: 2rem">add</div>
   </div>
 </div>

--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -959,7 +959,7 @@
 <div id="newResultFilterPresetPopupWrapper" class="popupWrapper hidden">
   <div id="newResultFilterPresetPopup">
     <div class="title">Add new filter preset</div>
-    <input type="text" style="margin-top: 2rem" value="new preset" />
-    <div class="button" style="margin-top: 2rem">add</div>
+    <input type="text" value="new preset" />
+    <div class="button">add</div>
   </div>
 </div>


### PR DESCRIPTION
As recommended by @Bruception , This PR is for the FrontEnd and will ovveride #3084 
NOTE: I will rebase this pr onto main once #3105 is merged, so ignore the backend changes in the pr, they are from the previous pr

### Description

"As a user i would like to be able to save filter configurations to be able to generate mutiple reports"

This PR allows users to create custom filters, which are just `ResultFilter` instances.
Previously the front end would store the `ResultFilter` in the local storage on the browser, however this means only 1 filter can be saved, and it is constantly overriden.
This PR now stores these custom filters in the backend database.

### UPDATED UI AND FLOW:

#### Updated flow:
- When the user clicks on the preset button, the filter preset section opens up
- The user can click on “save filter as preset” which will prompt them to select a name
- When the user clicks on an existing preset, the preset button is highlighted and the filters are set to the preset
- When the user changes the filters in any way (time frame, language, mode etc) the custom filter button is deselected, as the applied filters are no longer matching the preset 
- When a user selects a preset and its button is highlighted, the “delete preset” button appears
- When the user presses on the delete button, the preset is deleted


https://user-images.githubusercontent.com/26475724/173274961-a31f2989-cb9a-452c-a75f-949705ad7d85.mp4


