### PR TITLE
replaced edit with save

### DIFF
--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -987,6 +987,6 @@
       <label>website</label>
       <input class="website" type="text" value="" />
     </div>
-    <div class="button edit-profile-submit">edit</div>
+    <div class="button edit-profile-submit">save</div>
   </div>
 </div>


### PR DESCRIPTION
replaced the edit field in edit profile to 'save'. felt a little misleading since we were already editing and should be saving our changes. 