### PR TITLE
improve password length check

### DIFF
--- a/frontend/src/ts/controllers/account-controller.ts
+++ b/frontend/src/ts/controllers/account-controller.ts
@@ -614,14 +614,6 @@ async function signUp(): Promise<void> {
     return;
   }
 
-  if (password.length > 25) {
-    LoginPage.hidePreloader();
-    LoginPage.enableInputs();
-    LoginPage.updateSignupButton();
-    Notifications.add("Password is too long", 0);
-    return;
-  }
-
   if (
     !email.match(
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -650,10 +642,10 @@ async function signUp(): Promise<void> {
     return;
   }
 
-  // Force user to use a capital letter, number, special character when setting up an account and changing password
+  // Force user to use a capital letter, number, special character and reasonable length when setting up an account and changing password
   if (!Misc.isLocalhost() && !Misc.isPasswordStrong(password)) {
     Notifications.add(
-      "Password must contain at least one capital letter, number, a special character and at least 8 characters long",
+      "Password must contain at least one capital letter, number, a special character and must be between 8 and 64 characters long",
       0,
       4
     );

--- a/frontend/src/ts/pages/login.ts
+++ b/frontend/src/ts/pages/login.ts
@@ -4,6 +4,7 @@ import Page from "./page";
 import * as Notifications from "../elements/notifications";
 import { InputIndicator } from "../elements/input-indicator";
 import * as Skeleton from "../popups/skeleton";
+import * as Misc from "../utils/misc";
 
 export function enableSignUpButton(): void {
   $(".page.pageLogin .register.side .button").removeClass("disabled");
@@ -112,22 +113,20 @@ const checkPassword = (): void => {
     ".page.pageLogin .register.side .passwordInput"
   ).val() as string;
 
-  // Force user to use a capital letter, number, special character when setting up an account and changing password
-  if (password.length < 8) {
-    passwordIndicator.show("short", "Password must be at least 8 characters");
-    return;
-  } else {
-    const hasCapital = password.match(/[A-Z]/);
-    const hasNumber = password.match(/[\d]/);
-    const hasSpecial = password.match(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/);
-    if (!hasCapital || !hasNumber || !hasSpecial) {
+  // Force user to use a capital letter, number, special character and reasonable length when setting up an account and changing password
+  if (!Misc.isLocalhost() && !Misc.isPasswordStrong(password)) {
+    if (password.length < 8) {
+      passwordIndicator.show("short", "Password must be at least 8 characters");
+    } else if (password.length > 64) {
+      passwordIndicator.show("long", "Password must be at most 64 characters");
+    } else {
       passwordIndicator.show(
         "weak",
         "Password must contain at least one capital letter, number, and special character"
       );
-    } else {
-      passwordIndicator.show("good", "Password is good");
     }
+  } else {
+    passwordIndicator.show("good", "Password is good");
   }
   updateSignupButton();
 };
@@ -205,6 +204,10 @@ const passwordIndicator = new InputIndicator(
       level: 1,
     },
     short: {
+      icon: "fa-times",
+      level: -1,
+    },
+    long: {
       icon: "fa-times",
       level: -1,
     },

--- a/frontend/src/ts/popups/simple-popups.ts
+++ b/frontend/src/ts/popups/simple-popups.ts
@@ -537,7 +537,7 @@ list["updatePassword"] = new SimplePopup(
       }
       if (!isLocalhost() && !isPasswordStrong(newPass)) {
         Notifications.add(
-          "New password must contain at least one capital letter, number, a special character and at least 8 characters long",
+          "New password must contain at least one capital letter, number, a special character and must be between 8 and 64 characters long",
           0,
           4
         );

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1330,7 +1330,8 @@ export function isPasswordStrong(password: string): boolean {
   const hasNumber = !!password.match(/[\d]/);
   const hasSpecial = !!password.match(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/);
   const isLong = password.length >= 8;
-  return hasCapital && hasNumber && hasSpecial && isLong;
+  const isShort = password.length <= 64;
+  return hasCapital && hasNumber && hasSpecial && isLong && isShort;
 }
 
 export function areUnsortedArraysEqual(a: unknown[], b: unknown[]): boolean {

--- a/frontend/static/email-handler.html
+++ b/frontend/static/email-handler.html
@@ -182,7 +182,8 @@
         /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/
       );
       const isLong = password.length >= 8;
-      return hasCapital && hasNumber && hasSpecial && isLong;
+      const isShort = password.length <= 64;
+      return hasCapital && hasNumber && hasSpecial && isLong && isShort;
     }
 
     function handleVerifyEmail(actionCode, continueUrl) {
@@ -244,7 +245,7 @@
 
           if (!isPasswordStrong(newPassword)) {
             alert(
-              "Password must be at least 8 characters long and contain at least one capital letter, one number and one special character."
+              "Password must contain at least one capital letter, number, a special character and must be between 8 and 64 characters long"
             );
             showResetPassword();
             return;


### PR DESCRIPTION
### Description

Integrate check for too long passwords into `isPasswordStrong`, and consistently check for it wherever passwords can be created / changed.

As discussed on discord with @Miodec. There was 1 check in place for 25 characters, which could easily be avoided when resetting your password, or changing it in settings.

The max length of 64 is a sure-to-be-safe length that still allows for much safer passwords, but longer lengths should still work fine with firebase.

The login page now also checks for `isLocalhost` to ingore password checks as requested by @Miodec.

There is still some duplication of the password checks where importing the function is not possible, or more info than the boolean result is needed. 