### PR TITLE
Fixed an typo at the documentation of monkeytype api

### DIFF
--- a/backend/src/documentation/public-swagger.json
+++ b/backend/src/documentation/public-swagger.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "Documentation for the public endpoints provided by the Monketype API server.\n\nNote that authentication is performed with the Authorization HTTP header in the format `Authorization: ApeKey YOUR_APE_KEY`\n\nThere is a rate limit of `30 requests per minute` across all endpoints with some endpoints being more strict. Rate limit rates are shared across all ape keys.",
+    "description": "Documentation for the public endpoints provided by the Monkeytype API server.\n\nNote that authentication is performed with the Authorization HTTP header in the format `Authorization: ApeKey YOUR_APE_KEY`\n\nThere is a rate limit of `30 requests per minute` across all endpoints with some endpoints being more strict. Rate limit rates are shared across all ape keys.",
     "version": "1.0.0",
     "title": "Monkeytype API",
     "termsOfService": "https://monkeytype.com/terms-of-service",


### PR DESCRIPTION


### Description

Fixed an typo at the documentation of monkeytype api. Changed "monketype" to "monkeytype".

![Monkeytype API Documentation and 8 more pages - Personal - Microsoft​ Edge 20-05-2023 12_22_35](https://github.com/monkeytypegame/monkeytype/assets/89198650/20a94d32-a7e4-4295-9dc1-382ec02e9a1d)
