### PR TITLE
refactor funbox

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -304,17 +304,6 @@
   &.tape .word {
     margin: 0.25em 0.5em 0.75em 0;
   }
-
-  &.nospace .word {
-    margin: 0.5em 0;
-  }
-
-  &.arrows .word {
-    margin: 0.5em 0;
-    letter {
-      margin: 0 0.25em;
-    }
-  }
 }
 
 .word {
@@ -1223,5 +1212,22 @@
 #middle.focus .pageTest {
   #testModesNotice {
     opacity: 0 !important;
+  }
+}
+
+/* funbox nospace */
+body.fb-nospace {
+  #words .word {
+    margin: 0.5em 0;
+  }
+}
+
+/* funbox arrows */
+body.fb-arrows {
+  #words .word {
+    margin: 0.5em 0;
+    letter {
+      margin: 0 0.25em;
+    }
   }
 }

--- a/frontend/src/ts/test/funbox/funbox-list.ts
+++ b/frontend/src/ts/test/funbox/funbox-list.ts
@@ -2,10 +2,12 @@ const list: MonkeyTypes.FunboxMetadata[] = [
   {
     name: "nausea",
     info: "I think I'm gonna be sick.",
+    hasCSS: true,
   },
   {
     name: "round_round_baby",
     info: "...right round, like a record baby. Right, round round round.",
+    hasCSS: true,
   },
   {
     name: "simon_says",
@@ -14,14 +16,17 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     forcedConfig: {
       highlightMode: ["letter", "off"],
     },
+    hasCSS: true,
   },
   {
     name: "mirror",
     info: "Everything is mirrored!",
+    hasCSS: true,
   },
   {
     name: "upside_down",
     info: "Everything is upside down!",
+    hasCSS: true,
   },
   {
     name: "tts",
@@ -30,11 +35,13 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     forcedConfig: {
       highlightMode: ["letter", "off"],
     },
+    hasCSS: true,
   },
   {
     name: "choo_choo",
     info: "All the letters are spinning!",
     properties: ["noLigatures", "conflictsWithSymmetricChars"],
+    hasCSS: true,
   },
   {
     name: "arrows",
@@ -71,10 +78,12 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     name: "earthquake",
     info: "Everybody get down! The words are shaking!",
     properties: ["noLigatures"],
+    hasCSS: true,
   },
   {
     name: "space_balls",
     info: "In a galaxy far far away.",
+    hasCSS: true,
   },
   {
     name: "gibberish",
@@ -129,6 +138,7 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     forcedConfig: {
       highlightMode: ["letter", "off"],
     },
+    hasCSS: true,
   },
   {
     name: "read_ahead",
@@ -137,6 +147,7 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     forcedConfig: {
       highlightMode: ["letter", "off"],
     },
+    hasCSS: true,
   },
   {
     name: "read_ahead_hard",
@@ -145,6 +156,7 @@ const list: MonkeyTypes.FunboxMetadata[] = [
     forcedConfig: {
       highlightMode: ["letter", "off"],
     },
+    hasCSS: true,
   },
   {
     name: "memory",

--- a/frontend/src/ts/test/funbox/funbox-validation.ts
+++ b/frontend/src/ts/test/funbox/funbox-validation.ts
@@ -271,7 +271,7 @@ export function areFunboxesCompatible(
         f.functions?.pullSection
     ).length <= 1;
   const oneApplyCSSMax =
-    funboxesToCheck.filter((f) => f.functions?.applyCSS).length <= 1;
+    funboxesToCheck.filter((f) => f.hasCSS == true).length <= 1;
   const onePunctuateWordMax =
     funboxesToCheck.filter((f) => f.functions?.punctuateWord).length <= 1;
   const oneCharCheckerMax =

--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -546,7 +546,15 @@ export function toggleFunbox(funbox: string): boolean {
 }
 
 export async function clear(): Promise<boolean> {
-  $("body").attr("class", "");
+  $("body").attr(
+    "class",
+    $("body")
+      ?.attr("class")
+      ?.split(/\s+/)
+      ?.filter((it) => !it.startsWith("fb-"))
+      ?.join(" ") || ""
+  );
+
   $("#funBoxTheme").removeAttr("href");
 
   $("#wordsWrapper").removeClass("hidden");
@@ -706,22 +714,17 @@ FunboxList.setFunboxFunctions("crt", {
 async function setFunboxBodyClasses(): Promise<boolean> {
   const $body = $("body");
 
-  const activeFbNames = FunboxList.get(Config.funbox).map(
+  const activeFbClasses = FunboxList.get(Config.funbox).map(
     (it) => "fb-" + it.name.replaceAll("_", "-")
   );
-  const currentFbClasses =
+
+  const currentClasses =
     $body
       ?.attr("class")
       ?.split(/\s+/)
-      ?.filter((it) => it.startsWith("fb-")) || [];
+      ?.filter((it) => !it.startsWith("fb-")) || [];
 
-  currentFbClasses
-    .filter((it) => !activeFbNames.includes(it))
-    .forEach((it) => $body?.removeClass(it));
-
-  activeFbNames
-    .filter((it) => !currentFbClasses.includes(it))
-    .forEach((it) => $body?.addClass(it));
+  $body.attr("class", [...currentClasses, ...activeFbClasses].join(" "));
 
   return true;
 }

--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -99,22 +99,11 @@ class PseudolangWordGenerator extends Wordset {
   }
 }
 
-FunboxList.setFunboxFunctions("nausea", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/nausea.css`);
-  },
-});
+FunboxList.setFunboxFunctions("nausea", {});
 
-FunboxList.setFunboxFunctions("round_round_baby", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/round_round_baby.css`);
-  },
-});
+FunboxList.setFunboxFunctions("round_round_baby", {});
 
 FunboxList.setFunboxFunctions("simon_says", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/simon_says.css`);
-  },
   applyConfig(): void {
     UpdateConfig.setKeymapMode("next", true);
   },
@@ -123,22 +112,11 @@ FunboxList.setFunboxFunctions("simon_says", {
   },
 });
 
-FunboxList.setFunboxFunctions("mirror", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/mirror.css`);
-  },
-});
+FunboxList.setFunboxFunctions("mirror", {});
 
