### PR TITLE
Added discord blurple theme

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1181,6 +1181,11 @@
     "mainColor": "#363636",
     "subColor": "#4f4f4f",
     "textColor": "#1f1f1f"
+  ,{
+    "name": "discord_blurple",
+    "bgColor": "#454FBF",
+    "mainColor": "#00ffff"
+}
   }
 
 ]

--- a/frontend/static/themes/discord_blurple.css
+++ b/frontend/static/themes/discord_blurple.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #454FBF;
+    --main-color: #00ffff;
+    --caret-color: #00ffff;
+    --sub-color: #3b3b3b;
+    --sub-alt-color: #3b3b3b;
+    --text-color: #ffffff;
+    --error-color: #ff0000;
+    --error-extra-color: #ff0000;
+    --colorful-error-color: #ffffff;
+    --colorful-error-extra-color: #ffffff;
+  }


### PR DESCRIPTION
<!-- Adding a language or a theme?
For languages, make sure to edit the `_list.json`, `_groups.json` files, and add the `language.json` file as well.
 For themes, make sure to add the `theme.css` file. It will not work if you don't follow these steps!

If your change is visual (mainly themes) it would be extra awesome if you could include a screenshot.

 -->

### Description

Added a theme "**discord blurple**" where it uses discord's blurple color seen in the app icon.
Since i always open it every day i decided to try to (attempt to) contribute to this

For the screenshots, idk maybe itll look as good as the "**_our_** theme"

yeah thats all i have to say i just pressed the windows key for no reason now



Closes # <-- what do i do with this
