### PR TITLE
Rewrite input system to use composition events

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -24,6 +24,7 @@ import * as MonkeyPower from "../elements/monkey-power";
 import * as WeakSpot from "../test/weak-spot";
 import * as ActivePage from "../states/active-page";
 import * as TestActive from "../states/test-active";
+import * as CompositionState from "../states/composition";
 import * as TestInput from "../test/test-input";
 import * as TestWords from "../test/test-words";
 import { navigate } from "./route-controller";
@@ -418,7 +419,12 @@ function handleChar(char: string, charIndex: number): void {
     char +
     TestInput.input.current.substring(charIndex + 1);
 
-  if (!thisCharCorrect && Misc.trailingComposeChars.test(resultingWord)) {
+  // If a trailing composed char is used, ignore it when counting accuracy
+  if (
+    !thisCharCorrect &&
+    Misc.trailingComposeChars.test(resultingWord) &&
+    CompositionState.getComposing()
+  ) {
     TestInput.input.current = resultingWord;
     TestUI.updateWordElement();
     Caret.updatePosition();
@@ -801,14 +807,16 @@ $(document).keydown(async (event) => {
   }
 
   //show dead keys
-  if (
-    event.key === "Dead" &&
-    !Misc.trailingComposeChars.test(TestInput.input.current)
-  ) {
+  if (event.key === "Dead" && !CompositionState.getComposing()) {
     Sound.playClick();
     const word = document.querySelector<HTMLElement>("#words .word.active");
     const len = TestInput.input.current.length; // have to do this because prettier wraps the line and causes an error
-    word?.querySelectorAll("letter")[len].classList.toggle("dead");
+
+    // Check to see if the letter actually exists to toggle it as dead
+    const deadLetter = word?.querySelectorAll("letter")[len];
+    if (deadLetter) {
+      deadLetter.classList.toggle("dead");
+    }
   }
 
   if (Config.oppositeShiftMode !== "off") {
@@ -907,7 +915,7 @@ $("#wordsInput").on("input", (event) => {
     TestInput.input.current = inputValue;
     TestUI.updateWordElement();
     Caret.updatePosition();
-    if (!Misc.trailingComposeChars.test(TestInput.input.current)) {
+    if (!CompositionState.getComposing()) {
       Replay.addReplayEvent("setLetterIndex", TestInput.input.current.length);
     }
   } else if (inputValue !== TestInput.input.current) {
@@ -957,4 +965,14 @@ $("#wordsInput").on("focus", (event) => {
 
 $("#wordsInput").on("copy paste", (event) => {
   event.preventDefault();
+});
+
+// Composing events
+$("#wordsInput").on("compositionstart", () => {
+  CompositionState.setComposing(true);
+  CompositionState.setStartPos(TestInput.input.current.length);
+});
+
+$("#wordsInput").on("compositionend", () => {
+  CompositionState.setComposing(false);
 });

--- a/frontend/src/ts/states/composition.ts
+++ b/frontend/src/ts/states/composition.ts
@@ -1,0 +1,29 @@
+interface CompositionState {
+  composing: boolean;
+  startPos: number;
+}
+
+const compositionState = {
+  composing: false,
+  startPos: -1,
+};
+
+export function get(): CompositionState {
+  return compositionState;
+}
+
+export function getComposing(): boolean {
+  return compositionState.composing;
+}
+
+export function getStartPos(): number {
+  return compositionState.startPos;
+}
+
+export function setComposing(isComposing: boolean): void {
+  compositionState.composing = isComposing;
+}
+
+export function setStartPos(pos: number): void {
+  compositionState.startPos = pos;
+}

--- a/frontend/src/ts/test/caret.ts
+++ b/frontend/src/ts/test/caret.ts
@@ -44,10 +44,8 @@ export async function updatePosition(): Promise<void> {
     caretWidth /= 3;
   }
 
-  let inputLen = TestInput.input.current.length;
-  inputLen = Misc.trailingComposeChars.test(TestInput.input.current)
-    ? TestInput.input.current.search(Misc.trailingComposeChars) + 1
-    : inputLen;
+  const inputLen = TestInput.input.current.length;
+
   let currentLetterIndex = inputLen - 1;
   if (currentLetterIndex == -1) {
     currentLetterIndex = 0;


### PR DESCRIPTION
### Description
Changed from using trailingComposeChars to using compositionstart and compositionend events to check when a composing character was entered.
This doesn't fix any of the accuracy issues for languages like Japanese, but this should be helpful for any future attempts to fix this.
Closes #2536

I've tested this on pretty much every major browser and OS, but this could possibly break some input systems I'm either unaware of or don't have access to.
These changes should ideally be tested by a few people who use input systems with accents or any type of composing characters, in case anything breaks.