### PR TITLE
Fixed wrong scale when displaying accuracy average line chart

### DIFF
--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -392,6 +392,7 @@ export const accountHistory: ChartWithUpdateColors<
         axis: "y",
         beginAtZero: true,
         min: 0,
+        max: 100,
         reverse: true,
         ticks: {
           stepSize: 10,
@@ -417,6 +418,7 @@ export const accountHistory: ChartWithUpdateColors<
         axis: "y",
         beginAtZero: true,
         min: 0,
+        max: 100,
         reverse: true,
         ticks: {
           stepSize: 10,


### PR DESCRIPTION
The scale of the accuracy average over time(on the last 10/100) line chart wasn't fixed at 0-100 which caused a scale issue in some cases.

Before - the lower line is too low [about 0.25x of what it should have been]:

<img width="1191" alt="image" src="https://github.com/monkeytypegame/monkeytype/assets/11258180/a62f3eeb-d226-4562-8d04-9cfe00e64229">

After:

<img width="1197" alt="image" src="https://github.com/monkeytypegame/monkeytype/assets/11258180/9936d720-683b-44aa-9fed-d83fe2299574">
