### PR TITLE
Add `greys` to British English

### DIFF
--- a/frontend/static/languages/britishenglish.json
+++ b/frontend/static/languages/britishenglish.json
@@ -505,6 +505,7 @@
   ["color", "colour"],
   ["tire", "tyre"],
   ["gray", "grey"],
+  ["grays", "greys"],
   ["theater", "theatre"],
   ["center", "centre"],
   ["realize", "realise"],


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Add `grays` -> `greys` to British English
