### PR TITLE
Fixed #2361

### DIFF
--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -382,7 +382,7 @@ function restoreOldCommandLine(sshow = true): void {
   if (sshow) show();
 }
 
-$("#commandLine input").on("input", () => {
+$("#commandLine input").on("input", (e) => {
   commandLineMouseMode = false;
   $("#commandLineWrapper #commandLine .suggestions .entry").removeClass(
     "activeMouse"

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -382,21 +382,11 @@ function restoreOldCommandLine(sshow = true): void {
   if (sshow) show();
 }
 
-$("#commandLine input").keyup((e) => {
+$("#commandLine input").on("input", () => {
   commandLineMouseMode = false;
   $("#commandLineWrapper #commandLine .suggestions .entry").removeClass(
     "activeMouse"
   );
-  if (
-    e.key === "ArrowUp" ||
-    e.key === "ArrowDown" ||
-    e.key === "Enter" ||
-    e.key === "Tab" ||
-    e.code == "AltLeft" ||
-    (e.key.length > 1 && e.key !== "Backspace" && e.key !== "Delete")
-  ) {
-    return;
-  }
   updateSuggested();
 });
 

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -382,7 +382,7 @@ function restoreOldCommandLine(sshow = true): void {
   if (sshow) show();
 }
 
-$("#commandLine input").on("input", (e) => {
+$("#commandLine input").on("input", () => {
   commandLineMouseMode = false;
   $("#commandLineWrapper #commandLine .suggestions .entry").removeClass(
     "activeMouse"


### PR DESCRIPTION
### Description

Closes #2361. Fixed command line input bug on android. 

1. Replaced the `keyup` listener with `input` listener on the command line component.
2. Removed meta key checks that won't be needed with `input` listener.
