### PR TITLE
fix: hide account icon when using discord avatar

### DIFF
--- a/frontend/src/ts/elements/account-button.ts
+++ b/frontend/src/ts/elements/account-button.ts
@@ -29,8 +29,8 @@ export function update(discordId?: string, discordAvatar?: string): void {
       const avatarUrl = `https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png`;
       $("<img/>")
         .attr("src", avatarUrl)
-        .on("load", function () {
-          $(this).remove();
+        .on("load", (event) => {
+          $(event.currentTarget).remove();
 
           usingAvatar = true;
           $("#top #menu .account .avatar").css(

--- a/frontend/src/ts/elements/account-button.ts
+++ b/frontend/src/ts/elements/account-button.ts
@@ -25,12 +25,23 @@ export function update(discordId?: string, discordAvatar?: string): void {
   if (Auth.currentUser != null) {
     if (discordAvatar && discordId) {
       usingAvatar = true;
-      $("#top #menu .account .avatar").css(
-        "background-image",
-        `url(https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png)`
-      );
-      $("#top #menu .account .icon").addClass("hidden");
-      $("#top #menu .account .avatar").removeClass("hidden");
+
+      // Replace font-awesome account icon with Discord avatar only if it loads successfully
+      // https://stackoverflow.com/a/5058336/9080819
+      const avatarUrl = `https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png`;
+      $("<img/>")
+        .attr("src", avatarUrl)
+        .on("load", function () {
+          $(this).remove();
+
+          $("#top #menu .account .avatar").css(
+            "background-image",
+            `url(${avatarUrl})`
+          );
+
+          $("#top #menu .account .icon").addClass("hidden");
+          $("#top #menu .account .avatar").removeClass("hidden");
+        });
     } else {
       $("#top #menu .account .avatar").addClass("hidden");
     }

--- a/frontend/src/ts/elements/account-button.ts
+++ b/frontend/src/ts/elements/account-button.ts
@@ -24,8 +24,6 @@ export function loading(truefalse: boolean): void {
 export function update(discordId?: string, discordAvatar?: string): void {
   if (Auth.currentUser != null) {
     if (discordAvatar && discordId) {
-      usingAvatar = true;
-
       // Replace font-awesome account icon with Discord avatar only if it loads successfully
       // https://stackoverflow.com/a/5058336/9080819
       const avatarUrl = `https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png`;
@@ -34,6 +32,7 @@ export function update(discordId?: string, discordAvatar?: string): void {
         .on("load", function () {
           $(this).remove();
 
+          usingAvatar = true;
           $("#top #menu .account .avatar").css(
             "background-image",
             `url(${avatarUrl})`

--- a/frontend/src/ts/elements/account-button.ts
+++ b/frontend/src/ts/elements/account-button.ts
@@ -29,6 +29,7 @@ export function update(discordId?: string, discordAvatar?: string): void {
         "background-image",
         `url(https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png)`
       );
+      $("#top #menu .account .icon").addClass("hidden");
       $("#top #menu .account .avatar").removeClass("hidden");
     } else {
       $("#top #menu .account .avatar").addClass("hidden");


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

- Hide the avatar icon when using an avatar from discord.
- Prevents the avatar icon from being shown underneath a transparent discord avatar

Before:
![avatar before](https://user-images.githubusercontent.com/31896377/174497147-846fb68f-0b23-47f6-9ce5-8ff5250a0765.PNG)

After:
![avatar after](https://user-images.githubusercontent.com/31896377/174497150-31ee9177-5b37-4348-a406-dfbea69038df.PNG)


<!-- Closes # -->

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
