### PR TITLE
Add GitHub funbox mode to pull words from source code on GitHub

### DIFF
--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -1,0 +1,131 @@
+import * as Loader from "../elements/loader";
+import * as Misc from "../utils/misc";
+
+export class Section {
+  public title: string;
+  public author: string;
+  public words: string[];
+  constructor(title: string, author: string, words: string[]) {
+    this.title = title;
+    this.author = author;
+    this.words = words;
+  }
+}
+
+export async function getTLD(
+  languageGroup: MonkeyTypes.LanguageGroup
+): Promise<"en" | "es" | "fr" | "de" | "pt" | "it" | "nl"> {
+  // language group to tld
+  switch (languageGroup.name) {
+    case "english":
+      return "en";
+
+    case "spanish":
+      return "es";
+
+    case "french":
+      return "fr";
+
+    case "german":
+      return "de";
+
+    case "portuguese":
+      return "pt";
+
+    case "italian":
+      return "it";
+
+    case "dutch":
+      return "nl";
+
+    default:
+      return "en";
+  }
+}
+
+interface Post {
+  title: string;
+  author: string;
+  pageid: number;
+}
+
+interface SectionObject {
+  title: string;
+  author: string;
+}
+
+export async function getSection(language: string): Promise<Section> {
+  // console.log("Getting section");
+  Loader.show();
+
+  // get TLD for wikipedia according to language group
+  let urlTLD = "en";
+  const currentLanguageGroup = await Misc.findCurrentGroup(language);
+  if (currentLanguageGroup !== undefined) {
+    urlTLD = await getTLD(currentLanguageGroup);
+  }
+
+  const randomPostURL = `https://${urlTLD}.wikipedia.org/api/rest_v1/page/random/summary`;
+  const sectionObj: SectionObject = { title: "", author: "" };
+  const randomPostReq = await fetch(randomPostURL);
+  let pageid = 0;
+
+  if (randomPostReq.status == 200) {
+    const postObj: Post = await randomPostReq.json();
+    sectionObj.title = postObj.title;
+    sectionObj.author = postObj.author;
+    pageid = postObj.pageid;
+  }
+
+  return new Promise((res, rej) => {
+    if (randomPostReq.status != 200) {
+      Loader.hide();
+      rej(randomPostReq.status);
+    }
+
+    const sectionURL = `https://${urlTLD}.wikipedia.org/w/api.php?action=query&format=json&pageids=${pageid}&prop=extracts&exintro=true&origin=*`;
+
+    const sectionReq = new XMLHttpRequest();
+    sectionReq.onload = (): void => {
+      if (sectionReq.readyState == 4) {
+        if (sectionReq.status == 200) {
+          let sectionText: string = JSON.parse(sectionReq.responseText).query
+            .pages[pageid.toString()].extract;
+
+          // Converting to one paragraph
+          sectionText = sectionText.replace(/<\/p><p>+/g, " ");
+
+          // Convert HTML to text
+          sectionText = $("<div/>").html(sectionText).text();
+
+          // Remove reference links
+          sectionText = sectionText.replace(/\[\d+\]/gi, "");
+
+          // Remove invisible characters
+          sectionText = sectionText.replace(/[\u200B-\u200D\uFEFF]/g, "");
+
+          // Convert all whitespace to space
+          sectionText = sectionText.replace(/\s+/g, " ");
+
+          // Removing whitespace before and after text
+          sectionText = sectionText.trim();
+
+          const words = sectionText.split(" ");
+
+          const section = new Section(
+            sectionObj.title,
+            sectionObj.author,
+            words
+          );
+          Loader.hide();
+          res(section);
+        } else {
+          Loader.hide();
+          rej(sectionReq.status);
+        }
+      }
+    };
+    sectionReq.open("GET", sectionURL);
+    sectionReq.send();
+  });
+}

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -123,6 +123,7 @@ function extractWords(fileContent: string): string[] {
 }
 
 async function sendGithubApiRequest(endpoint: string): Promise<unknown> {
+  const origin = "https://api.github.com";
   const url = origin + endpoint;
   const fileRequest = await fetch(url);
   if (!fileRequest.ok) {

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -67,7 +67,9 @@ export async function getSection(language: string): Promise<Section> {
   const repoListResponse = (await apiRequest(
     repoListRequestEndpoint
   )) as RepoListResponse;
-  const repoName = getRandomItem(repoListResponse.items).full_name;
+  const repoName = getRandomItem(repoListResponse.items, {
+    maxIndex: 25, // maxIndex because we want some randomness, but still want a popular repository
+  }).full_name;
 
   const fileListEndpoint = `https://api.github.com/search/code?q=%20+language:${codeLanguage}+repo:${repoName}`;
   const fileListResponse = (await apiRequest(
@@ -101,7 +103,10 @@ async function apiRequest(url: string): Promise<unknown> {
   return await fileRequest.json();
 }
 
-function getRandomItem<T>(list: T[]): T {
-  const randomIndex = Math.floor(Math.random() * list.length);
+function getRandomItem<T>(list: T[], options?: { maxIndex?: number }): T {
+  const maxIndex = options?.maxIndex
+    ? Math.min(list.length, options.maxIndex)
+    : list.length;
+  const randomIndex = Math.floor(Math.random() * maxIndex);
   return list[randomIndex];
 }

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -1,4 +1,6 @@
 import * as Loader from "../elements/loader";
+import { getRandomItem } from "../utils/arrays";
+import { cache } from "../utils/decorators";
 
 const fallbackCodeLanguage = "javascript";
 
@@ -126,52 +128,4 @@ async function sendGithubApiRequest(url: string): Promise<unknown> {
     throw Error(fileRequest.statusText);
   }
   return await fileRequest.json();
-}
-
-function getRandomItem<T>(list: T[]): T {
-  const randomIndex = Math.floor(Math.random() * list.length);
-  return list[randomIndex];
-}
-
-function cache<T extends unknown[], U>(
-  fn: (...args: T) => U,
-  options = {
-    cacheDurationMilliseconds: 30000,
-  }
-): (...args: T) => U {
-  let cacheTimestamp = Date.now();
-  const cache = new Map();
-
-  const isCacheExpired = (): boolean => {
-    if (cacheTimestamp === null) {
-      return true;
-    }
-
-    if (Date.now() > cacheTimestamp + options.cacheDurationMilliseconds) {
-      return true;
-    }
-
-    return false;
-  };
-
-  const cachedFn = (...args: T): U => {
-    if (isCacheExpired()) {
-      cache.clear();
-    }
-
-    const cacheKey = JSON.stringify(args);
-
-    if (cache.has(cacheKey)) {
-      return cache.get(cacheKey);
-    }
-
-    const result = fn(...args);
-
-    cache.set(cacheKey, result);
-    cacheTimestamp = Date.now();
-
-    return result;
-  };
-
-  return cachedFn;
 }

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -94,7 +94,7 @@ async function getFileUrls(codeLanguage: string): Promise<string[]> {
 const getFileUrlsWithCache = cache(getFileUrls);
 
 async function searchRepos(codeLanguage: string): Promise<RepoSearchResponse> {
-  const endpoint = `https://api.github.com/search/repositories?q=language:${codeLanguage}&sort=stars&order=desc`;
+  const endpoint = `/search/repositories?q=language:${codeLanguage}&sort=stars&order=desc`;
   const response = await sendGithubApiRequest(endpoint);
   return response as RepoSearchResponse;
 }
@@ -103,7 +103,7 @@ async function searchFiles(
   codeLanguage: string,
   repoName: string
 ): Promise<FileSearchResponse> {
-  const endpoint = `https://api.github.com/search/code?q=%20+language:${codeLanguage}+repo:${repoName}`;
+  const endpoint = `/search/code?q=%20+language:${codeLanguage}+repo:${repoName}`;
   const response = (await sendGithubApiRequest(endpoint)) as FileSearchResponse;
   return response as FileSearchResponse;
 }
@@ -122,7 +122,8 @@ function extractWords(fileContent: string): string[] {
     .split(" ");
 }
 
-async function sendGithubApiRequest(url: string): Promise<unknown> {
+async function sendGithubApiRequest(endpoint: string): Promise<unknown> {
+  const url = origin + endpoint;
   const fileRequest = await fetch(url);
   if (!fileRequest.ok) {
     throw Error(fileRequest.statusText);

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -1,131 +1,71 @@
 import * as Loader from "../elements/loader";
-import * as Misc from "../utils/misc";
 
-export class Section {
-  public title: string;
-  public author: string;
-  public words: string[];
-  constructor(title: string, author: string, words: string[]) {
-    this.title = title;
-    this.author = author;
-    this.words = words;
-  }
+interface Section {
+  words: string[];
 }
 
-export async function getTLD(
-  languageGroup: MonkeyTypes.LanguageGroup
-): Promise<"en" | "es" | "fr" | "de" | "pt" | "it" | "nl"> {
-  // language group to tld
-  switch (languageGroup.name) {
-    case "english":
-      return "en";
-
-    case "spanish":
-      return "es";
-
-    case "french":
-      return "fr";
-
-    case "german":
-      return "de";
-
-    case "portuguese":
-      return "pt";
-
-    case "italian":
-      return "it";
-
-    case "dutch":
-      return "nl";
-
-    default:
-      return "en";
-  }
+interface RepoListResponse {
+  items: {
+    full_name: string;
+  }[];
 }
 
-interface Post {
-  title: string;
-  author: string;
-  pageid: number;
+interface FileListResponse {
+  items: {
+    name: string;
+    url: string;
+  }[];
 }
 
-interface SectionObject {
-  title: string;
-  author: string;
+interface FileResponse {
+  content: string;
 }
 
-export async function getSection(language: string): Promise<Section> {
-  // console.log("Getting section");
+export async function getSection(): Promise<Section> {
   Loader.show();
 
-  // get TLD for wikipedia according to language group
-  let urlTLD = "en";
-  const currentLanguageGroup = await Misc.findCurrentGroup(language);
-  if (currentLanguageGroup !== undefined) {
-    urlTLD = await getTLD(currentLanguageGroup);
+  const language = "javascript";
+
+  const repoListRequestEndpoint = `https://api.github.com/search/repositories?q=language:${language}&sort=stars&order=desc`;
+  console.log(repoListRequestEndpoint);
+  const repoListResponse = (await apiRequest(
+    repoListRequestEndpoint
+  )) as RepoListResponse;
+  const repoName = getRandomItem(repoListResponse.items).full_name;
+
+  const fileListEndpoint = `https://api.github.com/search/code?q=%20+language:${language}+repo:${repoName}`;
+  const fileListResponse = (await apiRequest(
+    fileListEndpoint
+  )) as FileListResponse;
+  const fileContentEndpoint = getRandomItem(fileListResponse.items).url;
+
+  const fileContentResponse = (await apiRequest(
+    fileContentEndpoint
+  )) as FileResponse;
+
+  const decodedContent = window.atob(fileContentResponse.content);
+  const words = decodedContent
+    .replace(/[\u200B-\u200D\uFEFF]/g, "") // Remove invisible characters
+    .replace(/\s+/g, " ") // Convert all whitespace to space
+    .trim() // Removing whitespace before and after text
+    .split(" ");
+
+  const section = { words };
+
+  Loader.hide();
+
+  return section;
+}
+
+async function apiRequest(url: string): Promise<unknown> {
+  const fileRequest = await fetch(url);
+  if (!fileRequest.ok) {
+    throw Error(fileRequest.statusText);
   }
+  return await fileRequest.json();
+}
 
-  const randomPostURL = `https://${urlTLD}.wikipedia.org/api/rest_v1/page/random/summary`;
-  const sectionObj: SectionObject = { title: "", author: "" };
-  const randomPostReq = await fetch(randomPostURL);
-  let pageid = 0;
-
-  if (randomPostReq.status == 200) {
-    const postObj: Post = await randomPostReq.json();
-    sectionObj.title = postObj.title;
-    sectionObj.author = postObj.author;
-    pageid = postObj.pageid;
-  }
-
-  return new Promise((res, rej) => {
-    if (randomPostReq.status != 200) {
-      Loader.hide();
-      rej(randomPostReq.status);
-    }
-
-    const sectionURL = `https://${urlTLD}.wikipedia.org/w/api.php?action=query&format=json&pageids=${pageid}&prop=extracts&exintro=true&origin=*`;
-
-    const sectionReq = new XMLHttpRequest();
-    sectionReq.onload = (): void => {
-      if (sectionReq.readyState == 4) {
-        if (sectionReq.status == 200) {
-          let sectionText: string = JSON.parse(sectionReq.responseText).query
-            .pages[pageid.toString()].extract;
-
-          // Converting to one paragraph
-          sectionText = sectionText.replace(/<\/p><p>+/g, " ");
-
-          // Convert HTML to text
-          sectionText = $("<div/>").html(sectionText).text();
-
-          // Remove reference links
-          sectionText = sectionText.replace(/\[\d+\]/gi, "");
-
-          // Remove invisible characters
-          sectionText = sectionText.replace(/[\u200B-\u200D\uFEFF]/g, "");
-
-          // Convert all whitespace to space
-          sectionText = sectionText.replace(/\s+/g, " ");
-
-          // Removing whitespace before and after text
-          sectionText = sectionText.trim();
-
-          const words = sectionText.split(" ");
-
-          const section = new Section(
-            sectionObj.title,
-            sectionObj.author,
-            words
-          );
-          Loader.hide();
-          res(section);
-        } else {
-          Loader.hide();
-          rej(sectionReq.status);
-        }
-      }
-    };
-    sectionReq.open("GET", sectionURL);
-    sectionReq.send();
-  });
+function getRandomItem<T>(list: T[]): T {
+  const randomIndex = Math.floor(Math.random() * list.length);
+  return list[randomIndex];
 }

--- a/frontend/src/ts/test/github.ts
+++ b/frontend/src/ts/test/github.ts
@@ -1,5 +1,35 @@
 import * as Loader from "../elements/loader";
 
+const languageToGithubLanguageMap: Record<string, string> = {
+  code_python: "python",
+  code_c: "c",
+  code_csharp: "csharp",
+  "code_c++": "c++",
+  code_dart: "dart",
+  code_brainfck: "brainfuck",
+  code_fsharp: "fsharp",
+  code_javascript: "javascript",
+  code_javascript_1k: "javascript",
+  code_julia: "julia",
+  code_html: "html",
+  code_pascal: "pascal",
+  code_java: "java",
+  code_kotlin: "kotlin",
+  code_go: "go",
+  code_rust: "rust",
+  code_ruby: "ruby",
+  code_r: "r",
+  code_swift: "swift",
+  code_scala: "scala",
+  code_bash: "bash",
+  code_lua: "lua",
+  code_matlab: "matlab",
+  code_sql: "sql",
+  code_perl: "perl",
+  code_php: "php",
+  code_vim: "vim",
+};
+
 interface Section {
   words: string[];
 }
@@ -21,19 +51,25 @@ interface FileResponse {
   content: string;
 }
 
-export async function getSection(): Promise<Section> {
+export async function getSection(language: string): Promise<Section> {
   Loader.show();
 
-  const language = "javascript";
+  const languageIsMapped = Object.prototype.hasOwnProperty.call(
+    languageToGithubLanguageMap,
+    language
+  );
+  const codeLanguage = languageIsMapped
+    ? languageToGithubLanguageMap[language]
+    : "javascript";
 
-  const repoListRequestEndpoint = `https://api.github.com/search/repositories?q=language:${language}&sort=stars&order=desc`;
+  const repoListRequestEndpoint = `https://api.github.com/search/repositories?q=language:${codeLanguage}&sort=stars&order=desc`;
   console.log(repoListRequestEndpoint);
   const repoListResponse = (await apiRequest(
     repoListRequestEndpoint
   )) as RepoListResponse;
   const repoName = getRandomItem(repoListResponse.items).full_name;
 
-  const fileListEndpoint = `https://api.github.com/search/code?q=%20+language:${language}+repo:${repoName}`;
+  const fileListEndpoint = `https://api.github.com/search/code?q=%20+language:${codeLanguage}+repo:${repoName}`;
   const fileListResponse = (await apiRequest(
     fileListEndpoint
   )) as FileListResponse;

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -880,10 +880,9 @@ export async function init(): Promise<void> {
       Config.mode != "custom"
     ) {
       let wordCount = 0;
-
       // If mode is words, get as many sections as you need until the wordCount is fullfilled
       while (
-        (Config.mode == "words" && Config.words >= wordCount) ||
+        (Config.mode === "words" && Config.words >= wordCount) ||
         (Config.mode === "time" && wordCount < 100)
       ) {
         let section;
@@ -895,7 +894,7 @@ export async function init(): Promise<void> {
             section = await Poetry.getPoem();
             break;
           case "github":
-            section = await GitHub.getSection(Config.language);
+            section = await GitHub.getSection();
             break;
           default:
             console.log(`Unknown funbox type ${Config.funbox}`);
@@ -904,11 +903,10 @@ export async function init(): Promise<void> {
         if (section === undefined) continue;
 
         for (const word of section.words) {
+          wordCount++;
           if (wordCount >= Config.words && Config.mode == "words") {
-            wordCount++;
             break;
           }
-          wordCount++;
           TestWords.words.push(word);
         }
       }

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -894,7 +894,7 @@ export async function init(): Promise<void> {
             section = await Poetry.getPoem();
             break;
           case "github":
-            section = await GitHub.getSection();
+            section = await GitHub.getSection(Config.language);
             break;
           default:
             console.log(`Unknown funbox type ${Config.funbox}`);

--- a/frontend/src/ts/utils/arrays.ts
+++ b/frontend/src/ts/utils/arrays.ts
@@ -1,0 +1,4 @@
+export function getRandomItem<T>(list: T[]): T {
+  const randomIndex = Math.floor(Math.random() * list.length);
+  return list[randomIndex];
+}

--- a/frontend/src/ts/utils/decorators/cache.ts
+++ b/frontend/src/ts/utils/decorators/cache.ts
@@ -1,0 +1,42 @@
+export function cache<T extends unknown[], U>(
+  fn: (...args: T) => U,
+  options = {
+    cacheDurationMilliseconds: 30000,
+  }
+): (...args: T) => U {
+  let cacheTimestamp = Date.now();
+  const cache = new Map();
+
+  const isCacheExpired = (): boolean => {
+    if (cacheTimestamp === null) {
+      return true;
+    }
+
+    if (Date.now() > cacheTimestamp + options.cacheDurationMilliseconds) {
+      return true;
+    }
+
+    return false;
+  };
+
+  const cachedFn = (...args: T): U => {
+    if (isCacheExpired()) {
+      cache.clear();
+    }
+
+    const cacheKey = JSON.stringify(args);
+
+    if (cache.has(cacheKey)) {
+      return cache.get(cacheKey);
+    }
+
+    const result = fn(...args);
+
+    cache.set(cacheKey, result);
+    cacheTimestamp = Date.now();
+
+    return result;
+  };
+
+  return cachedFn;
+}

--- a/frontend/src/ts/utils/decorators/index.ts
+++ b/frontend/src/ts/utils/decorators/index.ts
@@ -1,0 +1,1 @@
+export * from "./cache";

--- a/frontend/static/funbox/_list.json
+++ b/frontend/static/funbox/_list.json
@@ -148,7 +148,7 @@
     "name": "github",
     "type": "script",
     "affectsWordGeneration": true,
-    "info": "Practice typing real source code from GitHub."
+    "info": "Practice typing real source code from GitHub, based on the current language."
   }
 ]
 

--- a/frontend/static/funbox/_list.json
+++ b/frontend/static/funbox/_list.json
@@ -143,6 +143,12 @@
     "type": "script",
     "affectsWordGeneration": true,
     "info": "Nonsense words that look like the current language."
+  },
+  {
+    "name": "github",
+    "type": "script",
+    "affectsWordGeneration": true,
+    "info": "Practice typing real source code from GitHub."
   }
 ]
 


### PR DESCRIPTION
### Description

This PR adds a "GitHub" funbox mode that pulls source code from GitHub to provide words.

The code language of the files pulled from GitHub can be selected using the existing language selection, and falls back to JavaScript when the current language is not a code language. It searches for files in the top 25 most popular repositories that make use of the selected language.

Some code files have front-matter that the user must type through before getting to code. This could potentially be filtered out in the future for a more consistent experience.

The GitHub search API has has a rate limit of 10 requests a minute. This funbox makes two requests to the search API for each file, so it is low enough to be hit if someone refreshes the test a few times. Hitting the API limit hangs the website and requires a refresh, so I'd love some help figuring out a more graceful failure mode.


