### PR TITLE
Mapped letter k to make a sound in sound controller

### DIFF
--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -306,7 +306,7 @@ const codeToNote: Record<string, GetNoteFrequencyCallback> = {
   BracketLeft: bindToNote(notes.F, 2),
   Equal: bindToNote(notes.Gb, 2),
   BracketRight: bindToNote(notes.G, 2),
-  KeyK: bindToNote(notes.Ab, 1)
+  KeyK: bindToNote(notes.Ab, 1),
 };
 
 type DynamicClickSounds = Extract<

--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -306,6 +306,7 @@ const codeToNote: Record<string, GetNoteFrequencyCallback> = {
   BracketLeft: bindToNote(notes.F, 2),
   Equal: bindToNote(notes.Gb, 2),
   BracketRight: bindToNote(notes.G, 2),
+  KeyK: bindToNote(notes.Ab, 1),
 };
 
 type DynamicClickSounds = Extract<

--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -306,7 +306,7 @@ const codeToNote: Record<string, GetNoteFrequencyCallback> = {
   BracketLeft: bindToNote(notes.F, 2),
   Equal: bindToNote(notes.Gb, 2),
   BracketRight: bindToNote(notes.G, 2),
-  KeyK: bindToNote(notes.Ab, 1),
+  KeyK: bindToNote(notes.Ab, 1)
 };
 
 type DynamicClickSounds = Extract<


### PR DESCRIPTION
For some reason, the 'K' key isn't mapped to produce any sound within the sound-controller. I'm not sure if this is some sort of deliberate persecution against the letter k, but in case it is unintentional, here we go!

I mapped it according to the chromatic pattern within `codeToNote`, and choose A flat as the note since it is the least frequent to even out the distribution of sounds from the keys. 