### PR TITLE
Change displayed modifier key based on platform

### DIFF
--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -9,7 +9,7 @@ import * as TestUI from "./test/test-ui";
 import { get as getActivePage } from "./states/active-page";
 
 export function updateKeytips(): void {
-  const modifierKey = window.navigator.platform.includes("Mac")
+  const modifierKey = window.navigator.userAgent.toLowerCase().includes("mac")
     ? "cmd"
     : "ctrl";
 

--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -9,28 +9,32 @@ import * as TestUI from "./test/test-ui";
 import { get as getActivePage } from "./states/active-page";
 
 export function updateKeytips(): void {
+  const modifierKey = window.navigator.platform.includes("Mac")
+    ? "cmd"
+    : "ctrl";
+
   if (Config.quickRestart === "esc") {
     $(".pageSettings .tip").html(`
     tip: You can also change all these settings quickly using the
-    command line (<key>ctrl/cmd</key>+<key>shift</key>+<key>p</key>)`);
+    command line (<key>${modifierKey}</key>+<key>shift</key>+<key>p</key>)`);
   } else {
     $(".pageSettings .tip").html(`
     tip: You can also change all these settings quickly using the
-    command line (<key>esc</key> or <key>ctrl/cmd</key>+<key>shift</key>+<key>p</key>)`);
+    command line (<key>esc</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key>)`);
   }
 
   if (Config.quickRestart === "esc") {
     $("#bottom .keyTips").html(`
     <key>esc</key> - restart test<br>
-    <key>tab</key> or <key>ctrl/cmd</key>+<key>shift</key>+<key>p</key> - command line`);
+    <key>tab</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
   } else if (Config.quickRestart === "tab") {
     $("#bottom .keyTips").html(`
     <key>tab</key> - restart test<br>
-      <key>esc</key> or <key>ctrl/cmd</key>+<key>shift</key>+<key>p</key> - command line`);
+      <key>esc</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
   } else {
     $("#bottom .keyTips").html(`
     <key>tab</key> + <key>enter</key> - restart test<br>
-    <key>esc</key> or <key>ctrl/cmd</key>+<key>shift</key>+<key>p</key> - command line`);
+    <key>esc</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
   }
 }
 


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

This PR changes the bottom key tip to just be `ctrl + shift + p` or `cmd + shift + p` based on the detected platform, rather than `ctrl/cmd + shift + p`.

Before:
![image](https://user-images.githubusercontent.com/27079662/190320501-eeebad00-e16b-4c61-b345-21a9bc338516.png)

After (Windows):
![image](https://user-images.githubusercontent.com/27079662/190320529-8106a1b2-3153-4259-9fba-6a6aba2d0695.png)

<!-- Please describe the change(s) made in your PR -->

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
