### PR TITLE
Fixed issue #3971 - active theme selection is properly removed

### DIFF
--- a/frontend/src/ts/settings/theme-picker.ts
+++ b/frontend/src/ts/settings/theme-picker.ts
@@ -223,7 +223,6 @@ export async function refreshButtons(): Promise<void> {
       }
 
       const activeTheme = activeThemeName === theme.name ? "active" : "";
-      console.log(activeTheme);
       themesElHTML += `<div class="theme button ${activeTheme}" theme='${
         theme.name
       }' style="background: ${theme.bgColor}; color: ${

--- a/frontend/src/ts/settings/theme-picker.ts
+++ b/frontend/src/ts/settings/theme-picker.ts
@@ -21,8 +21,10 @@ export function updateActiveButton(): void {
   }
 
   document
-    .querySelector(`.pageSettings .section.themes .theme`)
-    ?.classList.remove("active");
+    .querySelectorAll(".pageSettings .section.themes .theme")
+    .forEach((el) => {
+      el.classList.remove("active");
+    });
   document
     .querySelector(
       `.pageSettings .section.themes .theme[theme='${activeThemeName}']`
@@ -221,6 +223,7 @@ export async function refreshButtons(): Promise<void> {
       }
 
       const activeTheme = activeThemeName === theme.name ? "active" : "";
+      console.log(activeTheme);
       themesElHTML += `<div class="theme button ${activeTheme}" theme='${
         theme.name
       }' style="background: ${theme.bgColor}; color: ${


### PR DESCRIPTION
I left a bug report, issue #3971, which showed how the active theme selection in the theme section of the settings wasn't being properly removed when the user changed the settings. We would have something that looked like this. 

![image](https://user-images.githubusercontent.com/46613983/216743906-44de2825-9aa3-459e-8613-ea7fcd6150e4.png)

This PR fixes that.
