### PR TITLE
Safe leaderboard avatar loading

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,4 @@ log_success.txt
 log_failed.txt
 build
 worker.*
+docker-compose.override.yml

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -135,7 +135,9 @@
           grid-template-columns: 1.25rem max-content auto;
           gap: 0.5rem;
           place-items: center left;
-          .avatarPlaceholder {
+          .avatar {
+            display: flex;
+
             width: 1.25rem;
             height: 1.25rem;
             font-size: 1.25rem;
@@ -144,10 +146,7 @@
             // display: grid;
             // place-content: center center;
             border-radius: 100%;
-            margin-top: -0.25rem;
-          }
-          .avatarPlaceholder,
-          .avatar {
+
             grid-row: 1/2;
             grid-column: 1/2;
           }

--- a/frontend/src/ts/elements/account-button.ts
+++ b/frontend/src/ts/elements/account-button.ts
@@ -1,5 +1,6 @@
 import { Auth } from "../firebase";
 import * as Misc from "../utils/misc";
+import { loadDiscordAvatar } from "../utils/load-discord-avatar";
 
 let usingAvatar = false;
 
@@ -23,27 +24,21 @@ export function loading(truefalse: boolean): void {
 
 export function update(discordId?: string, discordAvatar?: string): void {
   if (Auth.currentUser != null) {
-    if (discordAvatar && discordId) {
-      // Replace font-awesome account icon with Discord avatar only if it loads successfully
-      // https://stackoverflow.com/a/5058336/9080819
-      const avatarUrl = `https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}.png`;
-      $("<img/>")
-        .attr("src", avatarUrl)
-        .on("load", (event) => {
-          $(event.currentTarget).remove();
+    loadDiscordAvatar(discordId, discordAvatar)
+      .then((avatarUrl) => {
+        usingAvatar = true;
 
-          usingAvatar = true;
-          $("#top #menu .account .avatar").css(
-            "background-image",
-            `url(${avatarUrl})`
-          );
+        $("#top #menu .account .avatar").css(
+          "background-image",
+          `url(${avatarUrl})`
+        );
 
-          $("#top #menu .account .icon").addClass("hidden");
-          $("#top #menu .account .avatar").removeClass("hidden");
-        });
-    } else {
-      $("#top #menu .account .avatar").addClass("hidden");
-    }
+        $("#top #menu .account .icon").addClass("hidden");
+        $("#top #menu .account .avatar").removeClass("hidden");
+      })
+      .catch(() => {
+        usingAvatar = false;
+      });
     Misc.swapElements(
       $("#menu .text-button.login"),
       $("#menu .text-button.account"),

--- a/frontend/src/ts/utils/load-discord-avatar.ts
+++ b/frontend/src/ts/utils/load-discord-avatar.ts
@@ -1,0 +1,25 @@
+/**
+ * Replace font-awesome account icon with Discord avatar only if it loads successfully
+ * https://stackoverflow.com/a/5058336/9080819
+ * @param discordId Discord ID of the user
+ * @param discordAvatar Discord Avatar ID of the user
+ * @returns A promise that resolves to the avatar URL if it was loaded successfully, rejects otherwise.
+ */
+export const loadDiscordAvatar = async (
+  discordId?: string,
+  discordAvatar?: string
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    if (!discordId || !discordAvatar) reject();
+
+    const avatarUrl = `https://cdn.discordapp.com/avatars/${discordId}/${discordAvatar}`;
+
+    $("<img/>")
+      .attr("src", avatarUrl)
+      .on("load", (event) => {
+        $(event.currentTarget).remove();
+        resolve(avatarUrl);
+      })
+      .on("error", () => reject());
+  });
+};


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

As requested by @Miodec here
https://github.com/monkeytypegame/monkeytype/pull/3162#issuecomment-1160331780

- Refactor the Discord avatar loading logic I wrote in #3162  into `loadDiscordAvatar` util function
- Use `loadDiscordAvatar` in both the account button and leaderboard avatars
- Adjust leaderboard avatar styling

![leaderboard avatars](https://user-images.githubusercontent.com/31896377/174659998-702d2104-41a2-4450-bf0f-cfb21b0d666e.PNG)



<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
