### PR TITLE
fixed a typo

### DIFF
--- a/frontend/static/terms-of-service.html
+++ b/frontend/static/terms-of-service.html
@@ -222,7 +222,7 @@
         <a href="https://monkeytype.com/privacy-policy" target="_blank">
           Privacy Policy
         </a>
-        and understand that it sets forth how we collect, use, and store your
+         and understand that it sets forth how we collect, use, and store your
         information. If you do not agree with our Privacy Statement, then you
         must stop using the Services immediately. Any person, entity, or service
         collecting data from the Services must comply with our Privacy


### PR DESCRIPTION
### Description
Added a space after the link to the privacy policy, so that it doesn't look like this:
![image](https://user-images.githubusercontent.com/89305228/176996057-c0d9401a-cc64-4fd0-89ba-66535ce6fe4e.png)
