### PR TITLE
Fix: Move large live wpm down if quick tab is disabled (#3806)

### DIFF
--- a/frontend/static/html/pages/test.html
+++ b/frontend/static/html/pages/test.html
@@ -118,7 +118,6 @@
     </div>
     <div id="miniTimerAndLiveWpm" class="timerMain">
       <div class="time hidden">1:00</div>
-      <div class="wpm hidden">60</div>
       <div class="acc hidden">100%</div>
       <div class="burst hidden">1</div>
     </div>
@@ -141,6 +140,10 @@
       <div id="liveWpm" class="hidden">123</div>
       <div id="liveAcc" class="hidden">100%%</div>
       <div id="liveBurst" class="hidden">1</div>
+    </div>
+
+    <div id="miniTimerAndLiveWpm" style="width: 100%; justify-content: center; align-items: center; margin-top: 4%;" class="timerMain">
+      <div class="wpm hidden">60</div>
     </div>
 
     <div


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

Closes #3806 

![image](https://user-images.githubusercontent.com/74089487/210770432-3c892888-9fc2-443e-8840-ab8a01d8fafc.png)

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