-FunboxList.setFunboxFunctions("upside_down", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/upside_down.css`);
-  },
-});
+FunboxList.setFunboxFunctions("upside_down", {});
 
 FunboxList.setFunboxFunctions("tts", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/simon_says.css`);
-  },
   applyConfig(): void {
     UpdateConfig.setKeymapMode("off", true);
   },
@@ -154,18 +132,11 @@ FunboxList.setFunboxFunctions("tts", {
   },
 });
 
-FunboxList.setFunboxFunctions("choo_choo", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/choo_choo.css`);
-  },
-});
+FunboxList.setFunboxFunctions("choo_choo", {});
 
 FunboxList.setFunboxFunctions("arrows", {
   getWord(_wordset, wordIndex): string {
     return Misc.chart2Word(wordIndex === 0);
-  },
-  applyConfig(): void {
-    $("#words").addClass("arrows");
   },
   rememberSettings(): void {
     save("highlightMode", Config.highlightMode, UpdateConfig.setHighlightMode);
@@ -347,17 +318,9 @@ FunboxList.setFunboxFunctions("layoutfluid", {
   },
 });
 
-FunboxList.setFunboxFunctions("earthquake", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/earthquake.css`);
-  },
-});
+FunboxList.setFunboxFunctions("earthquake", {});
 
-FunboxList.setFunboxFunctions("space_balls", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/space_balls.css`);
-  },
-});
+FunboxList.setFunboxFunctions("space_balls", {});
 
 FunboxList.setFunboxFunctions("gibberish", {
   getWord(): string {
@@ -425,27 +388,18 @@ FunboxList.setFunboxFunctions("specials", {
 });
 
 FunboxList.setFunboxFunctions("read_ahead_easy", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/read_ahead_easy.css`);
