### PR TITLE
feat: support Emacs/Vim navigation in command line

### DIFF
--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -669,7 +669,14 @@ $(document).on("keydown", (e) => {
       trigger(command);
       return;
     }
-    if (e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "Tab") {
+    if (
+      e.key === "ArrowUp" ||
+      e.key === "ArrowDown" ||
+      e.key === "Tab" ||
+      // Should only branch on n/p if ctrl is held to allow n/p to still be typed
+      ((e.key === "p" || e.key === "n" || e.key === "j" || e.key === "k") &&
+        e.ctrlKey)
+    ) {
       e.preventDefault();
       $("#commandLineWrapper #commandLine .suggestions .entry").unbind(
         "mouseenter mouseleave"
@@ -682,7 +689,10 @@ $(document).on("keydown", (e) => {
       });
       if (
         e.key === "ArrowUp" ||
-        (e.key === "Tab" && e.shiftKey && Config.quickRestart !== "esc")
+        (e.key === "Tab" && e.shiftKey && Config.quickRestart !== "esc") ||
+        // Don't need to check for ctrl because that was already done above
+        e.key === "p" ||
+        e.key === "k"
       ) {
         entries.removeClass("activeKeyboard");
         if (activenum == 0) {
@@ -695,7 +705,9 @@ $(document).on("keydown", (e) => {
       }
       if (
         e.key === "ArrowDown" ||
-        (e.key === "Tab" && !e.shiftKey && Config.quickRestart !== "esc")
+        (e.key === "Tab" && !e.shiftKey && Config.quickRestart !== "esc") ||
+        e.key === "n" ||
+        e.key === "j"
       ) {
         entries.removeClass("activeKeyboard");
         if (activenum + 1 == entries.length) {

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -674,8 +674,8 @@ $(document).on("keydown", (e) => {
       e.key === "ArrowDown" ||
       e.key === "Tab" ||
       // Should only branch if ctrl is held to allow the letters to still be typed
-      ((e.key === "p" || e.key === "n" || e.key === "j" || e.key === "k") &&
-        e.ctrlKey)
+      (e.ctrlKey &&
+        (e.key === "p" || e.key === "n" || e.key === "j" || e.key === "k"))
     ) {
       e.preventDefault();
       $("#commandLineWrapper #commandLine .suggestions .entry").unbind(

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -673,7 +673,7 @@ $(document).on("keydown", (e) => {
       e.key === "ArrowUp" ||
       e.key === "ArrowDown" ||
       e.key === "Tab" ||
-      // Should only branch on n/p if ctrl is held to allow n/p to still be typed
+      // Should only branch if ctrl is held to allow the letters to still be typed
       ((e.key === "p" || e.key === "n" || e.key === "j" || e.key === "k") &&
         e.ctrlKey)
     ) {


### PR DESCRIPTION
### Description

Adds support for moving the selection up and down in the command line with ctrl-n/p (emacs) and ctrl-j/k (vim), which is muscle memory for a lot of people but currently unsupported in the main list view people use.

Supporting both feels a lot more natural, and makes navigation easier for people that either don't have arrow keys at all or on their main layer (like myself!)