### PR TITLE
Add word filter feature

### DIFF
--- a/frontend/src/ts/commandline/lists/word-filter.ts
+++ b/frontend/src/ts/commandline/lists/word-filter.ts
@@ -1,0 +1,46 @@
+import * as UpdateConfig from "../../config";
+
+const subgroup: MonkeyTypes.CommandsSubgroup = {
+  title: "Word Filter...",
+  configKey: "wordFilter",
+  list: [
+    {
+      id: "setWordFilterOff",
+      display: "off",
+      configValue: "off",
+      exec: (): void => {
+        UpdateConfig.setWordFilter("off");
+        console.log("off");
+      },
+    },
+    {
+      id: "setWordFilterLeft",
+      display: "letter",
+      configValue: "letter",
+      exec: (): void => {
+        UpdateConfig.setWordFilter("left");
+        console.log("left");
+      },
+    },
+    {
+      id: "setWordFilterRight",
+      display: "word",
+      configValue: "word",
+      exec: (): void => {
+        UpdateConfig.setWordFilter("right");
+        console.log("right");
+      },
+    },
+  ],
+};
+
+const commands: MonkeyTypes.Command[] = [
+  {
+    id: "changeWordFilter",
+    display: "Word Filter...",
+    icon: "fa-tape",
+    subgroup,
+  },
+];
+
+export default commands;

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1747,6 +1747,21 @@ export function setBurstHeatmap(value: boolean, nosave?: boolean): boolean {
   return true;
 }
 
