### PR TITLE
Add typescript support for jest

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -17,12 +17,6 @@
   "ts-node": {
     "files": true
   },
-  "include": ["./src/**/*"],
-  "exclude": [
-    "node_modules",
-    "build",
-    "worker.js",
-    "setup-tests.ts",
-    "**/*.spec.ts"
-  ]
+  "include": ["./src/**/*", "**/*.spec.ts"],
+  "exclude": ["node_modules", "build", "worker.js", "setup-tests.ts"]
 }


### PR DESCRIPTION
Idk why it wasn't originally added to `tsconfig.json` but this fixes the type errors you get when you open `.spec.ts` files in Visual Studio Code.