### PR TITLE
added dark_violet theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1,5 +1,12 @@
 [
   {
+    "name": "dark_violet",
+    "bgColor": "#000000",
+    "mainColor": "#9045e6",
+    "subColor": "#454864",
+    "textColor": "#cdd6f4"
+  },
+  {
     "name": "dark_note",
     "bgColor": "#1f1f1f",
     "mainColor": "#f2c17b",
@@ -1175,5 +1182,4 @@
     "subColor": "#651e56",
     "textColor": "#fff"
   }
-
 ]

--- a/frontend/static/themes/dark_violet.css
+++ b/frontend/static/themes/dark_violet.css
@@ -1,0 +1,35 @@
+:root {
+  --bg-color: #000000;
+  --main-color: #9045e6;
+  --caret-color: #9045e6;
+  --sub-color: #454864;
+  --sub-alt-color: #121212;
+  --text-color: #cdd6f4;
+  --error-color: #da3333;
+  --error-extra-color: #791717;
+  --colorful-error-color: #da3333;
+  --colorful-error-extra-color: #791717;
+}
+
+#menu .textButton:nth-child(1) {
+  color: #9045e6;
+}
+#menu .textButton:nth-child(2) {
+  color: #397dc1;
+}
+
+#menu .textButton:nth-child(3) {
+  color: #01c301;
+}
+
+#menu .textButton:nth-child(4) {
+  color: #c599c5;
+}
+
+#menu .textButton:nth-child(5) {
+  color: #9045e6;
+}
+
+#menu .textButton:nth-child(6) {
+  color: #9045e6;
+}


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Added a theme based on a theme I use on my terminal. Might look similar to ``husqy`` but I wanted something more muted for the sub color.

#### Dark Violet
<img width="1680" alt="Screenshot 2023-07-23 at 12 05 25 AM" src="https://github.com/monkeytypegame/monkeytype/assets/14011425/010edc3e-a01b-4a78-90fc-872075630ad2">

#### Results page
<img width="1680" alt="Screenshot 2023-07-23 at 12 06 43 AM" src="https://github.com/monkeytypegame/monkeytype/assets/14011425/703bc9d8-2294-4bc8-bf39-297abb539480">

#### Flipped
<img width="1680" alt="Screenshot 2023-07-23 at 12 05 53 AM" src="https://github.com/monkeytypegame/monkeytype/assets/14011425/b0d2912a-b5c6-46aa-9fdf-42fcc8a0a89d">

#### Flipped + Colorful mode
<img width="1680" alt="Screenshot 2023-07-23 at 12 06 03 AM" src="https://github.com/monkeytypegame/monkeytype/assets/14011425/0288fa66-22f0-40f9-aef8-23f4e7275fb8">



<!-- Please describe the change(s) made in your PR -->



<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
