### PR TITLE
fix: disable autocomplete on MacOS in Safari

### DIFF
--- a/frontend/static/html/pages/test.html
+++ b/frontend/static/html/pages/test.html
@@ -126,6 +126,7 @@
       data-gramm_editor="false"
       data-enable-grammarly="false"
       list="autocompleteOff"
+      spellcheck="false"
     />
     <div id="wordsWrapper" translate="no">
       <div id="paceCaret" class="default hidden"></div>


### PR DESCRIPTION
### Description

Adds `spellcheck="false"` which disables autocomplete on MacOS in Safari. 