### PR TITLE
add `tailwind` theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1181,6 +1181,12 @@
     "mainColor": "#363636",
     "subColor": "#4f4f4f",
     "textColor": "#1f1f1f"
+  },
+  {
+    "name": "tailwind",
+    "bgColor": "#0d1628",
+    "mainColor": "#38bdf8",
+    "subColor": "#94a3b8",
+    "textColor": "#e5e7eb"
   }
-
 ]

--- a/frontend/static/themes/tailwind.css
+++ b/frontend/static/themes/tailwind.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #0d1628;
+  --main-color: #38bdf8;
+  --caret-color: #38bdf8;
+  --sub-color: #94a3b8;
+  --sub-alt-color: #1e293b;
+  --text-color: #e5e7eb;
+  --error-color: #e32b2b;
+  --error-extra-color: #a62626;
+  --colorful-error-color: #e32b2b;
+  --colorful-error-extra-color: #a62626;
+}


### PR DESCRIPTION
### Tailwind Theme

Add tailwind theme, according to [tailwindcss.com](https://tailwindcss.com) palettes.

![Web capture_8-8-2023_13954_monkeytype com](https://github.com/monkeytypegame/monkeytype/assets/99963638/8a10e929-0221-4b87-97a8-6382abcd5ca0)
![Web capture_8-8-2023_131353_monkeytype com](https://github.com/monkeytypegame/monkeytype/assets/99963638/44e8dde0-2099-43f7-b5c1-1e44365b0cf6)
![Web capture_8-8-2023_131337_monkeytype com](https://github.com/monkeytypegame/monkeytype/assets/99963638/a67447ff-f9fc-47df-aa74-ba8dbdb8e00d)
![Web capture_8-8-2023_13108_monkeytype com](https://github.com/monkeytypegame/monkeytype/assets/99963638/e6be2203-4718-47bc-98d1-9d249527c654)



