### PR TITLE
perf: Switch to async file system read API in new quotes

### DIFF
--- a/backend/src/dal/new-quotes.ts
+++ b/backend/src/dal/new-quotes.ts
@@ -2,8 +2,8 @@ import simpleGit from "simple-git";
 import { ObjectId } from "mongodb";
 import stringSimilarity from "string-similarity";
 import path from "path";
-import fs from "fs";
-import { readFile, writeFile } from 'node:fs/promises'
+import { existsSync, writeFileSync } from "fs";
+import { readFile } from 'node:fs/promises'
 import * as db from "../init/db";
 import MonkeyError from "../utils/error";
 
@@ -61,7 +61,7 @@ export async function add(
   );
   let duplicateId = -1;
   let similarityScore = -1;
-  if (fs.existsSync(fileDir)) {
+  if (existsSync(fileDir)) {
     const quoteFile = await readFile(fileDir);
     const quoteFileJSON = JSON.parse(quoteFile.toString());
     quoteFileJSON.quotes.every((old) => {
@@ -156,7 +156,7 @@ export async function approve(
     `${PATH_TO_REPO}/frontend/static/quotes/${language}.json`
   );
   await git.pull("upstream", "master");
-  if (fs.existsSync(fileDir)) {
+  if (existsSync(fileDir)) {
     const quoteFile = await readFile(fileDir);
     const quoteObject = JSON.parse(quoteFile.toString());
     quoteObject.quotes.every((old) => {
@@ -172,12 +172,12 @@ export async function approve(
     });
     quote.id = maxid + 1;
     quoteObject.quotes.push(quote);
-    await writeFile(fileDir, JSON.stringify(quoteObject, null, 2));
+    writeFileSync(fileDir, JSON.stringify(quoteObject, null, 2));
     message = `Added quote to ${language}.json.`;
   } else {
     //file doesnt exist, create it
     quote.id = 1;
-    await writeFile(
+    writeFileSync(
       fileDir,
       JSON.stringify({
         language: language,

--- a/backend/src/dal/new-quotes.ts
+++ b/backend/src/dal/new-quotes.ts
@@ -3,6 +3,7 @@ import { ObjectId } from "mongodb";
 import stringSimilarity from "string-similarity";
 import path from "path";
 import fs from "fs";
+import { readFile, writeFile } from 'node:fs/promises'
 import * as db from "../init/db";
 import MonkeyError from "../utils/error";
 
@@ -61,7 +62,7 @@ export async function add(
   let duplicateId = -1;
   let similarityScore = -1;
   if (fs.existsSync(fileDir)) {
-    const quoteFile = fs.readFileSync(fileDir);
+    const quoteFile = await readFile(fileDir);
     const quoteFileJSON = JSON.parse(quoteFile.toString());
     quoteFileJSON.quotes.every((old) => {
       if (stringSimilarity.compareTwoStrings(old.text, quote.text) > 0.9) {
@@ -156,7 +157,7 @@ export async function approve(
   );
   await git.pull("upstream", "master");
   if (fs.existsSync(fileDir)) {
-    const quoteFile = fs.readFileSync(fileDir);
+    const quoteFile = await readFile(fileDir);
     const quoteObject = JSON.parse(quoteFile.toString());
     quoteObject.quotes.every((old) => {
       if (stringSimilarity.compareTwoStrings(old.text, quote.text) > 0.8) {
@@ -171,12 +172,12 @@ export async function approve(
     });
     quote.id = maxid + 1;
     quoteObject.quotes.push(quote);
-    fs.writeFileSync(fileDir, JSON.stringify(quoteObject, null, 2));
+    await writeFile(fileDir, JSON.stringify(quoteObject, null, 2));
     message = `Added quote to ${language}.json.`;
   } else {
     //file doesnt exist, create it
     quote.id = 1;
-    fs.writeFileSync(
+    await writeFile(
       fileDir,
       JSON.stringify({
         language: language,


### PR DESCRIPTION


### Description

Instead of using readFileSync which blocks the event loop, I've made the new quotes DAO use the asynchronous promise version `readFile`. 


From chat gpt:
> The synchronous version of `fs.readFileSync` blocks program execution until the file reading operation completes, potentially leading to reduced responsiveness. In contrast, the Promise version, `fs.promises.readFile`, offers non-blocking behavior, allowing other tasks to proceed concurrently while awaiting the completion of the file read operation.