### PR TITLE
fix: Rework 'revoke all tokens' flow

### DIFF
--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -25,6 +25,7 @@ import { ObjectId } from "mongodb";
 import * as ReportDAL from "../../dal/report";
 import emailQueue from "../../queues/email-queue";
 import FirebaseAdmin from "../../init/firebase-admin";
+import { removeTokensFromCache } from "../../utils/auth";
 
 async function verifyCaptcha(captcha: string): Promise<void> {
   if (!(await verify(captcha))) {
@@ -897,5 +898,6 @@ export async function revokeAllTokens(
 ): Promise<MonkeyResponse> {
   const { uid } = req.ctx.decodedToken;
   await FirebaseAdmin().auth().revokeRefreshTokens(uid);
+  await removeTokensFromCache(uid);
   return new MonkeyResponse("All tokens revoked");
 }

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -58,3 +58,11 @@ export async function updateUserEmail(
     emailVerified: false,
   });
 }
+
+export async function removeTokensFromCache(uid: string): Promise<void> {
+  for (const entry of tokenCache.entries()) {
+    if (entry[1].uid === uid) {
+      tokenCache.delete(entry[0]);
+    }
+  }
+}


### PR DESCRIPTION
### Description
This pull request introduces a new function that plays a crucial role in the operation of the "revoke all tokens" endpoint. The primary purpose of this function is to efficiently iterate through cached authentication tokens and identify and remove all tokens associated with a specific user ID.

It's worth noting that the solution implemented here differs from the one originally discussed in the related issue. Instead, this approach aligns with the approach detailed in the [Discord conversation](https://discord.com/channels/713194177403420752/713196019206324306/1161694629926801468), ensuring a more effective resolution.

Closes [#4684](https://github.com/monkeytypegame/monkeytype/issues/4684)