### PR TITLE
prevent redirect to /profile/undefined when going to the page of a non-existing profile

### DIFF
--- a/frontend/src/ts/pages/profile.ts
+++ b/frontend/src/ts/pages/profile.ts
@@ -170,9 +170,9 @@ async function update(options: UpdateOptions): Promise<void> {
         "Failed to load profile: " + response.message,
         -1
       );
+    } else {
+      window.history.replaceState(null, "", `/profile/${response.data.name}`);
     }
-
-    window.history.replaceState(null, "", `/profile/${response.data.name}`);
 
     Profile.update("profile", response.data);
     PbTables.update(response.data.personalBests, true);


### PR DESCRIPTION
Fix it automatically changing the url in the url bar (which gets requested if someone reloads the page) to https://monkeytype.com/profile/undefined (which apparently is already the username of an existing user) when going to the profile url of a non-existent user (for ex. https://monkeytype.com/profile/dfjksahjkadfsjhkasfhjkadhjksf ) , by not replacing url state unless the response status is 200