### PR TITLE
fixed quick toggle-to-highlight bug

### DIFF
--- a/frontend/src/ts/elements/result-word-highlight.ts
+++ b/frontend/src/ts/elements/result-word-highlight.ts
@@ -188,11 +188,14 @@ async function init(): Promise<boolean> {
   isInitInProgress = true;
 
   // Wait for toggle button to fully populate resultWordHighlights before highlighting
-  let timeDiffSinceLastToggle =
+  const TIME_DIFF_SINCE_LAST_TOGGLE =
     new Date().getTime() - lastToggleWordsHistoryTime.getTime();
-  if (timeDiffSinceLastToggle < TOGGLE_RESULT_WORDS_BUFFER) {
+  if (TIME_DIFF_SINCE_LAST_TOGGLE < TOGGLE_RESULT_WORDS_BUFFER) {
     await new Promise((resolve) =>
-      setTimeout(resolve, TOGGLE_RESULT_WORDS_BUFFER - timeDiffSinceLastToggle)
+      setTimeout(
+        resolve,
+        TOGGLE_RESULT_WORDS_BUFFER - TIME_DIFF_SINCE_LAST_TOGGLE
+      )
     );
   }
 

--- a/frontend/src/ts/elements/result-word-highlight.ts
+++ b/frontend/src/ts/elements/result-word-highlight.ts
@@ -534,6 +534,6 @@ function getHighlightWidth(
   return width;
 }
 
-export function updateToggleWordsHistoryTime() {
+export function updateToggleWordsHistoryTime(): void {
   lastToggleWordsHistoryTime = new Date();
 }

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1021,6 +1021,7 @@ async function loadWordsHistory(): Promise<boolean> {
 
 export function toggleResultWords(noAnimation = false): void {
   if (resultVisible) {
+    ResultWordHighlight.updateToggleWordsHistoryTime();
     if ($("#resultWordsHistory").stop(true, true).hasClass("hidden")) {
       //show
 


### PR DESCRIPTION
Bug when user toggles result words and instantly hovers over chart. Occurs because of animation. Waits 250 ms since last toggle before highlighting
https://gyazo.com/ae4eb42efab8dccd8078fdbf448e22ec