### PR TITLE
docs: add one key step to configure Firebase

### DIFF
--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -82,7 +82,7 @@ Within the `frontend/src/ts/constants` directory, duplicate `firebase-config-exa
   3. In the `SDK setup and configuration` section, select `npm`
   4. The Firebase config will be visible below
   5. Paste the config into `firebase-config.ts`
-  6. Add `export` statement before `const firebaseConfig`
+  6. Ensure there is an `export` statement before `const firebaseConfig`
 
 If you want to access the frontend from other machines on your network create a file `frontend/.env` with this content:
 

--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -82,6 +82,7 @@ Within the `frontend/src/ts/constants` directory, duplicate `firebase-config-exa
   3. In the `SDK setup and configuration` section, select `npm`
   4. The Firebase config will be visible below
   5. Paste the config into `firebase-config.ts`
+  6. Add `export` statement before `const firebaseConfig`
 
 If you want to access the frontend from other machines on your network create a file `frontend/.env` with this content:
 


### PR DESCRIPTION
### Description
Building with no `export` statement will result following output: 
```
monkeytype-frontend  | [0] ERROR in /monkeytype/frontend/src/ts/firebase.ts
monkeytype-frontend  | [0] ./src/ts/firebase.ts 4:9-23
monkeytype-frontend  | [0] [tsl] ERROR in /monkeytype/frontend/src/ts/firebase.ts(4,10)
monkeytype-frontend  | [0]       TS2459: Module '"./constants/firebase-config"' declares 'firebaseConfig' locally, but it is not exported.
monkeytype-frontend  | [0] ts-loader-default_e3b0c44298fc1c14
monkeytype-frontend  | [0]  @ ./src/ts/index.ts 27:0-21
monkeytype-frontend  | [0] 
monkeytype-frontend  | [0] ERROR in /monkeytype/frontend/src/ts/firebase.ts
monkeytype-frontend  | [0] ./src/ts/firebase.ts 4:9-23
monkeytype-frontend  | [0] [tsl] ERROR in /monkeytype/frontend/src/ts/firebase.ts(4,10)
monkeytype-frontend  | [0]       TS2459: Module '"./constants/firebase-config"' declares 'firebaseConfig' locally, but it is not exported.
monkeytype-frontend  | [0] ts-loader-default_e3b0c44298fc1c14
monkeytype-frontend  | [0]  @ ./src/ts/index.ts 27:0-21
monkeytype-frontend  | [0] 
monkeytype-frontend  | [0] webpack 5.72.0 compiled with 2 errors in 17856 ms
```
After I added `export`, the project can be built successfully. 