### PR TITLE
fix the links in the footer for profile pages

### DIFF
--- a/frontend/static/html/bottom.html
+++ b/frontend/static/html/bottom.html
@@ -51,15 +51,15 @@
         <i class="fab fa-fw fa-twitter"></i>
         <div class="text">Twitter</div>
       </a>
-      <a href="terms-of-service.html" class="textButton" target="_blank">
+      <a href="/terms-of-service.html" class="textButton" target="_blank">
         <i class="fas fa-fw fa-file-contract"></i>
         <div class="text">Terms</div>
       </a>
-      <a href="security-policy.html" class="textButton" target="_blank">
+      <a href="/security-policy.html" class="textButton" target="_blank">
         <i class="fas fa-fw fa-shield-alt"></i>
         <div class="text">Security</div>
       </a>
-      <a href="privacy-policy.html" class="textButton" target="_blank">
+      <a href="/privacy-policy.html" class="textButton" target="_blank">
         <i class="fas fa-fw fa-lock"></i>
         <div class="text">Privacy</div>
       </a>


### PR DESCRIPTION
The Privacy, Security and Terms links in the footer were broken when clicked on a page whose URL is a subdirectory (e.g. https://monkeytype.com/profile/<profile-id>), pointing at https://monkeytype.com/profile/privacy-policy.html, etc. This PR changes the hrefs to absolute rather than relative to fix that.