### PR TITLE
Update README link to discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Monkeytype is a minimalistic and customizable typing test. It features many test
 
 # Discord bot
 
-On the [Monkeytype Discord server](https://www.discord.gg/monkeytype), we added a Discord bot to auto-assign optional roles based on typing performance and challenge completion. You can find its code over at https://github.com/Miodec/monkey-bot.
+On the [Monkeytype Discord server](https://www.discord.gg/monkeytype), we added a Discord bot to auto-assign optional roles based on typing performance and challenge completion. You can find its code over at https://github.com/monkeytypegame/monkeytype-bot.
 
 # Bug report or Feature request
 


### PR DESCRIPTION
### Description

I changed the link to the discord bot from https://github.com/Miodec/monkey-bot to https://github.com/monkeytypegame/monkeytype-bot.