### PR TITLE
chore: use docker compose v2 (SethFalco)

### DIFF
--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -93,7 +93,7 @@ Follow these steps if you want to work on anything involving the database/accoun
 
 | Local Server                                                                                                                                             | Docker (recommended)                                                                                                                                                                                                   |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <ol><li>Install [MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/)</li><li>Make sure it is running</li></ol> | <ol><li>Install [Docker](http://www.docker.io/gettingstarted/#h_installation) on your machine</li><li>Run `docker-compose up` from the `./backend` directory (this is also how you start the backend server)</li></ol> |
+| <ol><li>Install [MongoDB Community Edition](https://docs.mongodb.com/manual/administration/install-community/)</li><li>Make sure it is running</li></ol> | <ol><li>Install [Docker](http://www.docker.io/gettingstarted/#h_installation) on your machine</li><li>Run `docker compose up` from the `./backend` directory (this is also how you start the backend server)</li></ol> |
 
 3. (Optional) Install [MongoDB-compass](https://www.mongodb.com/try/download/compass?tck=docs_compass). This tool can be used to see and manipulate your database visually.
    - To connect, type `mongodb://localhost:27017` in the connection string box and press connect. The Monkeytype database will be created and shown after the server is started.
@@ -109,11 +109,11 @@ Follow these steps if you want to work on anything involving the database/accoun
 
 - Frontend:
   ```
-  cd frontend && docker-compose up
+  cd frontend && docker compose up
   ```
 - Backend (in another terminal window):
   ```
-  cd backend && docker-compose up
+  cd backend && docker compose up
   ```
 
 ### **_Without_** Docker:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-fe": "eslint \"./frontend/**/*.ts\"",
     "install-all": "sh ./bin/install.sh",
     "install-windows": ".\\bin\\install.cmd",
-    "docker": "cd backend && docker-compose up",
+    "docker": "cd backend && docker compose up",
     "test-be": "cd backend && npm run test",
     "dev": "concurrently --kill-others \"npm run dev-fe\" \"npm run dev-be\"",
     "dev-be": "cd backend && npm run dev",


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

<!-- Please describe the change(s) made in your PR -->

**_Most_** engineers working with Docker Compose, or who have installed Docker Compose since July 2023 should have Docker Compose v2 installed.

For clarity, `docker-compose` is v1, and `docker compose` is v2. Compose V1 is deprecated.

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
> 
> — https://docs.docker.com/compose/

Docker Compose v2 is fully backward compatible with v1, so nothing else needs to change. Could we have the Compose v2 syntax referenced instead?

### Related

* Similar to https://github.com/flathub/website/pull/1937
* Similar to https://github.com/nextcloud/cookbook/pull/1772
* Similar to https://github.com/juliushaertl/nextcloud-docker-dev/pull/209