### PR TITLE
Fix typo in quote

### DIFF
--- a/frontend/static/quotes/english.json
+++ b/frontend/static/quotes/english.json
@@ -381,7 +381,7 @@
     },
     {
       "text": "This is not the end, this is not even the beginning of the end, this is just perhaps the end of the beginning.",
-      "source": "End of the begining",
+      "source": "End of the beginning",
       "id": 63,
       "length": 110
     },


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Fixed a small typo in the source of an English quote. Changed `begining` to `beginning`.
`frontend/static/quotes/english.json`, Line `384`

Closes #

<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
