### PR TITLE
De-emphasize unreached words in burst heatmap

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -540,6 +540,9 @@
         letter.incorrect.extra {
           color: var(--error-extra-color);
         }
+        &.unreached letter {
+          filter: opacity(0.2);
+        }
         &.heatmap0 letter {
           color: var(--colorful-error-color);
         }

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -941,11 +941,16 @@ export function applyBurstHeatmap(): void {
     });
 
     $("#resultWordsHistory .words .word").each((_, word) => {
-      const wordBurstVal = parseInt(<string>$(word).attr("burst"));
       let cls = "";
-      steps.forEach((step) => {
-        if (wordBurstVal > step.val) cls = step.class;
-      });
+      const wordBurstAttr = $(word).attr("burst");
+      if (wordBurstAttr === undefined) {
+        cls = "unreached";
+      } else {
+        const wordBurstVal = parseInt(<string>wordBurstAttr);
+        steps.forEach((step) => {
+          if (wordBurstVal >= step.val) cls = step.class;
+        });
+      }
       $(word).addClass(cls);
     });
   } else {
@@ -955,6 +960,7 @@ export function applyBurstHeatmap(): void {
     $("#resultWordsHistory .words .word").removeClass("heatmap2");
     $("#resultWordsHistory .words .word").removeClass("heatmap3");
     $("#resultWordsHistory .words .word").removeClass("heatmap4");
+    $("#resultWordsHistory .words .word").removeClass("unreached");
   }
 }
 


### PR DESCRIPTION
### Description

I noticed the "unreached" words at the end of the input burst heatmap use the same styling as the median speed, which is misleading. In this test I never reached "under first":

<img width="1177" alt="スクリーンショット 2022-10-04 13 11 50" src="https://user-images.githubusercontent.com/45430/193883984-a16f00bd-a969-4253-b6c6-d03b6fa695c8.png">

These words don't have a `.heatmap#` class so they get the default `.word` styling.

This PR de-emphasizes those words:

<img width="1177" alt="スクリーンショット 2022-10-04 13 11 38" src="https://user-images.githubusercontent.com/45430/193884091-bd13fad0-7f4a-4a1e-9a1c-c5a83fec2d6e.png">