### PR TITLE
Remove "telecharger" from `english_10k`

### DIFF
--- a/frontend/static/languages/english_10k.json
+++ b/frontend/static/languages/english_10k.json
@@ -7238,7 +7238,6 @@
     "teenage",
     "teens",
     "teeth",
-    "telecharger",
     "telecommunications",
     "telephone",
     "telephony",


### PR DESCRIPTION
### Description

This removes the word "telecharger" from `english_10k.json`. [_<span lang="fr">Télécharger</span>_](https://en.wiktionary.org/wiki/t%C3%A9l%C3%A9charger) is the French word for _download_, but I can't find any meaning for it in English. It probably slipped into the list because it looks like it plausibly could be an English word.