### PR TITLE
Added config for displaying the keymaps top row

### DIFF
--- a/backend/src/api/schemas/config-schema.ts
+++ b/backend/src/api/schemas/config-schema.ts
@@ -64,6 +64,9 @@ const CONFIG_SCHEMA = joi.object({
     .string()
     .valid("lowercase", "uppercase", "blank", "dynamic"),
   keymapLayout: joi.string().valid(),
+  keymapShowTopRow: joi
+    .string()
+    .valid("always", "layout", "never"),
   fontFamily: joi.string(),
   smoothLineScroll: joi.boolean(),
   alwaysShowDecimalPlaces: joi.boolean(),

--- a/backend/src/api/schemas/config-schema.ts
+++ b/backend/src/api/schemas/config-schema.ts
@@ -64,9 +64,7 @@ const CONFIG_SCHEMA = joi.object({
     .string()
     .valid("lowercase", "uppercase", "blank", "dynamic"),
   keymapLayout: joi.string().valid(),
-  keymapShowTopRow: joi
-    .string()
-    .valid("always", "layout", "never"),
+  keymapShowTopRow: joi.string().valid("always", "layout", "never"),
   fontFamily: joi.string(),
   smoothLineScroll: joi.boolean(),
   alwaysShowDecimalPlaces: joi.boolean(),

--- a/frontend/src/styles/keymap.scss
+++ b/frontend/src/styles/keymap.scss
@@ -78,7 +78,7 @@
 
   .r1 {
     display: grid;
-    grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: 0fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   }
 
   .r2 {

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1515,6 +1515,26 @@ export function setKeymapLayout(layout: string, nosave?: boolean): boolean {
   return true;
 }
 
+export function setKeymapShowTopRow(
+  show: MonkeyTypes.KeymapShowTopRow,
+  nosave?: boolean
+): boolean {
+  if (
+    !isConfigValueValid("keymapShowTopRow", show, [
+      ["always", "layout", "never"],
+    ])
+  ) {
+    return false;
+  }
+
+  config.keymapShowTopRow = show;
+  saveToLocalStorage("keymapShowTopRow", nosave);
+  ConfigEvent.dispatch("keymapShowTopRow", config.keymapShowTopRow);
+
+  return true;
+}
+
+
 export function setLayout(layout: string, nosave?: boolean): boolean {
   if (!isConfigValueValid("layout", layout, ["string"])) return false;
 
@@ -1765,6 +1785,7 @@ export function apply(
     setKeymapStyle(configObj.keymapStyle, true);
     setKeymapLegendStyle(configObj.keymapLegendStyle, true);
     setKeymapLayout(configObj.keymapLayout, true);
+    setKeymapShowTopRow(configObj.keymapShowTopRow, true);
     setFontFamily(configObj.fontFamily, true);
     setSmoothCaret(configObj.smoothCaret, true);
     setSmoothLineScroll(configObj.smoothLineScroll, true);

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1534,7 +1534,6 @@ export function setKeymapShowTopRow(
   return true;
 }
 
-
 export function setLayout(layout: string, nosave?: boolean): boolean {
   if (!isConfigValueValid("layout", layout, ["string"])) return false;
 

--- a/frontend/src/ts/constants/default-config.ts
+++ b/frontend/src/ts/constants/default-config.ts
@@ -53,6 +53,7 @@ export default <MonkeyTypes.Config>{
   keymapStyle: "staggered",
   keymapLegendStyle: "lowercase",
   keymapLayout: "overrideSync",
+  keymapShowTopRow: "layout",
   fontFamily: "Roboto_Mono",
   smoothLineScroll: false,
   alwaysShowDecimalPlaces: false,

--- a/frontend/src/ts/elements/commandline-lists.ts
+++ b/frontend/src/ts/elements/commandline-lists.ts
@@ -1713,7 +1713,7 @@ const commandsKeymapShowTopRow: MonkeyTypes.CommandsGroup = {
       exec: (): void => {
         UpdateConfig.setKeymapShowTopRow("never");
       },
-    }
+    },
   ],
 };
 

--- a/frontend/src/ts/elements/commandline-lists.ts
+++ b/frontend/src/ts/elements/commandline-lists.ts
@@ -1686,6 +1686,37 @@ const commandsKeymapLegendStyle: MonkeyTypes.CommandsGroup = {
   ],
 };
 
+const commandsKeymapShowTopRow: MonkeyTypes.CommandsGroup = {
+  title: "Keymap show top row...",
+  configKey: "keymapShowTopRow",
+  list: [
+    {
+      id: "keymapShowTopRowAlways",
+      display: "always",
+      configValue: "always",
+      exec: (): void => {
+        UpdateConfig.setKeymapShowTopRow("always");
+      },
+    },
+    {
+      id: "keymapShowTopRowLayout",
+      display: "layout dependent",
+      configValue: "layout",
+      exec: (): void => {
+        UpdateConfig.setKeymapShowTopRow("layout");
+      },
+    },
+    {
+      id: "keymapShowTopRowNever",
+      display: "never",
+      configValue: "never",
+      exec: (): void => {
+        UpdateConfig.setKeymapShowTopRow("never");
+      },
+    }
+  ],
+};
+
 const commandsBritishEnglish: MonkeyTypes.CommandsGroup = {
   title: "British english...",
   configKey: "britishEnglish",
@@ -3110,6 +3141,13 @@ export const defaultCommands: MonkeyTypes.CommandsGroup = {
       alias: "keyboard",
       icon: "fa-keyboard",
       subgroup: commandsKeymapLayouts,
+    },
+    {
+      id: "changeKeymapShowTopRow",
+      display: "Keymap show top row...",
+      alias: "keyboard",
+      icon: "fa-keyboard",
+      subgroup: commandsKeymapShowTopRow,
     },
     {
       id: "changeCustomLayoutfluid",

--- a/frontend/src/ts/elements/keymap.ts
+++ b/frontend/src/ts/elements/keymap.ts
@@ -112,7 +112,10 @@ export async function refresh(
       layoutString = Config.keymapLayout;
     }
 
-    const showTopRow = Config.keymapShowTopRow === "always" || (lts as typeof layouts["qwerty"]).keymapShowTopRow && Config.keymapShowTopRow !== "never" ;
+    const showTopRow =
+      Config.keymapShowTopRow === "always" ||
+      ((lts as typeof layouts["qwerty"]).keymapShowTopRow &&
+        Config.keymapShowTopRow !== "never");
 
     const isMatrix =
       Config.keymapStyle === "matrix" || Config.keymapStyle === "split_matrix";
@@ -191,12 +194,14 @@ export async function refresh(
                 if (i === 6) {
                   splitSpacer += `<div class="keymapSplitSpacer"></div>`;
                 }
-              } else if (row === "row1" &&
-              (Config.keymapStyle === "split" ||
-                Config.keymapStyle === "alice")){
-                  if (i === 7) {
-                    splitSpacer += `<div class="keymapSplitSpacer"></div>`;
-                  }
+              } else if (
+                row === "row1" &&
+                (Config.keymapStyle === "split" ||
+                  Config.keymapStyle === "alice")
+              ) {
+                if (i === 7) {
+                  splitSpacer += `<div class="keymapSplitSpacer"></div>`;
+                }
               } else {
                 if (i === 5) {
                   splitSpacer += `<div class="keymapSplitSpacer"></div>`;
@@ -243,5 +248,11 @@ ConfigEvent.subscribe((eventKey) => {
   if (eventKey === "layout" && Config.keymapLayout === "overrideSync") {
     refresh(Config.keymapLayout);
   }
-  if (eventKey === "keymapLayout" || eventKey === "keymapStyle" || eventKey === "keymapShowTopRow") refresh();
+  if (
+    eventKey === "keymapLayout" ||
+    eventKey === "keymapStyle" ||
+    eventKey === "keymapShowTopRow"
+  ) {
+    refresh();
+  }
 });

--- a/frontend/src/ts/elements/keymap.ts
+++ b/frontend/src/ts/elements/keymap.ts
@@ -124,7 +124,13 @@ export async function refresh(
 
     (Object.keys(lts.keys) as (keyof MonkeyTypes.Keys)[]).forEach(
       (row, index) => {
-        const rowKeys = lts.keys[row];
+        let rowKeys = lts.keys[row];
+        if (
+          row === "row1" &&
+          (isMatrix || Config.keymapStyle === "staggered")
+        ) {
+          rowKeys = rowKeys.slice(1);
+        }
         let rowElement = "";
         if (row === "row1" && !showTopRow) {
           return;
@@ -171,7 +177,17 @@ export async function refresh(
             } else if (Config.keymapLegendStyle === "uppercase") {
               keyDisplay = keyDisplay.toUpperCase();
             }
-            const keyElement = `<div class="keymapKey" data-key="${key.replace(
+            let hide = "";
+            if (
+              row === "row1" &&
+              i === 0 &&
+              !isMatrix &&
+              Config.keymapStyle !== "staggered"
+            ) {
+              hide = ` invisible`;
+            }
+
+            const keyElement = `<div class="keymapKey${hide}" data-key="${key.replace(
               '"',
               "&quot;"
             )}">

--- a/frontend/src/ts/elements/keymap.ts
+++ b/frontend/src/ts/elements/keymap.ts
@@ -191,6 +191,12 @@ export async function refresh(
                 if (i === 6) {
                   splitSpacer += `<div class="keymapSplitSpacer"></div>`;
                 }
+              } else if (row === "row1" &&
+              (Config.keymapStyle === "split" ||
+                Config.keymapStyle === "alice")){
+                  if (i === 7) {
+                    splitSpacer += `<div class="keymapSplitSpacer"></div>`;
+                  }
               } else {
                 if (i === 5) {
                   splitSpacer += `<div class="keymapSplitSpacer"></div>`;

--- a/frontend/src/ts/elements/keymap.ts
+++ b/frontend/src/ts/elements/keymap.ts
@@ -112,7 +112,7 @@ export async function refresh(
       layoutString = Config.keymapLayout;
     }
 
-    const showTopRow = (lts as typeof layouts["qwerty"]).keymapShowTopRow;
+    const showTopRow = Config.keymapShowTopRow === "always" || (lts as typeof layouts["qwerty"]).keymapShowTopRow && Config.keymapShowTopRow !== "never" ;
 
     const isMatrix =
       Config.keymapStyle === "matrix" || Config.keymapStyle === "split_matrix";
@@ -237,5 +237,5 @@ ConfigEvent.subscribe((eventKey) => {
   if (eventKey === "layout" && Config.keymapLayout === "overrideSync") {
     refresh(Config.keymapLayout);
   }
-  if (eventKey === "keymapLayout" || eventKey === "keymapStyle") refresh();
+  if (eventKey === "keymapLayout" || eventKey === "keymapStyle" || eventKey === "keymapShowTopRow") refresh();
 });

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -85,7 +85,6 @@ async function initGroups(): Promise<void> {
         $(".pageSettings .section.keymapLayout").removeClass("hidden");
         $(".pageSettings .section.keymapLegendStyle").removeClass("hidden");
         $(".pageSettings .section.keymapShowTopRow").removeClass("hidden");
-
       }
     }
   );

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -79,10 +79,13 @@ async function initGroups(): Promise<void> {
         $(".pageSettings .section.keymapStyle").addClass("hidden");
         $(".pageSettings .section.keymapLayout").addClass("hidden");
         $(".pageSettings .section.keymapLegendStyle").addClass("hidden");
+        $(".pageSettings .section.keymapShowTopRow").addClass("hidden");
       } else {
         $(".pageSettings .section.keymapStyle").removeClass("hidden");
         $(".pageSettings .section.keymapLayout").removeClass("hidden");
         $(".pageSettings .section.keymapLegendStyle").removeClass("hidden");
+        $(".pageSettings .section.keymapShowTopRow").removeClass("hidden");
+
       }
     }
   );
@@ -99,6 +102,11 @@ async function initGroups(): Promise<void> {
   groups["keymapLegendStyle"] = new SettingsGroup(
     "keymapLegendStyle",
     UpdateConfig.setKeymapLegendStyle,
+    "button"
+  );
+  groups["keymapShowTopRow"] = new SettingsGroup(
+    "keymapShowTopRow",
+    UpdateConfig.setKeymapShowTopRow,
     "button"
   );
   groups["showKeyTips"] = new SettingsGroup(

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -72,6 +72,8 @@ declare namespace MonkeyTypes {
 
   type KeymapLegendStyle = "lowercase" | "uppercase" | "blank" | "dynamic";
 
+  type KeymapShowTopRow = "always" | "layout" | "never";
+
   type ShowAverage = "off" | "wpm" | "acc" | "both";
 
   type TapeMode = "off" | "letter" | "word";
@@ -342,6 +344,7 @@ declare namespace MonkeyTypes {
     keymapStyle: KeymapStyle;
     keymapLegendStyle: KeymapLegendStyle;
     keymapLayout: string;
+    keymapShowTopRow: KeymapShowTopRow;
     fontFamily: string;
     smoothLineScroll: boolean;
     alwaysShowDecimalPlaces: boolean;

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -1618,6 +1618,35 @@
         </div>
       </div>
     </div>
+    <div class="section keymapShowTopRow fullWidth">
+      <h1>keymap show top row</h1>
+      <div class="buttons">
+        <div
+          class="button"
+          keymapShowTopRow="always"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          always
+        </div>
+        <div
+          class="button"
+          keymapShowTopRow="layout"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          layout dependent
+        </div>
+        <div
+          class="button"
+          keymapShowTopRow="never"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          never
+        </div>
+      </div>
+    </div>
     <div class="sectionSpacer"></div>
   </div>
 


### PR DESCRIPTION
### Description

Added a setting for displaying the top key row in the keymap. 
Three options are available: always show the top row, show it depending on the layout setting or never show the top row. 

I thought this change was necessary as the top row normally pollutes the keymap but for the funbox simon says mode it is necessary to see some other characters( like the ß in qwertz).
