### PR TITLE
fix: save confidence mode after setting stopOnError and vice versa

### DIFF
--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -361,9 +361,9 @@ export function setStopOnError(
   config.stopOnError = soe;
   if (config.stopOnError !== "off") {
     config.confidenceMode = "off";
+    saveToLocalStorage("confidenceMode", nosave);
   }
   saveToLocalStorage("stopOnError", nosave);
-  saveToLocalStorage("confidenceMode", nosave);
   ConfigEvent.dispatch("stopOnError", config.stopOnError, nosave);
 
   return true;
@@ -1285,9 +1285,9 @@ export function setConfidenceMode(
   if (config.confidenceMode !== "off") {
     config.freedomMode = false;
     config.stopOnError = "off";
+    saveToLocalStorage("stopOnError", nosave);
   }
   saveToLocalStorage("confidenceMode", nosave);
-  saveToLocalStorage("stopOnError", nosave);
   ConfigEvent.dispatch("confidenceMode", config.confidenceMode, nosave);
 
   return true;

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -363,6 +363,7 @@ export function setStopOnError(
     config.confidenceMode = "off";
   }
   saveToLocalStorage("stopOnError", nosave);
+  saveToLocalStorage("confidenceMode", nosave);
   ConfigEvent.dispatch("stopOnError", config.stopOnError, nosave);
 
   return true;
@@ -1286,6 +1287,7 @@ export function setConfidenceMode(
     config.stopOnError = "off";
   }
   saveToLocalStorage("confidenceMode", nosave);
+  saveToLocalStorage("stopOnError", nosave);
   ConfigEvent.dispatch("confidenceMode", config.confidenceMode, nosave);
 
   return true;

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1285,6 +1285,7 @@ export function setConfidenceMode(
   if (config.confidenceMode !== "off") {
     config.freedomMode = false;
     config.stopOnError = "off";
+    saveToLocalStorage("freedomMode", nosave);
     saveToLocalStorage("stopOnError", nosave);
   }
   saveToLocalStorage("confidenceMode", nosave);


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Saving config to localStorage after resetting some values.

Closes #4638

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
