### PR TITLE
Add audio fade to remove audible 'pop' within sine's sound-on-click

### DIFF
--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -367,7 +367,6 @@ export function playNote(
     clickSoundIdsToOscillatorType[
       Config.playSoundOnClick as DynamicClickSounds
     ];
-
   gainNode.gain.value = parseFloat(Config.soundVolume) / 10;
 
   oscillatorNode.connect(gainNode);
@@ -375,7 +374,7 @@ export function playNote(
 
   oscillatorNode.frequency.value = currentFrequency;
   oscillatorNode.start(audioCtx.currentTime);
-  gainNode.gain.setTargetAtTime(0, audioCtx.currentTime, 0.15); //reduce pop sound
+  gainNode.gain.setTargetAtTime(0, audioCtx.currentTime, 0.15); //remove click sound
   oscillatorNode.stop(audioCtx.currentTime + 1);
 }
 

--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -375,7 +375,7 @@ export function playNote(
   oscillatorNode.frequency.value = currentFrequency;
   oscillatorNode.start(audioCtx.currentTime);
   gainNode.gain.setTargetAtTime(0, audioCtx.currentTime, 0.15); //remove click sound
-  oscillatorNode.stop(audioCtx.currentTime + 1);
+  oscillatorNode.stop(audioCtx.currentTime + 0.5);
 }
 
 export function playClick(): void {

--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -367,6 +367,7 @@ export function playNote(
     clickSoundIdsToOscillatorType[
       Config.playSoundOnClick as DynamicClickSounds
     ];
+
   gainNode.gain.value = parseFloat(Config.soundVolume) / 10;
 
   oscillatorNode.connect(gainNode);
@@ -374,7 +375,8 @@ export function playNote(
 
   oscillatorNode.frequency.value = currentFrequency;
   oscillatorNode.start(audioCtx.currentTime);
-  oscillatorNode.stop(audioCtx.currentTime + 0.15);
+  gainNode.gain.setTargetAtTime(0, audioCtx.currentTime, 0.15); //reduce pop sound
+  oscillatorNode.stop(audioCtx.currentTime + 1);
 }
 
 export function playClick(): void {


### PR DESCRIPTION
When the volume of the sound-on-click is set to loud, the 'sine' sound generated through the `oscillatorNode` has an audible 'pop' sound that can be quite distracting. This is most apparent when you go to zen mode and do some keyboard mashing.

The reason there is this pop is that the audio abruptly stops within the function call `oscillatorNode.stop(audioCtx.currentTime + 1);` on line 377 of `sound-controller.ts` without any fading in the volume. 

This problem is outlined in this [StackOverflow post.
](https://stackoverflow.com/questions/29378875/how-can-i-avoid-this-clicking-sound-when-i-stop-playing-a-sound)

This can be solved by implementing an audio fade using the gainNode's function setTargetAtTime(), which [the MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/AudioParam/setTargetAtTime) states is a function that exponentially curves the volume downwards to your desired volume. In this case, we would want to see it to curve downwards until a volume of zero, creating a natural audio fade.   

It also makes the sounds more organic, by tapering the volume as you would find in instruments like a piano note. 
 