### PR TITLE
"Arrows" funbox starts with left/right only

### DIFF
--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -159,9 +159,8 @@ FunboxList.setFunboxFunctions("choo_choo", {
 });
 
 FunboxList.setFunboxFunctions("arrows", {
-  getWord(wordset: Misc.Wordset): string {
-    if (wordset.lastRandomWordIndex === 0) return Misc.chart2Word(0);
-    else return Misc.chart2Word(1);
+  getWord(_wordset, wordIndex): string {
+    return Misc.chart2Word(wordIndex === 0);
   },
   applyConfig(): void {
     $("#words").addClass("arrows");

--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -159,8 +159,9 @@ FunboxList.setFunboxFunctions("choo_choo", {
 });
 
 FunboxList.setFunboxFunctions("arrows", {
-  getWord(): string {
-    return Misc.chart2Word();
+  getWord(wordset: Misc.Wordset): string {
+    if (wordset.lastRandomWordIndex === 0) return Misc.chart2Word(0);
+    else return Misc.chart2Word(1);
   },
   applyConfig(): void {
     $("#words").addClass("arrows");

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -687,12 +687,16 @@ function getFunboxWordsFrequency():
   return undefined;
 }
 
-function getFunboxWord(word: string, wordset?: Misc.Wordset): string {
+function getFunboxWord(
+  word: string,
+  wordIndex: number,
+  wordset?: Misc.Wordset
+): string {
   const wordFunbox = FunboxList.get(Config.funbox).find(
     (f) => f.functions?.getWord
   );
   if (wordFunbox?.functions?.getWord) {
-    word = wordFunbox.functions.getWord(wordset);
+    word = wordFunbox.functions.getWord(wordset, wordIndex);
   }
   return word;
 }
@@ -725,9 +729,11 @@ function applyLazyModeToWord(
 
 async function getNextWord(
   wordset: Misc.Wordset,
+  wordIndex: number,
   language: MonkeyTypes.LanguageObject,
   wordsBound: number
 ): Promise<string> {
+  console.log(wordIndex);
   const funboxFrequency = getFunboxWordsFrequency() ?? "normal";
 
   let randomWord = wordset.randomWord(funboxFrequency);
@@ -789,7 +795,7 @@ async function getNextWord(
   randomWord = randomWord.replace(/ +/gm, " ");
   randomWord = randomWord.replace(/(^ )|( $)/gm, "");
   randomWord = applyLazyModeToWord(randomWord, language);
-  randomWord = getFunboxWord(randomWord, wordset);
+  randomWord = getFunboxWord(randomWord, wordIndex, wordset);
   randomWord = await applyBritishEnglishToWord(randomWord);
 
   if (Config.punctuation) {
@@ -1029,7 +1035,7 @@ export async function init(): Promise<void> {
 
     if (wordCount == 0) {
       for (let i = 0; i < wordsBound; i++) {
-        const randomWord = await getNextWord(wordset, language, wordsBound);
+        const randomWord = await getNextWord(wordset, i, language, wordsBound);
 
         if (/\t/g.test(randomWord)) {
           TestWords.setHasTab(true);
@@ -1273,7 +1279,12 @@ export async function addWord(): Promise<void> {
         };
   const wordset = await Wordset.withWords(language.words);
 
-  const randomWord = await getNextWord(wordset, language, bound);
+  const randomWord = await getNextWord(
+    wordset,
+    TestWords.words.length,
+    language,
+    bound
+  );
 
   const split = randomWord.split(" ");
   if (split.length > 1) {

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -733,7 +733,6 @@ async function getNextWord(
   language: MonkeyTypes.LanguageObject,
   wordsBound: number
 ): Promise<string> {
-  console.log(wordIndex);
   const funboxFrequency = getFunboxWordsFrequency() ?? "normal";
 
   let randomWord = wordset.randomWord(funboxFrequency);

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -214,7 +214,7 @@ declare namespace MonkeyTypes {
     | "changesWordsFrequency";
 
   interface FunboxFunctions {
-    getWord?: (wordset?: Misc.Wordset) => string;
+    getWord?: (wordset?: Misc.Wordset, wordIndex?: number) => string;
     punctuateWord?: (word: string) => string;
     withWords?: (words?: string[]) => Promise<Misc.Wordset>;
     alterText?: (word: string) => string;

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1412,15 +1412,12 @@ export function memoizeAsync<T extends (...args: any) => Promise<any>>(
 export class Wordset {
   public words: string[];
   public length: number;
-  public lastRandomWordIndex: number;
   constructor(words: string[]) {
     this.words = words;
     this.length = this.words.length;
-    this.lastRandomWordIndex = -1;
   }
 
   public randomWord(mode: MonkeyTypes.FunboxWordsFrequency): string {
-    this.lastRandomWordIndex++;
     if (mode === "zipf") {
       return this.words[dreymarIndex(this.words.length)];
     } else {

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -725,7 +725,6 @@ export function getASCII(): string {
 // code for "generateStep" is from Mirin's "Queue" modfile,
 // converted from lua to typescript by Spax
 // lineout: https://youtu.be/LnnArS9yrSs
-let first = true;
 let footTrack = false;
 let currFacing = 0;
 let facingCount = 0;
@@ -733,12 +732,11 @@ let lastLeftStep = 0,
   lastRightStep = 3,
   leftStepCount = 0,
   rightStepCount = 0;
-function generateStep(): number {
+function generateStep(leftRightOverride: boolean): number {
   facingCount--;
   let randomStep = Math.round(Math.random());
   let stepValue = Math.round(Math.random() * 5 - 0.5);
-  if (first) {
-    first = !first;
+  if (leftRightOverride) {
     footTrack = Boolean(Math.round(Math.random()));
     if (footTrack) stepValue = 3;
     else stepValue = 0;
@@ -776,14 +774,11 @@ function generateStep(): number {
   return stepValue;
 }
 
-export function chart2Word(x: number): string {
+export function chart2Word(first: boolean): string {
   const arrowArray = ["←", "↓", "↑", "→"];
-  if (x === 0) {
-    first = true;
-  }
   let measure = "";
   for (let i = 0; i < 4; i++) {
-    measure += arrowArray[generateStep()];
+    measure += arrowArray[generateStep(i === 0 && first)];
   }
 
   return measure;

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -776,9 +776,11 @@ function generateStep(): number {
   return stepValue;
 }
 
-export function chart2Word(): string {
+export function chart2Word(x: number): string {
   const arrowArray = ["←", "↓", "↑", "→"];
-
+  if (x === 0) {
+    first = true;
+  }
   let measure = "";
   for (let i = 0; i < 4; i++) {
     measure += arrowArray[generateStep()];
@@ -1415,12 +1417,15 @@ export function memoizeAsync<T extends (...args: any) => Promise<any>>(
 export class Wordset {
   public words: string[];
   public length: number;
+  public lastRandomWordIndex: number;
   constructor(words: string[]) {
     this.words = words;
     this.length = this.words.length;
+    this.lastRandomWordIndex = -1;
   }
 
   public randomWord(mode: MonkeyTypes.FunboxWordsFrequency): string {
+    this.lastRandomWordIndex++;
     if (mode === "zipf") {
       return this.words[dreymarIndex(this.words.length)];
     } else {


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description
<!-- Please describe the change(s) made in your PR -->
The "arrows" funbox starts each test with either a left or right arrow.

Closes #4120

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
