### PR TITLE
Change the error colour in the blue dolphin theme to make it more readable

### DIFF
--- a/frontend/static/themes/blue_dolphin.css
+++ b/frontend/static/themes/blue_dolphin.css
@@ -7,6 +7,6 @@
   --text-color: #82eaff;
   --error-color: #ffbde6;
   --error-extra-color: #ff8188;
-  --colorful-error-color: #ffbde6;
+  --colorful-error-color: #d1a5fd;
   --colorful-error-extra-color: #ff8188;
 }


### PR DESCRIPTION

### Description


For the blue dolphin theme, when the colourful mode was used, errors were really hard to see.

![image](https://user-images.githubusercontent.com/66863579/186356286-5a2af56d-22ed-4c7c-bfaa-706044405637.png)

Colorful mode is on in the above image.

In the above image, the "c" is wrongly typed but it barely looks like it. The reason being the difference between the error color and the main color is too little.  Therefore I suggest a change in the colourful error colour.

![image](https://user-images.githubusercontent.com/66863579/186357290-f7995479-298d-4241-87cf-0931d67d5472.png)

Main colour vs **Previous** colourful error colour


![image](https://user-images.githubusercontent.com/66863579/186357701-bbca21ac-98db-40a0-99a1-272a07c70cba.png)

Main colour vs **New** colourful error colour

----------------------------------------------------------------------------------
Here's how it looks:

![image](https://user-images.githubusercontent.com/66863579/186359053-a5bb7fc6-3ace-4569-88ac-abbf6240b866.png)

**Before**


![image](https://user-images.githubusercontent.com/66863579/186359897-c8fd9278-cf45-4d69-b91c-46237a5623e6.png)

**After**

Original colourful error : #ffbde6
New colourful error : #d1a5fd

I tried to keep it with the pastel-like colours that @vimiomori used. 