### PR TITLE
chore: Add banana theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1181,6 +1181,13 @@
     "mainColor": "#363636",
     "subColor": "#4f4f4f",
     "textColor": "#1f1f1f"
+  },
+  {
+   "name": "banana",
+    "bgColor": "#fff04d",
+    "mainColor": "#ffffff",
+    "subColor": "#ffffff",
+    "textColor": "#ffffff" 
   }
 
 ]

--- a/frontend/static/themes/banana.css
+++ b/frontend/static/themes/banana.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #fff04d;
+    --main-color: #ffffff;
+    --caret-color: #dab634;
+    --sub-color: #ffffff;
+    --sub-alt-color: #cdc02d;
+    --text-color: #ffffff;
+    --error-color: #a88a1f;
+    --error-extra-color: #95875f;
+    --colorful-error-color: #a88a1f;
+    --colorful-error-extra-color: #95875f;
+  }


### PR DESCRIPTION
## Description
Added the `banana` theme.

## What does it look like?
![theme](https://github.com/monkeytypegame/monkeytype/assets/103459068/9a2288b1-8c7e-4c85-895e-bed21264807c)

Let me know if you want more pictures / any revisions I need to add or if it's not a good enough theme.