### PR TITLE
transform œ character which is not on many keyboard

### DIFF
--- a/frontend/static/quotes/french.json
+++ b/frontend/static/quotes/french.json
@@ -724,7 +724,7 @@
     {
       "text": "Ta chambre est la plus belle des iles désertes, et Paris est un désert que nul n’a jamais traversé. Tu n’as besoin de rien d’autre que de ce calme, de ce sommeil, que de ce silence, que de cette torpeur. Que les jours commencent et que les jours finissent, que le temps s’écoule, que ta bouche se ferme, que les muscles de ta nuque, de ta machoire, de ton menton, se relachent tout à fait, que seuls les soulèvements de ta cage thoracique, les battements de ton coeur témoignent encore de ta patiente survie.",
       "source": "Un homme qui dort de Georges Perec",
-      "length": 507,
+      "length": 508,
       "id": 120
     },
     {

--- a/frontend/static/quotes/french.json
+++ b/frontend/static/quotes/french.json
@@ -722,7 +722,7 @@
       "id": 119
     },
     {
-      "text": "Ta chambre est la plus belle des iles désertes, et Paris est un désert que nul n’a jamais traversé. Tu n’as besoin de rien d’autre que de ce calme, de ce sommeil, que de ce silence, que de cette torpeur. Que les jours commencent et que les jours finissent, que le temps s’écoule, que ta bouche se ferme, que les muscles de ta nuque, de ta machoire, de ton menton, se relachent tout à fait, que seuls les soulèvements de ta cage thoracique, les battements de ton cœur témoignent encore de ta patiente survie.",
+      "text": "Ta chambre est la plus belle des iles désertes, et Paris est un désert que nul n’a jamais traversé. Tu n’as besoin de rien d’autre que de ce calme, de ce sommeil, que de ce silence, que de cette torpeur. Que les jours commencent et que les jours finissent, que le temps s’écoule, que ta bouche se ferme, que les muscles de ta nuque, de ta machoire, de ton menton, se relachent tout à fait, que seuls les soulèvements de ta cage thoracique, les battements de ton coeur témoignent encore de ta patiente survie.",
       "source": "Un homme qui dort de Georges Perec",
       "length": 507,
       "id": 120


### PR DESCRIPTION
### Description

Hi,

Here is a transformation of the character `œ` which is not mapped on many french layout. It is replaced with `oe`
