### PR TITLE
impr(result): rework burst heatmap speed brackets (keenemeck)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1104,20 +1104,6 @@ export async function applyBurstHeatmap(): Promise<void> {
       burstlist[index] = Math.round(typingSpeedUnit.fromWpm(burst));
     });
 
-    if (
-      TestInput.input.getHistory(TestInput.input.getHistory().length - 1)
-        ?.length !== TestWords.words.getCurrent()?.length
-    ) {
-      burstlist = burstlist.splice(0, burstlist.length - 1);
-    }
-
-    const median = Misc.median(burstlist);
-    const adatm: number[] = [];
-    burstlist.forEach((burst) => {
-      adatm.push(Math.abs(median - burst));
-    });
-    const step = Misc.mean(adatm);
-
     const themeColors = await ThemeColors.getAll();
 
     let colors = [
@@ -1144,25 +1130,28 @@ export async function applyBurstHeatmap(): Promise<void> {
       unreachedColor = themeColors.subAlt;
     }
 
+    const burstlistSorted = burstlist.sort((a, b) => a - b);
+    const burstlistLength = burstlist.length;
+
     const steps = [
       {
         val: 0,
         colorId: 0,
       },
       {
-        val: median - step * 1.5,
+        val: burstlistSorted[(burstlistLength * 0.15) | 0],
         colorId: 1,
       },
       {
-        val: median - step * 0.5,
+        val: burstlistSorted[(burstlistLength * 0.35) | 0],
         colorId: 2,
       },
       {
-        val: median + step * 0.5,
+        val: burstlistSorted[(burstlistLength * 0.65) | 0],
         colorId: 3,
       },
       {
-        val: median + step * 1.5,
+        val: burstlistSorted[(burstlistLength * 0.85) | 0],
         colorId: 4,
       },
     ];
@@ -1172,11 +1161,15 @@ export async function applyBurstHeatmap(): Promise<void> {
       if (index === 0) {
         string = `<${Math.round(steps[index + 1].val)}`;
       } else if (index === 4) {
-        string = `${Math.round(step.val - 1)}+`;
+        string = `${Math.round(step.val)}+`;
       } else {
-        string = `${Math.round(step.val)}-${
-          Math.round(steps[index + 1].val) - 1
-        }`;
+        if (step.val != steps[index + 1].val) {
+          string = `${Math.round(step.val)}-${
+            Math.round(steps[index + 1].val) - 1
+          }`;
+        } else {
+          string = `${Math.round(step.val)}-${Math.round(step.val)}`;
+        }
       }
 
       $("#resultWordsHistory .heatmapLegend .box" + index).html(


### PR DESCRIPTION
fix for #4678

Indexes values to create uniform distribution, and prevents negative values from existing in burstmap.

Ranges can be modified by changing the decimal values; current distribution is below and appears similar to what is currently used.

<15%, 15%-35%, 35%-65%, 65%-85%, 85%+
where the percentages refer to the amount of words in a given range
i.e. the lowest ~15% of words are in the lowest range, and the next 20% are the in next, etc.

I believe it's less computationally expensive as well, so there's that.