### PR TITLE
Couldn't see `monkey see` in rainbow trail theme

### DIFF
--- a/frontend/static/themes/rainbow_trail.css
+++ b/frontend/static/themes/rainbow_trail.css
@@ -29,6 +29,10 @@
   animation: rainbow-gradient 30s alternate ease-in-out infinite;
 }
 
+#top .logo .top {
+  -webkit-text-fill-color: initial;
+}
+
 .textButton:hover,
 #restartTestButton:hover > i,
 #restartTestButton:hover > i,


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

The `monkey see` word couldn't see in rainbow trail theme.

Before:
<img width="263" alt="CleanShot 2023-08-06 at 21 34 48@2x" src="https://github.com/monkeytypegame/monkeytype/assets/92412722/63ebb0fb-970a-4a43-b76e-b42fbef0486d">

After:
<img width="263" alt="CleanShot 2023-08-06 at 21 34 48@2x" src="https://github.com/monkeytypegame/monkeytype/assets/92412722/4e79a984-e252-484f-be7e-b2bef333877a">
