### PR TITLE
Fixed Settings Sound-on-Click Preview - Sine, Sawtooth, Square, Triangle

### DIFF
--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -474,7 +474,7 @@ export function playNote(
   oscillatorNode.stop(audioCtx.currentTime + 0.5);
 }
 
-export function playClick(): void {
+export function playClick(codeOverride?: string): void {
   if (Config.playSoundOnClick === "off") return;
 
   if (Config.playSoundOnClick in scaleConfigurations) {
@@ -487,7 +487,7 @@ export function playClick(): void {
   }
 
   if (Config.playSoundOnClick in clickSoundIdsToOscillatorType) {
-    playNote();
+    playNote(codeOverride ?? undefined);
     return;
   }
 

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -253,7 +253,7 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setPlaySoundOnClick,
     "button",
     () => {
-      if (Config.playSoundOnClick !== "off") Sound.playClick();
+      if (Config.playSoundOnClick !== "off") Sound.playClick("KeyQ");
     }
   );
   groups["showAllLines"] = new SettingsGroup(


### PR DESCRIPTION
This PR addresses #4245. 

The error is that `sine`, `sawtooth`, `square` and `triangle` options within the setting's sound-on-click section is (sometimes) not being played. 

This is because the `playClick()` function in line 246 of `settings.ts` responsible for this logic plays the most recent key the user has pressed, instead of being given a fixed codeOverride. This can lead to unpredictable behaviour, and the preview will sometimes play (see #4245 for more detail)

I used `KeyQ` as the codeOverride because that is the same note used in the preview for these sounds in`sound-on-click.ts`, which is responsible for the sound-on-click commandsSubgroup. In that code, they provide the 'KeyQ' override for Sine, Sawtooth, Square and Triangle.

### Description

I provide an optional parameter that allows us to override `playClick` with a fixed note, therefore ensuring the preview for these four oscillators are being properly played, regardless of the key that was previously pressed. 

Closes #

#4245
