### PR TITLE
Add the whole language list to the daily leadeboard

### DIFF
--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -642,7 +642,9 @@ $("#leaderboardsWrapper").on("click", (e) => {
 
 import languages from "../../../static/languages/_list.json";
 
-function generateLanguageData(languages: string[]): { id: string; text: string; selected?: boolean }[] {
+function generateLanguageData(
+  languages: string[]
+): { id: string; text: string; selected?: boolean }[] {
   return languages.map((language, index) => {
     return {
       id: language,
@@ -659,7 +661,6 @@ const languageSelector = $(
   width: "100%",
   data: generateLanguageData(languages),
 });
-
 
 languageSelector.on("select2:select", (e) => {
   currentLanguage = e.params.data.id;

--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -640,39 +640,26 @@ $("#leaderboardsWrapper").on("click", (e) => {
   }
 });
 
+import languages from "../../../static/languages/_list.json";
+
+function generateLanguageData(languages: string[]): { id: string; text: string; selected?: boolean }[] {
+  return languages.map((language, index) => {
+    return {
+      id: language,
+      text: language,
+      selected: index === 0, // Set the first language as the default selected language
+    };
+  });
+}
+
 const languageSelector = $(
   "#leaderboardsWrapper #leaderboards .leaderboardsTop .buttonGroup.timeRange .languageSelect"
 ).select2({
   placeholder: "select a language",
   width: "100%",
-  data: [
-    {
-      id: "english",
-      text: "english",
-      selected: true,
-    },
-    {
-      id: "spanish",
-      text: "spanish",
-    },
-    {
-      id: "german",
-      text: "german",
-    },
-    {
-      id: "portuguese",
-      text: "portuguese",
-    },
-    {
-      id: "indonesian",
-      text: "indonesian",
-    },
-    {
-      id: "italian",
-      text: "italian",
-    },
-  ],
+  data: generateLanguageData(languages),
 });
+
 
 languageSelector.on("select2:select", (e) => {
   currentLanguage = e.params.data.id;


### PR DESCRIPTION
### Description

Modified leaderboard.ts to include the whole language list to the daily leadeboard.


Closes #

It works frontend side and it's responsive but I couldn't test it with firebase and a database, so I hope it just works, but I have some doubts.
The relative path should work on most environments.
