### PR TITLE
fix: Add about page supporters/contributors references

### DIFF
--- a/frontend/static/html/pages/about.html
+++ b/frontend/static/html/pages/about.html
@@ -275,11 +275,11 @@
     <div id="ad-about-2-small"></div>
   </div>
   <div class="section">
-    <div class="bigtitle">supporters</div>
+    <div id="supporters_title" class="bigtitle">supporters</div>
     <div class="supporters"></div>
   </div>
   <div class="section">
-    <div class="bigtitle">contributors</div>
+    <div id="contributors_title" class="bigtitle">contributors</div>
     <div class="contributors"></div>
   </div>
 </div>


### PR DESCRIPTION
The about page has a few anchor references to the supporters and contributors that have no corresponding reference location.

e.g.
```html
<a href="#supporters_title">Supported</a>
    and
    <a href="#contributors_title">expanded</a>
```