### PR TITLE
add backup font-family "sans-serif"

### DIFF
--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -1,6 +1,6 @@
 :root {
   --roundness: 0.5rem;
-  --font: "Roboto Mono", "Vazirmatn";
+  --font: "Roboto Mono", "Vazirmatn", sans-serif;
   // scroll-behavior: smooth;
   scroll-padding-top: 2rem;
   font-weight: 400;


### PR DESCRIPTION
In some cases when the styles are not loaded yet, the fonts are rolled back to the default 'serif' family which looks very ugly
