### PR TITLE
Fix webpack hot reload not working on html file changes.

### DIFF
--- a/frontend/webpack/config.base.js
+++ b/frontend/webpack/config.base.js
@@ -18,7 +18,8 @@ const htmlWebpackPlugins = [
   return new HtmlWebpackPlugin({
     filename: `${name}.html`,
     template: resolve(__dirname, `../static/${name}.html`),
-    inject: false,
+    inject: "body",
+    cache: false,
   });
 });
 

--- a/frontend/webpack/config.base.js
+++ b/frontend/webpack/config.base.js
@@ -8,21 +8,6 @@ const ExtraWatchWebpackPlugin = require("extra-watch-webpack-plugin");
 
 let circularImports = 0;
 
-const htmlWebpackPlugins = [
-  "terms-of-service",
-  "security-policy",
-  "privacy-policy",
-  "email-handler",
-  "das",
-].map((name) => {
-  return new HtmlWebpackPlugin({
-    filename: `${name}.html`,
-    template: resolve(__dirname, `../static/${name}.html`),
-    inject: "body",
-    cache: false,
-  });
-});
-
 /** @type { import('webpack').Configuration } */
 const BASE_CONFIG = {
   entry: {
@@ -111,7 +96,6 @@ const BASE_CONFIG = {
       template: resolve(__dirname, "../static/main.html"),
       inject: "body",
     }),
-    ...htmlWebpackPlugins,
     new MiniCssExtractPlugin({
       filename: "./css/style.[chunkhash:8].css",
     }),

--- a/frontend/webpack/config.dev.js
+++ b/frontend/webpack/config.dev.js
@@ -9,6 +9,8 @@ const DEV_CONFIG = {
     compress: true,
     port: 3000,
     open: true,
+    hot: false,
+    liveReload: true,
     historyApiFallback: true,
     client: {
       overlay: false,

--- a/frontend/webpack/config.dev.js
+++ b/frontend/webpack/config.dev.js
@@ -1,5 +1,22 @@
+const { resolve } = require("path");
 const { merge } = require("webpack-merge");
 const BASE_CONFIG = require("./config.base");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+const htmlWebpackPlugins = [
+  "terms-of-service",
+  "security-policy",
+  "privacy-policy",
+  "email-handler",
+  "das",
+].map((name) => {
+  return new HtmlWebpackPlugin({
+    filename: `${name}.html`,
+    template: resolve(__dirname, `../static/${name}.html`),
+    inject: "body",
+    cache: false,
+  });
+});
 
 /** @type { import('webpack').Configuration } */
 const DEV_CONFIG = {
@@ -16,6 +33,8 @@ const DEV_CONFIG = {
       overlay: false,
     },
   },
+
+  plugins: htmlWebpackPlugins,
 };
 
 module.exports = merge(BASE_CONFIG, DEV_CONFIG);

--- a/frontend/webpack/config.prod.js
+++ b/frontend/webpack/config.prod.js
@@ -1,9 +1,24 @@
+const { resolve } = require("path");
 const { merge } = require("webpack-merge");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const HtmlMinimizerPlugin = require("html-minimizer-webpack-plugin");
 const JsonMinimizerPlugin = require("json-minimizer-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 const BASE_CONFIG = require("./config.base");
+
+const htmlWebpackPlugins = [
+  "terms-of-service",
+  "security-policy",
+  "privacy-policy",
+  "email-handler",
+  "das",
+].map((name) => {
+  return new HtmlWebpackPlugin({
+    filename: `${name}.html`,
+    template: resolve(__dirname, `../static/${name}.html`),
+  });
+});
 
 function pad(numbers, maxLength, fillString) {
   return numbers.map((number) =>
@@ -63,6 +78,7 @@ const PRODUCTION_CONFIG = {
       new CssMinimizerPlugin(),
     ],
   },
+  plugins: htmlWebpackPlugins,
 };
 
 module.exports = merge(BASE_CONFIG, PRODUCTION_CONFIG);

--- a/frontend/webpack/config.prod.js
+++ b/frontend/webpack/config.prod.js
@@ -17,6 +17,7 @@ const htmlWebpackPlugins = [
   return new HtmlWebpackPlugin({
     filename: `${name}.html`,
     template: resolve(__dirname, `../static/${name}.html`),
+    inject: false,
   });
 });
 


### PR DESCRIPTION
Credits to @devkennyy for leading me to mess around with webpack and fix this 

The `monkeytype.js` bundle has to be included in html files for the webpack live reload to work. I inferred this from the tests. Hence I have began including `monkeytype.js` bundle in html files in `development` mode but not in production mode.

This will provide us with the best of the both worlds as we will be able to enjoy live reload in html files in development mode and not have to bear unnecessary load on the server in production for serving javascript bundles.
