### PR TITLE
Update _list.json - Added graphite keymap layouts

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1561,7 +1561,7 @@
       "row5": [" "]
     }
   },
-  "graphite-angle": {
+  "graphite_angle": {
     "keymapShowTopRow": false,
     "type": "ansi",
     "keys": {
@@ -1572,7 +1572,7 @@
       "row5": [" "]
     }
   },
-  "graphite-matrix": {
+  "graphite_matrix": {
     "keymapShowTopRow": false,
     "type": "ansi",
     "keys": {

--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1549,5 +1549,38 @@
       "row4": ["vV", "mM", "hH", "xX", "zZ", "pP", "wW", "'\"", ";:", ".>"],
       "row5": [" "]
     }
+  },
+  "graphite": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "[{", "]}"],
+      "row2": ["bB", "lL", "dD", "wW", "zZ", "'_", "fF", "oO", "uU", "jJ", ";:", "=+", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", ",?"],
+      "row4": ["qQ", "xX", "mM", "cC", "vV", "pP", "kK", ".>", "-\"", "/<"],
+      "row5": [" "]
+    }
+  },
+  "graphite-angle": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "[{", "]}"],
+      "row2": ["bB", "lL", "dD", "wW", "zZ", "'_", "fF", "oO", "uU", "jJ", ";:", "=+", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", ",?"],
+      "row4": ["xX", "mM", "cC", "vV", "qQ", "pP", "kK", ".>", "-\"", "/<"],
+      "row5": [" "]
+    }
+  },
+  "graphite-matrix": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "[{", "]}"],
+      "row2": ["bB", "lL", "dD", "wW", "zZ", "'_", "fF", "oO", "uU", "jJ", ";:", "=+", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", ",?"],
+      "row4": ["qQ", "xX", "mM", "cC", "vV", "kK", "pP", ".>", "-\"", "/<"],
+      "row5": [" "]
+    }
   }
 }


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Adds keymaps for the graphite keyboard layout as described [here](https://github.com/rdavison/graphite-layout).

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
