### PR TITLE
Custom theme edit fix

### DIFF
--- a/frontend/src/ts/popups/simple-popups.ts
+++ b/frontend/src/ts/popups/simple-popups.ts
@@ -1088,12 +1088,13 @@ list["updateCustomTheme"] = new SimplePopup(
     }
 
     const newTheme = {
-      name: name,
+      name: name.replaceAll(" ", "_"),
       colors: newColors,
     };
     Loader.show();
-    await DB.editCustomTheme(customTheme._id, newTheme);
+    const validation = await DB.editCustomTheme(customTheme._id, newTheme);
     Loader.hide();
+    if (!validation) return;
     UpdateConfig.setCustomThemeColors(newColors);
     Notifications.add("Custom theme updated", 1);
     ThemePicker.refreshButtons();


### PR DESCRIPTION
Before this fix you couldn't add themes with " ", and now you can. And also when you make invalid name for your theme, now you don't see popup that theme was updated successfully