### PR TITLE
Move types dependency to devDeps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@types/jquery": "3.5.14",
     "@types/object-hash": "2.2.1",
     "@types/select2": "4.0.55",
+    "@types/throttle-debounce": "2.1.0",
     "@types/tinycolor2": "1.4.3",
     "buffer": "6.0.3",
     "circular-dependency-plugin": "5.2.2",
@@ -53,7 +54,6 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@types/throttle-debounce": "2.1.0",
     "axios": "0.21.4",
     "chart.js": "3.7.1",
     "chartjs-adapter-date-fns": "2.0.0",


### PR DESCRIPTION
### Description
`@types/${libName}` are usually supposed to be in `"devDependencies"`.
It's not a "major" feature or sth. Just a little dependency fix.

P.S. No discussion or an issue is closed, opened while casually looking through the monkeytype's source code.

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
