### PR TITLE
fix:  issue #4674: Ensure Proper Handling of Escaping Characters in Q…

### DIFF
--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -565,9 +565,10 @@ async function generateQuoteWords(
   rq.language = Config.language.replace(/_\d*k$/g, "");
   rq.text = rq.text.replace(/ +/gm, " ");
   rq.text = rq.text.replace(/\\\\t/gm, "\t");
-  rq.text = rq.text.replace(/\\\\n/gm, "\n");
+  rq.text = rq.text.replace(/\\\\n/gm, "&bsol;n");
   rq.text = rq.text.replace(/\\t/gm, "\t");
   rq.text = rq.text.replace(/\\n/gm, "\n");
+  rq.text = rq.text.replace(/&bsol;n/g, "\\n");
   rq.text = rq.text.replace(/( *(\r\n|\r|\n) *)/g, "\n ");
   rq.text = rq.text.replace(/…/g, "...");
   rq.text = rq.text.trim();

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -566,12 +566,10 @@ async function generateQuoteWords(
   rq.text = rq.text.replace(/ +/gm, " ");
   rq.text = rq.text.replace(/\\\\t/gm, "\t");
   rq.text = rq.text.replace(/\\t/gm, "\t");
-  console.log("input", rq.text);
   rq.text = rq.text.replace(
     /([^'"])(\\n)(?=(?:(?:[^'"]*(?:'|")[^'"]*(?:'|"))*[^'"]*$))/gm,
     "\n"
   );
-  console.log("output", rq.text);
   rq.text = rq.text.replace(/( *(\r\n|\r|\n) *)/g, "\n ");
   rq.text = rq.text.replace(/…/g, "...");
   rq.text = rq.text.trim();

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -565,10 +565,13 @@ async function generateQuoteWords(
   rq.language = Config.language.replace(/_\d*k$/g, "");
   rq.text = rq.text.replace(/ +/gm, " ");
   rq.text = rq.text.replace(/\\\\t/gm, "\t");
-  rq.text = rq.text.replace(/\\\\n/gm, "&bsol;n");
   rq.text = rq.text.replace(/\\t/gm, "\t");
-  rq.text = rq.text.replace(/\\n/gm, "\n");
-  rq.text = rq.text.replace(/&bsol;n/g, "\\n");
+  console.log("input", rq.text);
+  rq.text = rq.text.replace(
+    /([^'"])(\\n)(?=(?:(?:[^'"]*(?:'|")[^'"]*(?:'|"))*[^'"]*$))/gm,
+    "\n"
+  );
+  console.log("output", rq.text);
   rq.text = rq.text.replace(/( *(\r\n|\r|\n) *)/g, "\n ");
   rq.text = rq.text.replace(/…/g, "...");
   rq.text = rq.text.trim();

--- a/frontend/static/quotes/code_c++.json
+++ b/frontend/static/quotes/code_c++.json
@@ -92,7 +92,7 @@
       "id": 14
     },
     {
-      "text": "void print(const Student &s) {\\n\\tcout << s.name << \"  \" << s.address << \"  \" << s.rollNo << '\\n';\\n}",
+      "text": "void print(const Student &s) {\\n\\tcout << s.name << \"  \" << s.address << \"  \" << s.rollNo << '\\\\n';\\n}",
       "source": "geeksforgeeks - References",
       "length": 101,
       "id": 15

--- a/frontend/static/quotes/code_c++.json
+++ b/frontend/static/quotes/code_c++.json
@@ -94,7 +94,7 @@
     {
       "text": "void print(const Student &s) {\\n\\tcout << s.name << \"  \" << s.address << \"  \" << s.rollNo << '\\\\n';\\n}",
       "source": "geeksforgeeks - References",
-      "length": 101,
+      "length": 102,
       "id": 15
     },
     {

--- a/frontend/static/quotes/code_c++.json
+++ b/frontend/static/quotes/code_c++.json
@@ -92,9 +92,9 @@
       "id": 14
     },
     {
-      "text": "void print(const Student &s) {\\n\\tcout << s.name << \"  \" << s.address << \"  \" << s.rollNo << '\\\\n';\\n}",
+      "text": "void print(const Student &s) {\\n\\tcout << s.name << \"  \" << s.address << \"  \" << s.rollNo << '\\n';\\n}",
       "source": "geeksforgeeks - References",
-      "length": 102,
+      "length": 101,
       "id": 15
     },
     {


### PR DESCRIPTION
### Description
This commit addresses the issue titled 'Escaping characters not being treated as raw string literals in quote mode #4674' by modifying the regex pattern to correctly handle escaping characters when in quote mode:
- Replaces '\\n' with '&bsol;n' to prevent conflicts with subsequent transformations.
- Converts '&bsol;n' back to '\n' to maintain the intended behavior.


Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
 [#4674](https://github.com/monkeytypegame/monkeytype/issues/4674) Escaping characters not being treated as raw string literals in quote mode 