### PR TITLE
Fix persistent CapsLock message being displayed

### DIFF
--- a/frontend/src/ts/test/caps-warning.ts
+++ b/frontend/src/ts/test/caps-warning.ts
@@ -1,19 +1,21 @@
 import Config from "../config";
 
+const el = document.querySelector("#capsWarning") as HTMLElement;
+
 export let capsState = false;
 
 let visible = false;
 
 function show(): void {
   if (!visible) {
-    $("#capsWarning").removeClass("hidden");
+    el?.classList.remove("hidden");
     visible = true;
   }
 }
 
 function hide(): void {
   if (visible) {
-    $("#capsWarning").addClass("hidden");
+    el?.classList.add("hidden");
     visible = false;
   }
 }

--- a/frontend/src/ts/test/caps-warning.ts
+++ b/frontend/src/ts/test/caps-warning.ts
@@ -18,7 +18,7 @@ function hide(): void {
   }
 }
 
-$("#wordsInput").on("keydown", function (event) {
+$(document).on("keydown", function (event) {
   if (
     event?.originalEvent?.getModifierState &&
     event?.originalEvent?.getModifierState("CapsLock")
@@ -37,7 +37,7 @@ $("#wordsInput").on("keydown", function (event) {
   } catch {}
 });
 
-$("#wordsInput").on("keyup", function (event) {
+$(document).on("keyup", function (event) {
   if (
     event?.originalEvent?.getModifierState &&
     event?.originalEvent?.getModifierState("CapsLock")


### PR DESCRIPTION
Closes #4330 

### Description

**Issue**: The CapsLock message stayed on Screen even when turned off (by pressing CapsLock) when the focus was outside the test.
**Fix**: The status of CapsLock is now updated even when CapsLock is pressed outside of focus of the test, hence fixing the persistently displayed CapsLock message.


### Screenshots 

I am typing a word, then pressing <kbd>CapsLock</kbd> to turn it on, then pressing <kbd>Tab</kbd> to move out of focus and then pressing <kbd>CapsLock</kbd> to disable it (and enable and disable it again as you can see in the "After").  Earlier the message on screen stayed being displayed and status of CapsLock was not updated, it is now fixed.

Before:

![unfixed](https://github.com/monkeytypegame/monkeytype/assets/92792319/b918d80a-8d1c-468f-aed1-6a3a4fd4ff88)

After:

![fixed](https://github.com/monkeytypegame/monkeytype/assets/92792319/5317400d-02bd-45da-98e6-35c87f18784a)

Thank you!