### PR TITLE
Add nord light theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1132,5 +1132,12 @@
     "mainColor": "#9999ff",
     "subColor": "#ccddff",
     "textColor": "#9999ff"
+  },
+  {
+    "name": "nord_light",
+    "bgColor": "#eceff4",
+    "mainColor": "#8fbcbb",
+    "subColor": "#6a7791",
+    "textColor": "#8fbcbb"
   }
 ]

--- a/frontend/static/themes/nord_light.css
+++ b/frontend/static/themes/nord_light.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #eceff4;
+  --caret-color: #8fbcbb;
+  --main-color: #8fbcbb;
+  --sub-color: #6a7791;
+  --sub-alt-color: #d8dee9;
+  --text-color: #8fbcbb;
+  --error-color: #bf616a;
+  --error-extra-color: #793e44;
+  --colorful-error-color: #bf616a;
+  --colorful-error-extra-color: #793e44;
+}


### PR DESCRIPTION
### Description

Adds `nord light` theme. Uses [Nord palettes](https://www.nordtheme.com/#palettes-modularity).

Couldn't find any nordic-vibe light themes, so I though I'd try something myself.

![image](https://user-images.githubusercontent.com/61781601/217004790-3cd4e3f1-7ac4-4cbe-9c40-299b28d9362e.png)
![image](https://user-images.githubusercontent.com/61781601/217004939-7c4e1d64-6b83-4115-ad12-7b3f76b5fa24.png)
![image](https://user-images.githubusercontent.com/61781601/217006181-f7947e18-13bd-4477-8411-25709de52027.png)
![image](https://user-images.githubusercontent.com/61781601/217006234-669e0498-aefe-4b03-813c-6bdbd6e85932.png)

### P.S.

Also had a hard time chossing between `nord7` and `nord15` (see screenshots below). Settled with the former. Let me know your thoughts.

![image](https://user-images.githubusercontent.com/61781601/217008418-313e8656-aeac-4175-900d-eee4943a7cbd.png)
![image](https://user-images.githubusercontent.com/61781601/217008431-d46c2b8f-84c6-41db-92fe-d5f8c079a873.png)


