### PR TITLE
Fixed rainbow trail theme to support custom backgrounds

### DIFF
--- a/frontend/static/themes/rainbow_trail.css
+++ b/frontend/static/themes/rainbow_trail.css
@@ -70,33 +70,42 @@
 @keyframes rainbow {
   0% {
     color: #60b6ce;
+    opacity: 1;
   }
   11.11% {
     color: #7ce3e1;
+    opacity: 1;
   }
   22.22% {
     color: #b2e259;
+    opacity: 1;
   }
   33.33% {
     color: #f6ee75;
+    opacity: 1;
   }
   44.44% {
     color: #f5b83d;
+    opacity: 1;
   }
   55.56% {
     color: #f49a98;
+    opacity: 1;
   }
   66.67% {
     color: #ed7abd;
+    opacity: 1;
   }
   77.78% {
     color: #dea2fa;
+    opacity: 1;
   }
   88.89% {
     color: #a966f5;
+    opacity: 1;
   }
   100% {
-    color: var(--bg-color);
+    opacity: 0;
   }
 }
 


### PR DESCRIPTION
### Description

Rainbow trail theme is supposed to hide correct words after a while. Previously this was done by setting the color to the background color at the end of the animation. With a custom background set the words will still be visible.

The fix will set the opacity to 0 instead of setting the text color to the background color to hide the text.
