### PR TITLE
Adding theme "wikipedia"

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1175,5 +1175,11 @@
     "subColor": "#651e56",
     "textColor": "#fff"
   }
-
+  {
+    "name": "wikipedia",
+    "bgColor": "#ffffff",
+    "mainColor": "#b6e0fc",
+    "subColor": "#F8F9FA",
+    "textColor": "#36212d"
+  }
 ]

--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1174,7 +1174,7 @@
     "mainColor": "#ff8f00",
     "subColor": "#651e56",
     "textColor": "#fff"
-  }
+  },
   {
     "name": "wikipedia",
     "bgColor": "#ffffff",

--- a/frontend/static/themes/wikipedia.css
+++ b/frontend/static/themes/wikipedia.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #ffffff;
+    --main-color: #b6e0fc;
+    --caret-color: #F8F9FA;
+    --sub-color: #F8F9FA;
+    --sub-alt-color: #ffffff;
+    --text-color: #36212d;
+    --error-color: #b6e0fc;
+    --error-extra-color: #aac1e9;
+    --colorful-error-color: #ffffff;
+    --colorful-error-extra-color: #ffffff;
+  }


### PR DESCRIPTION
### Description
Hey everyone, this is my first pull request pretty much ever, so please tell me if I did something wrong.
I'm adding a theme, that is meant to look similar to the default Wikipedia theme, because I thought it would be cool.
I guess you can check what stuff I added, and I can show you what screenshot I was working off. I don't know how to add a screenshot of how my theme is meant to look, so this is probably the best I can do. Thanks!

![image](https://github.com/monkeytypegame/monkeytype/assets/132307750/5855c958-b670-49a1-967e-e8c15d447387)

