### PR TITLE
Corrected catalan_1K.json Cataluña -> Catalunya

### DIFF
--- a/frontend/static/languages/catalan_1k.json
+++ b/frontend/static/languages/catalan_1k.json
@@ -127,7 +127,7 @@
     "quals",
     "aquestes",
     "família",
-    "Cataluña",
+    "Catalunya",
     "país",
     "eren",
     "poden",


### PR DESCRIPTION
The "ñ" letter doesn't exist in catalan, it is written as "ny"

<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
