### PR TITLE
updates word count when backspacing words in zen mode

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -138,6 +138,8 @@ function backspaceToPrevious(): void {
   TestUI.updateWordElement();
 
   if (Config.mode === "zen") {
+    TimerProgress.update();
+
     const els: HTMLElement[] = (document.querySelector("#words")?.children ||
       []) as HTMLElement[];
 


### PR DESCRIPTION
### Description

Another small zen mode fix - currently when a user backspaces words, the word count doesn't update in real time

Prod:

https://github.com/monkeytypegame/monkeytype/assets/6445410/640d3828-0d8b-4365-8215-739d826083c6

This branch:

https://github.com/monkeytypegame/monkeytype/assets/6445410/3cac9e50-7e1f-42b6-b4ff-3893b645d897