### PR TITLE
fix: added missing dot to quote

### DIFF
--- a/frontend/static/quotes/english.json
+++ b/frontend/static/quotes/english.json
@@ -37553,9 +37553,9 @@
       "id": 6623
     },
     {
-      "text": "A darkness approaches. A day will come in the future where everything you care about will change... Until then I'll be watching you! I'll be watching you..",
+      "text": "A darkness approaches. A day will come in the future where everything you care about will change... Until then I'll be watching you! I'll be watching you...",
       "source": "Bill Cipher, Gravity Falls",
-      "length": 155,
+      "length": 156,
       "approvedBy": "Smithster",
       "id": 6624
     },


### PR DESCRIPTION
### Description

This quote was missing a dot. I added the dot. Quote char length is also updated accordingly. 

:^)