+export function setWordFilter(
+  mode: MonkeyTypes.WordFilter,
+  nosave?: boolean
+): boolean {
+  if (!isConfigValueValid("word filter", mode, [["off", "left", "right"]])) {
+    return false;
+  }
+
+  config.wordFilter = mode;
+  saveToLocalStorage("wordFilter", nosave);
+  ConfigEvent.dispatch("wordFilter", config.wordFilter);
+
+  return true;
+}
+
 export function apply(
   configToApply: MonkeyTypes.Config | MonkeyTypes.ConfigChanges
 ): void {
@@ -1850,6 +1865,7 @@ export function apply(
     setShowAverage(configObj.showAverage, true);
     setTapeMode(configObj.tapeMode, true);
     setAds(configObj.ads, true);
+    setWordFilter(configObj.wordFilter, true);
 
     ConfigEvent.dispatch(
       "configApplied",

--- a/frontend/src/ts/constants/default-config.ts
+++ b/frontend/src/ts/constants/default-config.ts
@@ -97,4 +97,5 @@ export default <MonkeyTypes.Config>{
   lazyMode: false,
   showAverage: "off",
   tapeMode: "off",
+  wordFilter: "off",
 };

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -385,6 +385,11 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setCustomBackgroundSize,
     "button"
   );
+  groups["wordFilter"] = new SettingsGroup(
+    "wordFilter",
+    UpdateConfig.setWordFilter,
+    "button"
+  );
   // groups.customLayoutfluid = new SettingsGroup(
   //   "customLayoutfluid",
   //   UpdateConfig.setCustomLayoutfluid

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -719,8 +719,10 @@ async function getNextWord(
   wordsBound: number
 ): Promise<string> {
   let randomWord = wordset.randomWord();
+
   const previousWord = TestWords.words.get(TestWords.words.length - 1, true);
   const previousWord2 = TestWords.words.get(TestWords.words.length - 2, true);
+
   if (Config.mode === "quote") {
     randomWord =
       TestWords.randomQuote.textSplit?.[TestWords.words.length] ?? "";
@@ -797,6 +799,75 @@ async function getNextWord(
       } else if (Config.language.startsWith("nepali")) {
         randomWord = Misc.convertNumberToNepali(randomWord);
       }
+    }
+  }
+  if (Config.wordFilter === "left") {
+    while (
+      randomWord.indexOf("y") > -1 ||
+      randomWord.indexOf("u") > -1 ||
+      randomWord.indexOf("i") > -1 ||
+      randomWord.indexOf("o") > -1 ||
+      randomWord.indexOf("p") > -1 ||
+      randomWord.indexOf("h") > -1 ||
+      randomWord.indexOf("i") > -1 ||
+      randomWord.indexOf("j") > -1 ||
+      randomWord.indexOf("k") > -1 ||
+      randomWord.indexOf("l") > -1 ||
+      randomWord.indexOf("n") > -1 ||
+      randomWord.indexOf("m") > -1 ||
+      randomWord.indexOf("Y") > -1 ||
+      randomWord.indexOf("U") > -1 ||
+      randomWord.indexOf("I") > -1 ||
+      randomWord.indexOf("O") > -1 ||
+      randomWord.indexOf("P") > -1 ||
+      randomWord.indexOf("H") > -1 ||
+      randomWord.indexOf("I") > -1 ||
+      randomWord.indexOf("J") > -1 ||
+      randomWord.indexOf("K") > -1 ||
+      randomWord.indexOf("L") > -1 ||
+      randomWord.indexOf("N") > -1 ||
+      randomWord.indexOf("M") > -1
+    ) {
+      randomWord = wordset.randomWord();
+    }
+  }
+
+  if (Config.wordFilter === "right") {
+    while (
+      randomWord.indexOf("q") > -1 ||
+      randomWord.indexOf("w") > -1 ||
+      randomWord.indexOf("e") > -1 ||
+      randomWord.indexOf("r") > -1 ||
+      randomWord.indexOf("t") > -1 ||
+      randomWord.indexOf("y") > -1 ||
+      randomWord.indexOf("a") > -1 ||
+      randomWord.indexOf("s") > -1 ||
+      randomWord.indexOf("d") > -1 ||
+      randomWord.indexOf("f") > -1 ||
+      randomWord.indexOf("g") > -1 ||
+      randomWord.indexOf("z") > -1 ||
+      randomWord.indexOf("x") > -1 ||
+      randomWord.indexOf("c") > -1 ||
+      randomWord.indexOf("v") > -1 ||
+      randomWord.indexOf("b") > -1 ||
+      randomWord.indexOf("Q") > -1 ||
+      randomWord.indexOf("W") > -1 ||
+      randomWord.indexOf("E") > -1 ||
+      randomWord.indexOf("R") > -1 ||
+      randomWord.indexOf("T") > -1 ||
+      randomWord.indexOf("Y") > -1 ||
+      randomWord.indexOf("A") > -1 ||
+      randomWord.indexOf("S") > -1 ||
+      randomWord.indexOf("D") > -1 ||
+      randomWord.indexOf("F") > -1 ||
+      randomWord.indexOf("G") > -1 ||
+      randomWord.indexOf("Z") > -1 ||
+      randomWord.indexOf("X") > -1 ||
+      randomWord.indexOf("C") > -1 ||
+      randomWord.indexOf("V") > -1 ||
+      randomWord.indexOf("B") > -1
+    ) {
+      randomWord = wordset.randomWord();
     }
   }
 

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -78,6 +78,8 @@ declare namespace MonkeyTypes {
 
   type TapeMode = "off" | "letter" | "word";
 
+  type WordFilter = "off" | "left" | "right";
+
   type SingleListCommandLine = "manual" | "on";
 
   /*
@@ -471,6 +473,7 @@ declare namespace MonkeyTypes {
     lazyMode: boolean;
     showAverage: ShowAverage;
     tapeMode: TapeMode;
+    wordFilter: WordFilter;
   }
 
   type ConfigValues =

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -1483,6 +1483,45 @@
         </div>
       </div>
     </div>
+
+    <div class="section wordFilter" section="">
+      <div class="groupTitle">
+        <span>word filter</span>
+      </div>
+      <div class="text">
+        When enabled words that appear will either be left or right handed.
+        Setting this to 'left' will make words appear with letters
+        'qwertasdfgzxcvb', while setting this to 'right' will make words appear
+        with letters 'yuiophjklnm'.
+      </div>
+      <div class="buttons">
+        <div
+          class="button"
+          wordFilter="off"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          off
+        </div>
+        <div
+          class="button"
+          wordFilter="left"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          left
+        </div>
+        <div
+          class="button"
+          wordFilter="right"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          right
+        </div>
+      </div>
+    </div>
+
     <div class="section smoothLineScroll">
       <div class="groupTitle">
         <i class="fas fa-align-left"></i>


### PR DESCRIPTION
### Description

  When enabled words that appear will either be left or right handed. Setting this to 'left' will make words appear with letters 'qwertasdfgzxcvb', while setting this to 'right' will make words appear with letters 'yuiophjklnm'.
  
 #### option left
![image](https://user-images.githubusercontent.com/91633962/220020313-764e761c-cdc6-41cc-80de-221aa8893694.png)
![image](https://user-images.githubusercontent.com/91633962/220020385-5f0f83be-7449-4b0f-95e6-f5d3fe1a8fcf.png)
![image](https://user-images.githubusercontent.com/91633962/220020872-4795d279-bff8-4720-ac0f-68a56231e17c.png)

 #### option right 
![image](https://user-images.githubusercontent.com/91633962/220020666-91a788b4-fa26-43d6-81d5-122e5ff51efd.png)
![image](https://user-images.githubusercontent.com/91633962/220020701-0a55ed28-0c91-4907-a289-7108591772d0.png)
![image](https://user-images.githubusercontent.com/91633962/220020825-3d801f55-c64b-40a5-9579-dcd0beae3596.png)

  I've never contributed to open source before, so sorry if I'm not doing something correctly.
  
  Closes #
  N/A
  