### PR TITLE
Add version indicator option 1

### DIFF
--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -52,14 +52,13 @@ Alternatively, if you use `nvm` then you can run `nvm install` and `nvm use` (yo
 
    - Run `firebase projects:list` to find your firebase project id.
 
-1. Within the `frontend/src/ts/constants` directory, duplicate `firebase-config-example.ts`, rename it to `firebase-config.ts` and paste in your firebase config
+1. Within the `frontend/src/ts/constants` directory, duplicate `firebase-config-example.ts`, rename it to `firebase-config.ts` and paste in your firebase config object
 
    - To find it, go to the Firebase console
    - Navigate to `Project Settings > General > Your apps`
      - If there are no apps in your project, create a new web app
    - In the `SDK setup and configuration` section, select `npm`
    - The Firebase config will be visible below
-   - After pasting, remove everything above and below the object `firebaseConfig` and add export to the front of the line containing `const firebaseConfig`
 
 1. Enable Firebase Authentication (optional)
 

--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -59,6 +59,7 @@ Alternatively, if you use `nvm` then you can run `nvm install` and `nvm use` (yo
      - If there are no apps in your project, create a new web app
    - In the `SDK setup and configuration` section, select `npm`
    - The Firebase config will be visible below
+   - After pasting, remove everything above and below the object `firebaseConfig` and add export to the front of the line containing `const firebaseConfig`
 
 1. Enable Firebase Authentication (optional)
 

--- a/frontend/src/styles/footer.scss
+++ b/frontend/src/styles/footer.scss
@@ -89,6 +89,12 @@
 
   .version {
     opacity: 0;
+    #newVersionIndicator {
+      background-color: var(--main-color);
+      height: 5px;
+      width: 5px;
+      border-radius: 50%;
+    }
   }
 }
 

--- a/frontend/src/ts/elements/version-check.ts
+++ b/frontend/src/ts/elements/version-check.ts
@@ -1,5 +1,3 @@
-import * as Notifications from "./notifications";
-
 function setMemory(v: string): void {
   window.localStorage.setItem("lastSeenVersion", v);
 }
@@ -18,11 +16,6 @@ export async function show(version: string): Promise<void> {
   caches.keys().then(function (names) {
     for (const name of names) caches.delete(name);
   });
-  Notifications.addBanner(
-    `Version ${version} has been released. Click the version number in the bottom right to view the changelog.`,
-    1,
-    "code-branch",
-    false
-  );
+  $("#newVersionIndicator").removeClass("hidden");
   setMemory(version);
 }

--- a/frontend/src/ts/elements/version-check.ts
+++ b/frontend/src/ts/elements/version-check.ts
@@ -14,14 +14,6 @@ export async function show(version: string): Promise<void> {
     setMemory(version);
     return;
   }
-  if (
-    window.location.hostname === "localhost" ||
-    window.location.hostname === "127.0.0.1"
-  ) {
-    caches.keys().then(function (names) {
-      for (const name of names) caches.delete(name);
-    });
-  }
   if (memory === version) return;
   caches.keys().then(function (names) {
     for (const name of names) caches.delete(name);

--- a/frontend/src/ts/popups/version-popup.ts
+++ b/frontend/src/ts/popups/version-popup.ts
@@ -3,6 +3,7 @@ export function show(): void {
     .css("opacity", 0)
     .removeClass("hidden")
     .animate({ opacity: 1 }, 125);
+  $("#newVersionIndicator").addClass("hidden");
 }
 
 $(document.body).on("click", ".version", (e) => {

--- a/frontend/static/html/bottom.html
+++ b/frontend/static/html/bottom.html
@@ -80,6 +80,7 @@
       <a class="version textButton">
         <i class="fas fa-fw fa-code-branch"></i>
         <div class="text">version</div>
+        <div id="newVersionIndicator" class="hidden"></div>
       </a>
       <!-- <div>
         <i class="fas fa-file"></i>


### PR DESCRIPTION
### Description
This pr removes the banner that shows when a new version is released and instead shows a 5px diameter circle at the upper right corner of the version number to alert users of a new version. Don't think I can test properly on localhost but it's pretty straightforward. Remove the hidden class on line 83 of bottom.html to see the indicator

Other edits:
* Removed a block of code that wouldn't be executed since it was checking if localhost after the code executing it ensures that it is not localhost
* Fixes a flaw in `CONTRIBUTING_ADVANCED.md` relating to the code copied to  `firebase-config.ts` containing more than is expected. 

What the indicator looks like:
![Screenshot from 2022-08-07 01-53-32](https://user-images.githubusercontent.com/47042841/183277360-70fd670a-ad68-4835-946a-38f01437b014.png)

