### PR TITLE
ci(frontend/scripts): print expected quote length

### DIFF
--- a/frontend/scripts/json-validation.js
+++ b/frontend/scripts/json-validation.js
@@ -406,17 +406,16 @@ function validateQuotes() {
       }
       const incorrectQuoteLength = quoteData.quotes
         .filter((quote) => quote.text.length !== quote.length)
-        .map((quote) => quote.id);
       if (incorrectQuoteLength.length !== 0) {
-        console.log(
-          `Quote ${quotefilename} ID(s) ${incorrectQuoteLength.join(
-            ","
-          )} length fields are \u001b[31mincorrect\u001b[0m`
-        );
+        console.log("Some length fields are \u001b[31mincorrect\u001b[0m");
+        incorrectQuoteLength
+          .map((quote) => { console.log(
+            `Quote ${quotefilename} ID ${quote.id}: expected length ${quote.text.length}`
+          )});
         quoteFilesAllGood = false;
-        incorrectQuoteLength.map((id) => {
+        incorrectQuoteLength.map((quote) => {
           quoteLengthErrors.push(
-            `${quotefilename} ${id} length field is incorrect`
+            `${quotefilename} ${quote.id} length field is incorrect`
           );
         });
       }


### PR DESCRIPTION
### Context

CI prompts when a quote length is incorrect but does not fix it, or print how to fix it.

<img width="700" alt="image" src="https://github.com/monkeytypegame/monkeytype/assets/7701186/b5e67bcd-1f68-40d2-b46d-f712c8e38468">

### Proposed change

Print the expected length.

![image|700](https://github.com/monkeytypegame/monkeytype/assets/7701186/c7094b62-6b43-44f4-ad2d-467b172fc8d7)