-  },
   rememberSettings(): void {
     save("highlightMode", Config.highlightMode, UpdateConfig.setHighlightMode);
   },
 });
 
 FunboxList.setFunboxFunctions("read_ahead", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/read_ahead.css`);
-  },
   rememberSettings(): void {
     save("highlightMode", Config.highlightMode, UpdateConfig.setHighlightMode);
   },
 });
 
 FunboxList.setFunboxFunctions("read_ahead_hard", {
-  applyCSS(): void {
-    $("#funBoxTheme").attr("href", `funbox/read_ahead_hard.css`);
-  },
   rememberSettings(): void {
     save("highlightMode", Config.highlightMode, UpdateConfig.setHighlightMode);
   },
@@ -479,9 +433,6 @@ FunboxList.setFunboxFunctions("memory", {
 });
 
 FunboxList.setFunboxFunctions("nospace", {
-  applyConfig(): void {
-    $("#words").addClass("nospace");
-  },
   rememberSettings(): void {
     save("highlightMode", Config.highlightMode, UpdateConfig.setHighlightMode);
   },
@@ -609,9 +560,8 @@ export function toggleFunbox(funbox: string): boolean {
 }
 
 export async function clear(): Promise<boolean> {
-  $("#funBoxTheme").attr("href", ``);
-  $("#words").removeClass("nospace");
-  $("#words").removeClass("arrows");
+  await setFunboxBodyClasses();
+  await applyFunboxCSS();
   $("#wordsWrapper").removeClass("hidden");
   MemoryTimer.reset();
   ManualRestart.set();
@@ -644,10 +594,10 @@ export async function activate(funbox?: string): Promise<boolean | undefined> {
   }
 
   MemoryTimer.reset();
+  await setFunboxBodyClasses();
+  await applyFunboxCSS();
+
   $("#wordsWrapper").removeClass("hidden");
-  $("#funBoxTheme").attr("href", ``);
-  $("#words").removeClass("nospace");
-  $("#words").removeClass("arrows");
 
   let language;
   try {
@@ -735,8 +685,7 @@ export async function activate(funbox?: string): Promise<boolean | undefined> {
 
   ManualRestart.set();
   FunboxList.get(Config.funbox).forEach(async (funbox) => {
-    if (funbox.functions?.applyCSS) funbox.functions.applyCSS();
-    if (funbox.functions?.applyConfig) funbox.functions.applyConfig();
+    funbox.functions?.applyConfig?.();
   });
   // ModesNotice.update();
   return true;
@@ -766,3 +715,48 @@ FunboxList.setFunboxFunctions("crt", {
     $("#globalFunBoxTheme").attr("href", ``);
   },
 });
+
+async function setFunboxBodyClasses(): Promise<boolean> {
+  const $body = $("body");
+
+  const activeFbNames = FunboxList.get(Config.funbox).map(
+    (it) => "fb-" + it.name.replaceAll("_", "-")
+  );
+  const currentFbClasses =
+    $body
+      ?.attr("class")
+      ?.split(/\s+/)
+      ?.filter((it) => it.startsWith("fb-")) || [];
+
+  currentFbClasses
+    .filter((it) => !activeFbNames.includes(it))
+    .forEach((it) => $body?.removeClass(it));
+
+  activeFbNames
+    .filter((it) => !currentFbClasses.includes(it))
+    .forEach((it) => $body?.addClass(it));
+
+  return true;
+}
+
+async function applyFunboxCSS(): Promise<boolean> {
+  const $theme = $("#funBoxTheme");
+
+  //currently we only support one active funbox with hasCSS
+  const activeFunboxWithTheme = FunboxList.get(Config.funbox).find(
+    (it) => it.hasCSS == true
+  );
+
+  const activeTheme =
+    activeFunboxWithTheme != null
+      ? "funbox/" + activeFunboxWithTheme.name + ".css"
+      : "";
+
+  const currentTheme = $theme.attr("href") || null;
+
+  if (activeTheme != currentTheme) {
+    $theme.attr("href", activeTheme);
+  }
+
+  return true;
+}

--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -99,10 +99,6 @@ class PseudolangWordGenerator extends Wordset {
   }
 }
 
-FunboxList.setFunboxFunctions("nausea", {});
-
-FunboxList.setFunboxFunctions("round_round_baby", {});
-
 FunboxList.setFunboxFunctions("simon_says", {
   applyConfig(): void {
     UpdateConfig.setKeymapMode("next", true);
@@ -111,10 +107,6 @@ FunboxList.setFunboxFunctions("simon_says", {
     save("keymapMode", Config.keymapMode, UpdateConfig.setKeymapMode);
   },
 });
-
-FunboxList.setFunboxFunctions("mirror", {});
-
-FunboxList.setFunboxFunctions("upside_down", {});
 
 FunboxList.setFunboxFunctions("tts", {
   applyConfig(): void {
@@ -131,8 +123,6 @@ FunboxList.setFunboxFunctions("tts", {
     TTSEvent.dispatch(params[0]);
   },
 });
-
-FunboxList.setFunboxFunctions("choo_choo", {});
 
 FunboxList.setFunboxFunctions("arrows", {
   getWord(_wordset, wordIndex): string {
@@ -317,10 +307,6 @@ FunboxList.setFunboxFunctions("layoutfluid", {
     }, 1);
   },
 });
-
-FunboxList.setFunboxFunctions("earthquake", {});
-
-FunboxList.setFunboxFunctions("space_balls", {});
 
 FunboxList.setFunboxFunctions("gibberish", {
   getWord(): string {
@@ -560,8 +546,9 @@ export function toggleFunbox(funbox: string): boolean {
 }
 
 export async function clear(): Promise<boolean> {
-  await setFunboxBodyClasses();
-  await applyFunboxCSS();
+  $("body").attr("class", "");
+  $("#funBoxTheme").removeAttr("href");
+
   $("#wordsWrapper").removeClass("hidden");
   MemoryTimer.reset();
   ManualRestart.set();

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -234,7 +234,6 @@ declare namespace MonkeyTypes {
     punctuateWord?: (word: string) => string;
     withWords?: (words?: string[]) => Promise<Misc.Wordset>;
     alterText?: (word: string) => string;
-    applyCSS?: () => void;
     applyConfig?: () => void;
     applyGlobalCSS?: () => void;
     clearGlobal?: () => void;
@@ -274,6 +273,7 @@ declare namespace MonkeyTypes {
     forcedConfig?: MonkeyTypes.FunboxForcedConfig;
     properties?: FunboxProperty[];
     functions?: FunboxFunctions;
+    hasCSS?: boolean;
   }
 
   interface CustomText {

--- a/frontend/static/funbox/tts.css
+++ b/frontend/static/funbox/tts.css
@@ -1,0 +1,7 @@
+/* #words {
+  opacity: 0 !important;
+} */
+
+#words .word {
+  color: transparent !important;
+}


### PR DESCRIPTION
### Description

Funbox refactoring

Refactoring of custom css rules and loading of custom css files to reduce the amout of redundant code and have a better code sparation.

1. add funbox mode as class

Remove need for `applyConfig` to set classes on e.g. `#words` and the `Funbox.activate` and `Funbox.clear` methods to cleanup individual funboxes.

Replace this by setting the funbox modes as classes on the body element (e.g. funbox `arrows` adds class `fb-arrows`). The css can now use `body.fb-arrows #words ` instead of `#words.arrows`. 

In addition the body class attribute is only altered if there was a change in active funboxes. Previously this was set on each test restart causing "flickering" in some cases.

2. loading of funbox css

Currently there is a method `applyCSS` on funboxes with needs a custom css file to be loaded. Each of the methods contain the same code. Replace this with  `FunboxMetaData.hasCSS: boolean`. The css to be loaded is always `funbox/${funbox.name}.css` so we don't need to specify the path it in each `applyCSS` method.

In addition the custom css href is only altered if there was a change in active funboxes. Previously this was set on each test restart causing the css to be loaded each time and also causing "flickering" in some cases.
