### PR TITLE
chore: add tests for authentication on public endpoints

### DIFF
--- a/backend/__tests__/middlewares/auth.spec.ts
+++ b/backend/__tests__/middlewares/auth.spec.ts
@@ -93,5 +93,41 @@ describe("middlewares/auth", () => {
       expect(decodedToken?.uid).toBe(mockDecodedToken.uid);
       expect(nextFunction).toHaveBeenCalledTimes(1);
     });
+    it("should allow the request with authentation on public endpoint", async () => {
+      const authenticateRequest = Auth.authenticateRequest({
+        isPublic: true,
+      });
+
+      await authenticateRequest(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      const decodedToken = mockRequest?.ctx?.decodedToken;
+      expect(decodedToken?.type).toBe("Bearer");
+      expect(decodedToken?.email).toBe(mockDecodedToken.email);
+      expect(decodedToken?.uid).toBe(mockDecodedToken.uid);
+      expect(nextFunction).toHaveBeenCalledTimes(1);
+    });
+    it("should allow the request without authentication on public endpoint", async () => {
+      mockRequest.headers = {};
+
+      const authenticateRequest = Auth.authenticateRequest({
+        isPublic: true,
+      });
+
+      await authenticateRequest(
+        mockRequest as Request,
+        mockResponse as Response,
+        nextFunction
+      );
+
+      const decodedToken = mockRequest?.ctx?.decodedToken;
+      expect(decodedToken?.type).toBe("None");
+      expect(decodedToken?.email).toBe("");
+      expect(decodedToken?.uid).toBe("");
+      expect(nextFunction).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Add test to cover the authentication on public endpoints.

Covers changes of
- https://github.com/monkeytypegame/monkeytype/commit/e3ce7b2458c6b6d52a402d402f7413d795fe675b
- https://github.com/monkeytypegame/monkeytype/commit/923f69ab55e1eae9c4e5e2eff31f27d96cf4416c