### PR TITLE
refactor(profile): notify that fields are too long before making a request to the server (sanidhyas3s)

### DIFF
--- a/frontend/src/ts/popups/edit-profile-popup.ts
+++ b/frontend/src/ts/popups/edit-profile-popup.ts
@@ -132,6 +132,31 @@ async function updateProfile(): Promise<void> {
   if (!snapshot) return;
   const updates = buildUpdatesFromInputs();
 
+  // check for length resctrictions before sending server requests
+  const githubLengthLimit = 39;
+  const twitterLengthLimit = 20;
+  if (
+    updates.socialProfiles.github &&
+    updates.socialProfiles.github.length > githubLengthLimit
+  ) {
+    Notifications.add(
+      `GitHub username exceeds maximum allowed length (${githubLengthLimit} characters).`,
+      -1
+    );
+    return;
+  }
+
+  if (
+    updates.socialProfiles.twitter &&
+    updates.socialProfiles.twitter.length > twitterLengthLimit
+  ) {
+    Notifications.add(
+      `Twitter username exceeds maximum allowed length (${twitterLengthLimit} characters).`,
+      -1
+    );
+    return;
+  }
+
   Loader.show();
   const response = await Ape.users.updateProfile(
     updates,

--- a/frontend/src/ts/popups/edit-profile-popup.ts
+++ b/frontend/src/ts/popups/edit-profile-popup.ts
@@ -134,7 +134,6 @@ async function updateProfile(): Promise<void> {
 
   // check for length resctrictions before sending server requests
   const githubLengthLimit = 39;
-  const twitterLengthLimit = 20;
   if (
     updates.socialProfiles.github &&
     updates.socialProfiles.github.length > githubLengthLimit
@@ -146,6 +145,7 @@ async function updateProfile(): Promise<void> {
     return;
   }
 
+  const twitterLengthLimit = 20;
   if (
     updates.socialProfiles.twitter &&
     updates.socialProfiles.twitter.length > twitterLengthLimit


### PR DESCRIPTION
Length checks for GitHub and Twitter are now made before sending server requests. Appropriate notifications are displayed, ~~while continuing the rest of the profile update~~.

Tested with different combinations of updates.

Closes #4653 
