### PR TITLE
fix(custom text): resolve incorrect loading of custom text with pipes

### DIFF
--- a/frontend/src/ts/popups/saved-texts-popup.ts
+++ b/frontend/src/ts/popups/saved-texts-popup.ts
@@ -86,7 +86,7 @@ function applySaved(name: string, long: boolean): void {
   if (long) {
     text = text.slice(CustomText.getCustomTextLongProgress(name));
   }
-  CustomText.setPopupTextareaState(text.join(CustomText.delimiter));
+  CustomText.setPopupTextareaState(text.join(" "));
 }
 
 $("#popups").on(


### PR DESCRIPTION
Text saved with space separated words are now loaded with space only.

Fixes #4534

Previous Behavior:
"This is|a test" --save with or without pipe delimiter on--> "This", "is|a", "test" --load with delimiter--> "This|is|a|test"

Fix Behavior
"This is|a test" --save with or without pipe delimiter on--> "This", "is|a", "test" --load with delimiter--> "This is|a test"
