### PR TITLE
Fix typo in language `code_haskell`

### DIFF
--- a/frontend/static/languages/code_haskell.json
+++ b/frontend/static/languages/code_haskell.json
@@ -174,7 +174,7 @@
     "break",
     "splitAt",
     "notElem",
-    "loopup",
+    "lookup",
     "zip",
     "zipWith",
     "unzip",


### PR DESCRIPTION
### Description

Fix `loopup` to `lookup`.