### PR TITLE
Improve word highlight UI in input history

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -280,9 +280,6 @@
   margin: 0.25em;
   color: var(--sub-color);
   font-variant: no-common-ligatures;
-  // display: flex;
-  // transition: 0.25s
-  /*   margin-bottom: 1px; */
   border-bottom: 2px solid transparent;
   letter {
     display: inline-block;
@@ -299,8 +296,6 @@
   .wordInputHighlight {
     opacity: 1;
     white-space: nowrap;
-    display: flex;
-    flex-direction: column-reverse;
     position: absolute;
     background: var(--sub-color);
     color: var(--bg-color);
@@ -316,15 +311,18 @@
     text-shadow: none;
     top: -0.5rem;
     z-index: 10;
-    cursor: text;
+    cursor: none !important;
 
     &.withSpeed {
-      top: -1.5rem;
       .speed {
         font-size: 0.75rem;
         color: var(--sub-alt-color);
       }
     }
+  }
+
+  &.nocursor {
+    cursor: none;
   }
 
   &.error {

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -311,7 +311,6 @@
     text-shadow: none;
     top: -0.5rem;
     z-index: 10;
-    cursor: none !important;
 
     &.withSpeed {
       .speed {

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -317,13 +317,13 @@
     top: -0.5rem;
     z-index: 10;
     cursor: text;
-  }
 
-  .wordInputHighlight--WithSpeed {
-    top: -1.5rem;
-    .speed {
-      font-size: 0.75rem;
-      color: var(--sub-alt-color);
+    &.withSpeed {
+      top: -1.5rem;
+      .speed {
+        font-size: 0.75rem;
+        color: var(--sub-alt-color);
+      }
     }
   }
 

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -296,10 +296,11 @@
     opacity: 0.25;
   }
 
-  // transition: .25s;
-  .wordInputAfter {
+  .wordInputHighlight {
     opacity: 1;
     white-space: nowrap;
+    display: flex;
+    flex-direction: column-reverse;
     position: absolute;
     background: var(--sub-color);
     color: var(--bg-color);
@@ -316,8 +317,13 @@
     top: -0.5rem;
     z-index: 10;
     cursor: text;
+  }
+
+  .wordInputHighlight--WithSpeed {
+    top: -1.5rem;
     .speed {
       font-size: 0.75rem;
+      color: var(--sub-alt-color);
     }
   }
 

--- a/frontend/src/ts/controllers/chart-controller.ts
+++ b/frontend/src/ts/controllers/chart-controller.ts
@@ -217,7 +217,7 @@ export const result: ChartWithUpdateColors<
           callbacks: {
             afterLabel: function (ti): string {
               try {
-                $(".wordInputAfter").remove();
+                $(".wordInputHighlight").remove();
 
                 const wordsToHighlight =
                   TestInput.keypressPerSecond[parseInt(ti.label) - 1].words;
@@ -230,7 +230,7 @@ export const result: ChartWithUpdateColors<
                   const input = wordEl.attr("input");
                   if (input !== undefined) {
                     wordEl.append(
-                      `<div class="wordInputAfter">${input
+                      `<div class="wordInputHighlight">${input
                         .replace(/\t/g, "_")
                         .replace(/\n/g, "_")
                         .replace(/</g, "&lt")

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1224,7 +1224,7 @@ $(".pageTest #resultWordsHistory").on("mouseenter", ".words .word", (e) => {
     const burst = parseInt(<string>$(e.currentTarget).attr("burst"));
     if (input !== undefined) {
       $(e.currentTarget).append(
-        `<div class="wordInputHighlight wordInputHighlight--WithSpeed">
+        `<div class="wordInputHighlight withSpeed">
           <div class="text">
           ${input
             .replace(/\t/g, "_")

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1211,11 +1211,11 @@ $(".pageTest #toggleBurstHeatmap").on("click", async () => {
 });
 
 $(".pageTest #resultWordsHistory").on("mouseleave", ".words .word", () => {
-  $(".wordInputAfter").remove();
+  $(".wordInputHighlight").remove();
 });
 
 $(".pageTest #result #wpmChart").on("mouseleave", () => {
-  $(".wordInputAfter").remove();
+  $(".wordInputHighlight").remove();
 });
 
 $(".pageTest #resultWordsHistory").on("mouseenter", ".words .word", (e) => {
@@ -1224,7 +1224,7 @@ $(".pageTest #resultWordsHistory").on("mouseenter", ".words .word", (e) => {
     const burst = parseInt(<string>$(e.currentTarget).attr("burst"));
     if (input !== undefined) {
       $(e.currentTarget).append(
-        `<div class="wordInputAfter">
+        `<div class="wordInputHighlight wordInputHighlight--WithSpeed">
           <div class="text">
           ${input
             .replace(/\t/g, "_")

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -895,13 +895,13 @@ async function loadWordsHistory(): Promise<boolean> {
         const correctedChar = !containsKorean
           ? TestInput.corrected.getHistory(i)
           : Hangul.assemble(TestInput.corrected.getHistory(i).split(""));
-        wordEl = `<div class='word' burst="${
+        wordEl = `<div class='word nocursor' burst="${
           TestInput.burstHistory[i]
         }" input="${correctedChar
           .replace(/"/g, "&quot;")
           .replace(/ /g, "_")}">`;
       } else {
-        wordEl = `<div class='word' burst="${
+        wordEl = `<div class='word nocursor' burst="${
           TestInput.burstHistory[i]
         }" input="${input.replace(/"/g, "&quot;").replace(/ /g, "_")}">`;
       }
@@ -928,14 +928,14 @@ async function loadWordsHistory(): Promise<boolean> {
         }
         if (wordstats.incorrect !== 0 || Config.mode !== "time") {
           if (Config.mode !== "zen" && input !== word) {
-            wordEl = `<div class='word error' burst="${
+            wordEl = `<div class='word nocursor error' burst="${
               TestInput.burstHistory[i]
             }" input="${input.replace(/"/g, "&quot;").replace(/ /g, "_")}">`;
           }
         }
       } else {
         if (Config.mode !== "zen" && input !== word) {
-          wordEl = `<div class='word error' burst="${
+          wordEl = `<div class='word nocursor error' burst="${
             TestInput.burstHistory[i]
           }" input="${input.replace(/"/g, "&quot;").replace(/ /g, "_")}">`;
         }


### PR DESCRIPTION
### Problem
* Mouse blocks wpm speed while hovering words in input history
![monkeytype-wpm-bad](https://github.com/monkeytypegame/monkeytype/assets/70380876/f566848e-c9bc-4c2b-ae5e-0727bdbe5266)


### Solution
* Moved wpm speed above word so that it is not blocked by mouse
* Changed color to sub-alt, cleaner imo
![monkeytype-wpm-good](https://github.com/monkeytypegame/monkeytype/assets/70380876/813cc05f-42ab-4d31-b3ee-371042681250)

### Notes
* Changed .wordInputAfter to .wordInputHighlight base class, added .wordInputHighlight--WithSpeed, which can be omitted for highlights not using speed
* Here is the only other time .wordInputAfter was being used. As you can see, it is working perfectly
![monkeytype-multi-highlight](https://github.com/monkeytypegame/monkeytype/assets/70380876/05ec17f2-87e9-4682-8333-e940a11cda48)





