### PR TITLE
removed 'capitilise' from the code_python language

### DIFF
--- a/frontend/static/languages/code_python.json
+++ b/frontend/static/languages/code_python.json
@@ -20,7 +20,6 @@
     "bytearray",
     "bytes",
     "callable",
-    "capitalise",
     "capitalize",
     "case",
     "casefold",


### PR DESCRIPTION
### Description

The word 'capitilise' was found in the `code_python.json`, but it is not a valid Python method or keyword. This commit removes the incorrect word from the list to ensure accuracy and consistency in the provided Python syntax information.



