### PR TITLE
Fix Cookie Popup from appearing in Screenshots when using Blocking Extension

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -384,7 +384,10 @@ export async function screenshot(): Promise<void> {
   let revealReplay = false;
 
   let revertCookie = false;
-  if (Misc.isElementVisible("#cookiePopupWrapper")) {
+  if (
+    Misc.isElementVisible("#cookiePopupWrapper") ||
+    document.contains(document.querySelector("#cookiePopupWrapper"))
+  ) {
     revertCookie = true;
   }
 


### PR DESCRIPTION
Closes #4414

`Misc.isElementVisible("#cookiePopupWrapper")` was not enough of a check as the pop-up still showed up in the screenshots even when this returned false. Since the pop-up must only exist if it has been blocked in some way, because otherwise you'd never reach the screenshot, so if the `isElementVisible` returns false but it does exist, we still set it to `hidden`.

Before:
![image](https://github.com/monkeytypegame/monkeytype/assets/92792319/60a45e72-30a7-41f3-bec5-db643b31d6b5)

After:
![image](https://github.com/monkeytypegame/monkeytype/assets/92792319/3561ce1a-4ed6-4271-a1a2-b010b3954c89)
