### PR TITLE
spanish quotes: replaced en dash with `-`

### DIFF
--- a/frontend/static/quotes/spanish.json
+++ b/frontend/static/quotes/spanish.json
@@ -620,9 +620,9 @@
       "id": 102
     },
     {
-      "text": "Mira ese punto. Eso es aquí. Eso es nuestro hogar. Eso somos nosotros. En él, todos los que amas, todos los que conoces, todos de los que alguna vez escuchaste, cada ser humano que ha existido, vivió su vida. La suma de todas nuestras alegrías y sufrimientos, miles de religiones seguras de sí mismas, ideologías y doctrinas económicas, cada cazador y recolector, cada héroe y cobarde, cada creador y destructor de civilizaciones, cada rey y campesino, cada joven pareja enamorada, cada madre y padre, niño esperanzado, inventor y explorador, cada maestro de la moral, cada político corrupto, cada “superestrella”, cada “líder supremo”, cada santo y pecador en la historia de nuestra especie, vivió ahí -- en una mota de polvo suspendida en un rayo de sol.",
+      "text": "Mira ese punto. Eso es aquí. Eso es nuestro hogar. Eso somos nosotros. En él, todos los que amas, todos los que conoces, todos de los que alguna vez escuchaste, cada ser humano que ha existido, vivió su vida. La suma de todas nuestras alegrías y sufrimientos, miles de religiones seguras de sí mismas, ideologías y doctrinas económicas, cada cazador y recolector, cada héroe y cobarde, cada creador y destructor de civilizaciones, cada rey y campesino, cada joven pareja enamorada, cada madre y padre, niño esperanzado, inventor y explorador, cada maestro de la moral, cada político corrupto, cada “superestrella”, cada “líder supremo”, cada santo y pecador en la historia de nuestra especie, vivió ahí - en una mota de polvo suspendida en un rayo de sol.",
       "source": "Carl Sagan",
-      "length": 756,
+      "length": 755,
       "id": 103
     }
   ]

--- a/frontend/static/quotes/spanish.json
+++ b/frontend/static/quotes/spanish.json
@@ -632,7 +632,7 @@
       "id": 102
     },
     {
-      "text": "Mira ese punto. Eso es aquí. Eso es nuestro hogar. Eso somos nosotros. En él, todos los que amas, todos los que conoces, todos de los que alguna vez escuchaste, cada ser humano que ha existido, vivió su vida. La suma de todas nuestras alegrías y sufrimientos, miles de religiones seguras de sí mismas, ideologías y doctrinas económicas, cada cazador y recolector, cada héroe y cobarde, cada creador y destructor de civilizaciones, cada rey y campesino, cada joven pareja enamorada, cada madre y padre, niño esperanzado, inventor y explorador, cada maestro de la moral, cada político corrupto, cada “superestrella”, cada “líder supremo”, cada santo y pecador en la historia de nuestra especie, vivió ahí – en una mota de polvo suspendida en un rayo de sol.",
+      "text": "Mira ese punto. Eso es aquí. Eso es nuestro hogar. Eso somos nosotros. En él, todos los que amas, todos los que conoces, todos de los que alguna vez escuchaste, cada ser humano que ha existido, vivió su vida. La suma de todas nuestras alegrías y sufrimientos, miles de religiones seguras de sí mismas, ideologías y doctrinas económicas, cada cazador y recolector, cada héroe y cobarde, cada creador y destructor de civilizaciones, cada rey y campesino, cada joven pareja enamorada, cada madre y padre, niño esperanzado, inventor y explorador, cada maestro de la moral, cada político corrupto, cada “superestrella”, cada “líder supremo”, cada santo y pecador en la historia de nuestra especie, vivió ahí -- en una mota de polvo suspendida en un rayo de sol.",
       "source": "Carl Sagan",
       "length": 755,
       "id": 103

--- a/frontend/static/quotes/spanish.json
+++ b/frontend/static/quotes/spanish.json
@@ -1,22 +1,10 @@
 {
   "language": "spanish",
   "groups": [
-    [
-      0,
-      100
-    ],
-    [
-      101,
-      300
-    ],
-    [
-      301,
-      600
-    ],
-    [
-      601,
-      9999
-    ]
+    [0, 100],
+    [101, 300],
+    [301, 600],
+    [601, 9999]
   ],
   "quotes": [
     {
@@ -634,7 +622,7 @@
     {
       "text": "Mira ese punto. Eso es aquí. Eso es nuestro hogar. Eso somos nosotros. En él, todos los que amas, todos los que conoces, todos de los que alguna vez escuchaste, cada ser humano que ha existido, vivió su vida. La suma de todas nuestras alegrías y sufrimientos, miles de religiones seguras de sí mismas, ideologías y doctrinas económicas, cada cazador y recolector, cada héroe y cobarde, cada creador y destructor de civilizaciones, cada rey y campesino, cada joven pareja enamorada, cada madre y padre, niño esperanzado, inventor y explorador, cada maestro de la moral, cada político corrupto, cada “superestrella”, cada “líder supremo”, cada santo y pecador en la historia de nuestra especie, vivió ahí -- en una mota de polvo suspendida en un rayo de sol.",
       "source": "Carl Sagan",
-      "length": 755,
+      "length": 756,
       "id": 103
     }
   ]


### PR DESCRIPTION
### Description

Replaced en dash U+2013 at quote 103 to one hyphen `-` as the former is difficult to type.