### PR TITLE
REMOVE: Redundant comment in CSS

### DIFF
--- a/frontend/src/styles/caret.scss
+++ b/frontend/src/styles/caret.scss
@@ -10,7 +10,6 @@
 
 #paceCaret {
   height: 1.2em;
-  // background: var(--sub-color);
   background: var(--sub-color);
   opacity: 0.5;
   position: absolute;

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -9,7 +9,6 @@
     top: 0;
     left: 0;
     width: 100vw;
-    /*   height: 0.5rem; */
     height: 0.5rem;
     background: black;
     /*   background: #0f0f0f; */


### PR DESCRIPTION
The comment indicated the same CSS which was written below


### Description
Removed 2 CSS comments which had the same style written below.

Like this -  
```diff
- / * property_x: value_y; */
property_x: value_y;
```

It ain't much but it's honest work 🙂

