### PR TITLE
fix(result page): cannot take screenshot if crt funbox is active (fehmer)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -429,6 +429,9 @@ export async function screenshot(): Promise<void> {
     }
     (document.querySelector("html") as HTMLElement).style.scrollBehavior =
       "smooth";
+    FunboxList.get(Config.funbox).forEach((f) =>
+      f.functions?.applyGlobalCSS?.()
+    );
   }
 
   if (!$("#resultReplay").hasClass("hidden")) {
@@ -464,6 +467,8 @@ export async function screenshot(): Promise<void> {
   $(".wordInputHighlight").addClass("hidden");
   $(".highlightContainer").addClass("hidden");
   if (revertCookie) $("#cookiePopupWrapper").addClass("hidden");
+
+  FunboxList.get(Config.funbox).forEach((f) => f.functions?.clearGlobal?.());
 
   (document.querySelector("html") as HTMLElement).style.scrollBehavior = "auto";
   window.scrollTo({


### PR DESCRIPTION
### Description

Screenshot is not working if funbox crt is enabled because html2canvas does not support  "modern" css color functions.

See https://github.com/niklasvh/html2canvas/issues/2700

As workaround disable globalCss before taking the screenshot and apply it after.

Closes #4754
