### PR TITLE
fix: use appropriate fallback fonts (SethFalco)

### DIFF
--- a/backend/private/style.css
+++ b/backend/private/style.css
@@ -12,7 +12,7 @@
 }
 
 body {
-  font-family: "Roboto Mono", sans-serif;
+  font-family: "Roboto Mono", monospace;
   margin: 0;
   padding: 0;
   background: var(--bg-color);
@@ -62,7 +62,7 @@ body {
   cursor: pointer;
   font-size: 1rem;
   margin-right: 1rem;
-  font-family: "Roboto Mono";
+  font-family: "Roboto Mono", monospace;
 }
 
 .array-input {
@@ -117,7 +117,7 @@ label {
   transition: all 0.2s ease-in-out;
   font-size: 1rem;
   padding: 0.25rem;
-  font-family: "Roboto Mono";
+  font-family: "Roboto Mono", monospace;
 }
 
 input[type="checkbox"] {

--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -1,6 +1,6 @@
 :root {
   --roundness: 0.5rem;
-  --font: "Roboto Mono", "Vazirmatn", sans-serif;
+  --font: "Roboto Mono", "Vazirmatn", monospace;
   // scroll-behavior: smooth;
   scroll-padding-top: 2rem;
   font-weight: 400;

--- a/frontend/src/styles/nav.scss
+++ b/frontend/src/styles/nav.scss
@@ -185,7 +185,7 @@
       position: relative;
       font-size: 2rem;
       line-height: 2rem;
-      font-family: "Lexend Deca";
+      font-family: "Lexend Deca", sans-serif;
       transition: color 0.25s;
       font-weight: unset;
       margin-block-start: unset;

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1248,7 +1248,7 @@ export function setFontFamily(font: string, nosave?: boolean): boolean {
   config.fontFamily = font;
   document.documentElement.style.setProperty(
     "--font",
-    `"${font.replace(/_/g, " ")}", "Roboto Mono", "Vazirmatn"`
+    `"${font.replace(/_/g, " ")}", "Roboto Mono", "Vazirmatn", monospace`
   );
   saveToLocalStorage("fontFamily", nosave);
   ConfigEvent.dispatch("fontFamily", config.fontFamily);


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

As a user who recently started using the web with downloadable fonts disabled, I noticed the experience of Monkeytype is very inconsistent with the normal experience.

This just adds an appropriate fallback font to any font declarations, so the UI is much closer to the experience of someone with downloadable fonts enabled.

The only odd one is `--font: "Roboto Mono", "Vazirmatn", monospace;`, where you have a monospace font, followed by a sans-serif font. For this, I appended `monospace` to the end.

### References

> You should always include at least one generic family name in a font-family list, since there's no guarantee that any given font is available.
> 
> — https://developer.mozilla.org/en-US/docs/Web/CSS/font-family

### Before

![image](https://github.com/monkeytypegame/monkeytype/assets/22801583/f4222e09-e823-471b-b9ce-beeb7de96854)

### After

![image](https://github.com/monkeytypegame/monkeytype/assets/22801583/90795b0b-c56c-41f2-aae5-0877bdf4b83a)


