### PR TITLE
Added "enter" as a button option for quick restart

### DIFF
--- a/backend/src/api/schemas/config-schema.ts
+++ b/backend/src/api/schemas/config-schema.ts
@@ -27,7 +27,7 @@ const CONFIG_SCHEMA = joi.object({
   showLiveWpm: joi.boolean(),
   showTimerProgress: joi.boolean(),
   smoothCaret: joi.boolean(),
-  quickRestart: joi.string().valid("off", "tab", "esc"),
+  quickRestart: joi.string().valid("off", "tab", "enter", "esc"),
   punctuation: joi.boolean(),
   numbers: joi.boolean(),
   words: joi.number().min(0),

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -454,7 +454,9 @@ $(document).ready(() => {
         (event.key?.toLowerCase() === "p" &&
           (event.metaKey || event.ctrlKey) &&
           event.shiftKey) ||
-        ((event.key === "Tab" || event.key === "Escape" || event.key === "Enter") &&
+        ((event.key === "Tab" ||
+          event.key === "Escape" ||
+          event.key === "Enter") &&
           Config.quickRestart === "esc")) &&
       isPopupVisible(wrapperId)
     ) {

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -454,7 +454,7 @@ $(document).ready(() => {
         (event.key?.toLowerCase() === "p" &&
           (event.metaKey || event.ctrlKey) &&
           event.shiftKey) ||
-        ((event.key === "Tab" || event.key === "Escape") &&
+        ((event.key === "Tab" || event.key === "Escape" || event.key === "enter") &&
           Config.quickRestart === "esc")) &&
       isPopupVisible(wrapperId)
     ) {

--- a/frontend/src/ts/commandline/index.ts
+++ b/frontend/src/ts/commandline/index.ts
@@ -454,7 +454,7 @@ $(document).ready(() => {
         (event.key?.toLowerCase() === "p" &&
           (event.metaKey || event.ctrlKey) &&
           event.shiftKey) ||
-        ((event.key === "Tab" || event.key === "Escape" || event.key === "enter") &&
+        ((event.key === "Tab" || event.key === "Escape" || event.key === "Enter") &&
           Config.quickRestart === "esc")) &&
       isPopupVisible(wrapperId)
     ) {

--- a/frontend/src/ts/commandline/lists/quick-restart.ts
+++ b/frontend/src/ts/commandline/lists/quick-restart.ts
@@ -21,6 +21,14 @@ const subgroup: MonkeyTypes.CommandsSubgroup = {
       },
     },
     {
+      id: "changeQuickRestartEnter",
+      display: "enter",
+      configValue: "enter",
+      exec: (): void => {
+        UpdateConfig.setQuickRestartMode("enter");
+      },
+    },
+    {
       id: "changeQuickRestartOff",
       display: "off",
       configValue: "off",

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1137,11 +1137,11 @@ export function setSmoothLineScroll(mode: boolean, nosave?: boolean): boolean {
 
 //quick restart
 export function setQuickRestartMode(
-  mode: "off" | "esc" | "tab",
+  mode: "off" | "esc" | "tab" | "enter",
   nosave?: boolean
 ): boolean {
   if (
-    !isConfigValueValid("quick restart mode", mode, [["off", "esc", "tab"]])
+    !isConfigValueValid("quick restart mode", mode, [["off", "esc", "tab", "enter"]])
   ) {
     return false;
   }

--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -702,7 +702,7 @@ function handleTab(event: JQuery.KeyDownEvent, popupVisible: boolean): void {
       setWordsInput(" " + TestInput.input.current);
       return;
     }
-  } else if (Config.quickRestart === "tab") {
+  } else if (Config.quickRestart === "tab" || Config.quickRestart === "escape") {
     // dont do anything special
     if (modalVisible) return;
 

--- a/frontend/src/ts/ready.ts
+++ b/frontend/src/ts/ready.ts
@@ -38,7 +38,7 @@ $(document).ready(() => {
 
   CookiePopup.check();
   $("body").css("transition", "all .25s, transform .05s");
-  if (Config.quickRestart === "tab" || Config.quickRestart === "esc") {
+  if (Config.quickRestart === "tab" || Config.quickRestart === "esc" || Config.quickRestart === "enter") {
     $("#restartTestButton").addClass("hidden");
   }
   if (!window.localStorage.getItem("merchbannerclosed")) {

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -399,6 +399,9 @@ export function restart(options = {} as RestartOptions): void {
         } else if (Config.quickRestart === "esc") {
           message = "Press shift + escape or use your mouse to confirm.";
         }
+        else if (Config.quickRestart === "enter") {
+          message = "Press shift + enter or use your mouse to confirm.";
+        }
         Notifications.add(
           `Quick restart disabled in long tests. ${message}`,
           0,

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -400,7 +400,7 @@ declare namespace MonkeyTypes {
     showLiveWpm: boolean;
     showTimerProgress: boolean;
     smoothCaret: boolean;
-    quickRestart: "off" | "esc" | "tab";
+    quickRestart: "off" | "esc" | "enter" | "tab";
     punctuation: boolean;
     numbers: boolean;
     words: WordsModes;

--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -32,6 +32,10 @@ export function updateKeytips(): void {
     $("#bottom .keyTips").html(`
     <key>tab</key> - restart test<br>
       <key>esc</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
+  } else if (Config.quickRestart === "enter") {
+    $("#bottom .keyTips").html(`
+    <key>enter</key> - restart test<br>
+      <key>esc</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
   } else {
     $("#bottom .keyTips").html(`
     <key>tab</key> + <key>enter</key> - restart test<br>

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -185,6 +185,8 @@
         <key>tab</key>
         or
         <key>esc</key>
+        or
+        <key>enter</key>
         to quickly restart the test, or to quickly jump to the test page. Both
         options disable tab navigation on most parts of the website. Using the
         "esc" option will move opening the commandline to the
@@ -215,6 +217,14 @@
           onclick="this.blur();"
         >
           esc
+        </div>
+        <div
+          class="button"
+          quickRestart="enter"
+          tabindex="0"
+          onclick="this.blur();"
+        >
+          enter
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added "enter" as a button option for quick restart. I feel like the enter key is super convenient to press after a round to quick start. I saw myself pressing it after each round because it felt intuitive, but realised it wasnt an option. 

I added the change in every possible file I could find that mentioned "quick restart". Please let me know if I missed anywhere or if I need to add anything else in order for it to work.