### PR TITLE
Fix typo in spanish_10k.json

### DIFF
--- a/frontend/static/languages/spanish_10k.json
+++ b/frontend/static/languages/spanish_10k.json
@@ -9570,7 +9570,7 @@
     "compradores",
     "comunión",
     "derivado",
-    "francésa",
+    "francesa",
     "interesada",
     "leí",
     "separan",


### PR DESCRIPTION

### Description

`francésa` to `francesa`
