### PR TITLE
Remove the (non-)word "tion" from the English 10k word list

### DIFF
--- a/frontend/static/languages/english_10k.json
+++ b/frontend/static/languages/english_10k.json
@@ -3999,7 +3999,6 @@
     "pour",
     "digest",
     "lodging",
-    "tion",
     "dust",
     "hence",
     "entirely",


### PR DESCRIPTION
I have removed "tion" from the english 10k word list because I was not able to find a definition for it in any dictionary, and as a native English speaker I am not aware of any definition for it. I certainly do not believe that it is one of the ten thousand most used words.
