### PR TITLE
Fix escaped HTML for banner notifications

### DIFF
--- a/frontend/src/ts/elements/notifications.ts
+++ b/frontend/src/ts/elements/notifications.ts
@@ -34,7 +34,7 @@ class Notification {
   ) {
     this.type = type;
     this.message =
-      this.type === "Notification" ? Misc.escapeHTML(message) : message;
+      this.type === "notification" ? Misc.escapeHTML(message) : message;
     this.level = level;
     if (type === "banner") {
       this.duration = duration as number;

--- a/frontend/src/ts/elements/notifications.ts
+++ b/frontend/src/ts/elements/notifications.ts
@@ -33,7 +33,8 @@ class Notification {
     }
   ) {
     this.type = type;
-    this.message = Misc.escapeHTML(message);
+    this.message =
+      this.type === "Notification" ? Misc.escapeHTML(message) : message;
     this.level = level;
     if (type === "banner") {
       this.duration = duration as number;


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

- Only escapes html for non-banner notifications

Before:
![Screen Shot 2022-06-19 at 7 24 52 PM](https://user-images.githubusercontent.com/58147810/174504191-ac30941d-2469-4dfe-838a-55c806b3c119.png)

After:
![Screen Shot 2022-06-19 at 7 25 09 PM](https://user-images.githubusercontent.com/58147810/174504173-55ad17f9-a35c-49f5-9503-777b0f266208.png)


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
