### PR TITLE
Zen mode - removes extra newlines if backspace ends up on a newline

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -137,6 +137,19 @@ function backspaceToPrevious(): void {
   Funbox.toggleScript(TestWords.words.getCurrent());
   TestUI.updateWordElement();
 
+  if (Config.mode === "zen") {
+    const els: HTMLElement[] = (document.querySelector("#words")?.children ||
+      []) as HTMLElement[];
+
+    for (let i = els.length - 1; i >= 0; i--) {
+      if (els[i].classList.contains("newline")) {
+        els[i].remove();
+      } else {
+        break;
+      }
+    }
+  }
+
   Caret.updatePosition();
   Replay.addReplayEvent("backWord");
 }


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Reproducing the issue:

1. Go to monkeytype.com and enter `zen` mode
2. Type some words, then press enter. This will put the cursor on a new line
3. Press backspace to get the cursor back on the previous line
4. Press space
5. Verify the cursor is on a new line

https://github.com/monkeytypegame/monkeytype/assets/6445410/58f86a54-1634-4e7d-9070-e72aee47c46a

The fix:

Pass a `boolean` into `updateWordElement` to determine if the function call came from `backspaceToPrevious`. If it did and the current character is a new line, set `newlineafter` to `false` and remove all existing `.newline` nodes which seems unnecessary for them to exist

https://github.com/monkeytypegame/monkeytype/assets/6445410/1e3dce74-cd2f-4858-9c70-bff6aecd4eb7

Feel free to close if this breaks other functionality that is unknown to me or if this is a non-issue

<!-- Please describe the change(s) made in your PR -->