### PR TITLE
Add 'programme' to British english

### DIFF
--- a/frontend/static/languages/britishenglish.json
+++ b/frontend/static/languages/britishenglish.json
@@ -603,5 +603,6 @@
   ["catalogs", "catalogues"],
   ["cataloged", "catalogued"],
   ["uncataloged", "uncatalogued"],
-  ["catalogers", "cataloguers"]
+  ["catalogers", "cataloguers"],
+  ["program", "programme"]
 ]


### PR DESCRIPTION
In British English, 'Programme' is the preferred spelling over 'Program'
