### PR TITLE
Fix french punctuation typo - missing space

### DIFF
--- a/frontend/static/quotes/french.json
+++ b/frontend/static/quotes/french.json
@@ -704,7 +704,7 @@
       "id": 116
     },
     {
-      "text": "Tu es assis et tu ne veux qu'attendre, attendre seulement jusqu'à ce qu'il n'y ait plus rien à attendre: que vienne la nuit, que sonnent les heures, que les jours s'en aillent, que les souvenirs s'estompent.",
+      "text": "Tu es assis et tu ne veux qu'attendre, attendre seulement jusqu'à ce qu'il n'y ait plus rien à attendre : que vienne la nuit, que sonnent les heures, que les jours s'en aillent, que les souvenirs s'estompent.",
       "source": "Un homme qui dort (1967) de Georges Perec",
       "length": 207,
       "id": 117
@@ -734,7 +734,7 @@
       "id": 121
     },
     {
-      "text": "Tu as tout à apprendre, tout ce qui ne s'apprend pas: la solitude, l'indifférence, la patience, le silence.",
+      "text": "Tu as tout à apprendre, tout ce qui ne s'apprend pas : la solitude, l'indifférence, la patience, le silence.",
       "source": "Un homme qui dort de Georges Perec",
       "length": 107,
       "id": 122
@@ -746,7 +746,7 @@
       "id": 123
     },
     {
-      "text": "Même quand je marcherais par la vallée de l'ombre de la mort, je ne craindrai aucun mal; car tu es avec moi: ta houlette et ton bâton, ce sont eux qui me consolent.",
+      "text": "Même quand je marcherais par la vallée de l'ombre de la mort, je ne craindrai aucun mal; car tu es avec moi : ta houlette et ton bâton, ce sont eux qui me consolent.",
       "source": "Psaume 23:4 Bible Darby",
       "length": 164,
       "id": 124

--- a/frontend/static/quotes/french.json
+++ b/frontend/static/quotes/french.json
@@ -706,7 +706,7 @@
     {
       "text": "Tu es assis et tu ne veux qu'attendre, attendre seulement jusqu'à ce qu'il n'y ait plus rien à attendre : que vienne la nuit, que sonnent les heures, que les jours s'en aillent, que les souvenirs s'estompent.",
       "source": "Un homme qui dort (1967) de Georges Perec",
-      "length": 207,
+      "length": 208,
       "id": 117
     },
     {
@@ -736,7 +736,7 @@
     {
       "text": "Tu as tout à apprendre, tout ce qui ne s'apprend pas : la solitude, l'indifférence, la patience, le silence.",
       "source": "Un homme qui dort de Georges Perec",
-      "length": 107,
+      "length": 108,
       "id": 122
     },
     {
@@ -748,7 +748,7 @@
     {
       "text": "Même quand je marcherais par la vallée de l'ombre de la mort, je ne craindrai aucun mal; car tu es avec moi : ta houlette et ton bâton, ce sont eux qui me consolent.",
       "source": "Psaume 23:4 Bible Darby",
-      "length": 164,
+      "length": 165,
       "id": 124
     },
     {


### PR DESCRIPTION
### Description

In french, there is always a space character before ! ? or : punctuation signs. 
This PR fixes the few quotes missing this space character.
