### PR TITLE
fix:#4124 graph buttons are now toggles

### DIFF
--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -948,7 +948,8 @@ type ButtonBelowChart =
   | ".toggleAverage10OnChart"
   | ".toggleAverage100OnChart";
 
-function updateButtonChartsColors(
+
+function updateAccountChartButton(
   isActive: boolean,
   className: ButtonBelowChart
 ): void {
@@ -959,7 +960,7 @@ function updateButtonChartsColors(
 
 function updateAccuracy(): void {
   const accOn = Config.accountChart[0] === "on";
-  updateButtonChartsColors(accOn, ".toggleAccuracyOnChart");
+  updateAccountChartButton(accOn, ".toggleAccuracyOnChart");
 
   accountHistory.data.datasets[2].hidden = !accOn;
   accountHistory.data.datasets[4].hidden = !accOn;
@@ -973,7 +974,7 @@ function updateAccuracy(): void {
 function updateAverage10(): void {
   const accOn = Config.accountChart[0] === "on";
   const avg10On = Config.accountChart[1] === "on";
-  updateButtonChartsColors(avg10On, ".toggleAverage10OnChart");
+  updateAccountChartButton(avg10On, ".toggleAverage10OnChart");
 
   if (accOn) {
     accountHistory.data.datasets[3].hidden = !avg10On;
@@ -988,7 +989,7 @@ function updateAverage10(): void {
 function updateAverage100(): void {
   const accOn = Config.accountChart[0] === "on";
   const avg100On = Config.accountChart[2] === "on";
-  updateButtonChartsColors(avg100On, ".toggleAverage100OnChart");
+  updateAccountChartButton(avg100On, ".toggleAverage100OnChart");
 
   if (accOn) {
     accountHistory.data.datasets[5].hidden = !avg100On;

--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -53,7 +53,7 @@ Chart.defaults.elements.line.fill = "origin";
 
 import "chartjs-adapter-date-fns";
 import format from "date-fns/format";
-import Config, { getConfigChanges } from "../config";
+import Config from "../config";
 import * as ThemeColors from "../elements/theme-colors";
 import * as ConfigEvent from "../observables/config-event";
 import * as TestInput from "../test/test-input";
@@ -943,14 +943,14 @@ export const miniResult: ChartWithUpdateColors<
   },
 });
 
-type ButtonBellowChart =
+type ButtonBelowChart =
   | ".toggleAccuracyOnChart"
   | ".toggleAverage10OnChart"
   | ".toggleAverage100OnChart";
 
 function updateButtonChartsColors(
   isActive: boolean,
-  className: ButtonBellowChart
+  className: ButtonBelowChart
 ): void {
   isActive
     ? $(`.pageAccount ${className}`).addClass("active")
@@ -958,10 +958,7 @@ function updateButtonChartsColors(
 }
 
 function updateAccuracy(): void {
-  const accOn =
-    getConfigChanges()?.accountChart?.[0] === "on" ??
-    Config.accountChart[0] === "on";
-
+  const accOn = Config.accountChart[0] === "on";
   updateButtonChartsColors(accOn, ".toggleAccuracyOnChart");
 
   accountHistory.data.datasets[2].hidden = !accOn;
@@ -974,13 +971,8 @@ function updateAccuracy(): void {
 }
 
 function updateAverage10(): void {
-  const accOn =
-    getConfigChanges()?.accountChart?.[0] === "on" ??
-    Config.accountChart[0] === "on";
-  const avg10On =
-    getConfigChanges()?.accountChart?.[1] === "on" ??
-    Config.accountChart[0] === "on";
-
+  const accOn = Config.accountChart[0] === "on";
+  const avg10On = Config.accountChart[1] === "on";
   updateButtonChartsColors(avg10On, ".toggleAverage10OnChart");
 
   if (accOn) {
@@ -994,13 +986,8 @@ function updateAverage10(): void {
 }
 
 function updateAverage100(): void {
-  const accOn =
-    getConfigChanges()?.accountChart?.[0] === "on" ??
-    Config.accountChart[0] === "on";
-  const avg100On =
-    getConfigChanges()?.accountChart?.[2] === "on" ??
-    Config.accountChart[0] === "on";
-
+  const accOn = Config.accountChart[0] === "on";
+  const avg100On = Config.accountChart[2] === "on";
   updateButtonChartsColors(avg100On, ".toggleAverage100OnChart");
 
   if (accOn) {

--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -53,7 +53,7 @@ Chart.defaults.elements.line.fill = "origin";
 
 import "chartjs-adapter-date-fns";
 import format from "date-fns/format";
-import Config from "../config";
+import Config, { getConfigChanges } from "../config";
 import * as ThemeColors from "../elements/theme-colors";
 import * as ConfigEvent from "../observables/config-event";
 import * as TestInput from "../test/test-input";
@@ -943,8 +943,26 @@ export const miniResult: ChartWithUpdateColors<
   },
 });
 
+type ButtonBellowChart =
+  | ".toggleAccuracyOnChart"
+  | ".toggleAverage10OnChart"
+  | ".toggleAverage100OnChart";
+
+function updateButtonChartsColors(
+  isActive: boolean,
+  className: ButtonBellowChart
+): void {
+  isActive
+    ? $(`.pageAccount ${className}`).addClass("active")
+    : $(`.pageAccount ${className}`).removeClass("active");
+}
+
 function updateAccuracy(): void {
-  const accOn = Config.accountChart[0] === "on";
+  const accOn =
+    getConfigChanges()?.accountChart?.[0] === "on" ??
+    Config.accountChart[0] === "on";
+
+  updateButtonChartsColors(accOn, ".toggleAccuracyOnChart");
 
   accountHistory.data.datasets[2].hidden = !accOn;
   accountHistory.data.datasets[4].hidden = !accOn;
@@ -956,8 +974,14 @@ function updateAccuracy(): void {
 }
 
 function updateAverage10(): void {
-  const accOn = Config.accountChart[0] === "on";
-  const avg10On = Config.accountChart[1] === "on";
+  const accOn =
+    getConfigChanges()?.accountChart?.[0] === "on" ??
+    Config.accountChart[0] === "on";
+  const avg10On =
+    getConfigChanges()?.accountChart?.[1] === "on" ??
+    Config.accountChart[0] === "on";
+
+  updateButtonChartsColors(avg10On, ".toggleAverage10OnChart");
 
   if (accOn) {
     accountHistory.data.datasets[3].hidden = !avg10On;
@@ -970,8 +994,14 @@ function updateAverage10(): void {
 }
 
 function updateAverage100(): void {
-  const accOn = Config.accountChart[0] === "on";
-  const avg100On = Config.accountChart[2] === "on";
+  const accOn =
+    getConfigChanges()?.accountChart?.[0] === "on" ??
+    Config.accountChart[0] === "on";
+  const avg100On =
+    getConfigChanges()?.accountChart?.[2] === "on" ??
+    Config.accountChart[0] === "on";
+
+  updateButtonChartsColors(avg100On, ".toggleAverage100OnChart");
 
   if (accOn) {
     accountHistory.data.datasets[5].hidden = !avg100On;

--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -1165,7 +1165,7 @@ export function updateAllChartColors(): void {
 }
 
 ConfigEvent.subscribe((eventKey, eventValue) => {
-  if (eventKey === "accountChart") {
+  if (eventKey === "accountChart" && ActivePage.get() === "account") {
     updateAccuracy();
     updateAverage10();
     updateAverage100();

--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -28,6 +28,8 @@ import chartAnnotation, {
 } from "chartjs-plugin-annotation";
 import chartTrendline from "chartjs-plugin-trendline";
 
+import * as ActivePage from "../states/active-page";
+
 Chart.register(
   BarController,
   BarElement,
@@ -948,6 +950,11 @@ type ButtonBelowChart =
   | ".toggleAverage10OnChart"
   | ".toggleAverage100OnChart";
 
+export function updateAccountChartButtons(): void {
+  updateAccuracy();
+  updateAverage10();
+  updateAverage100();
+}
 
 function updateAccountChartButton(
   isActive: boolean,

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1027,6 +1027,7 @@ function fillContent(): void {
     delete ChartController.accountHistory.options.animation;
   }
 
+  ChartController.updateAccountChartButtons();
   ChartController.accountActivity.update();
   ChartController.accountHistogram.update();
   LoadingPage.updateBar(100, true);


### PR DESCRIPTION
### Description
This pr fixes the problem with the buttons under chart, now they are toggles buttons with their respective color theme


Closes #

*This Pr fix is a fix to the issue [#4124](https://github.com/monkeytypegame/monkeytype/issues/4124)

*use the getConfigChanges function to get the updated values between bd and localstorage

*crea una nueva funcion para cambiar el estado de los botones con su tipado

