### PR TITLE
feat: add mode that doubles each letter to funbox

### DIFF
--- a/backend/src/constants/funbox-list.ts
+++ b/backend/src/constants/funbox-list.ts
@@ -331,6 +331,13 @@ const FunboxList: MonkeyTypes.FunboxMetadata[] = [
     canGetPb: true,
     difficultyLevel: 3,
   },
+  {
+    canGetPb: true,
+    difficultyLevel: 0,
+    properties: ["noLigatures"],
+    frontendFunctions: ["alterText"],
+    name: "ddoouubblleedd",
+  },
 ];
 
 export default FunboxList;

--- a/backend/src/constants/funbox-list.ts
+++ b/backend/src/constants/funbox-list.ts
@@ -333,7 +333,7 @@ const FunboxList: MonkeyTypes.FunboxMetadata[] = [
   },
   {
     canGetPb: true,
-    difficultyLevel: 0,
+    difficultyLevel: 1,
     properties: ["noLigatures"],
     frontendFunctions: ["alterText"],
     name: "ddoouubblleedd",

--- a/frontend/src/ts/test/funbox/funbox-list.ts
+++ b/frontend/src/ts/test/funbox/funbox-list.ts
@@ -255,6 +255,11 @@ const list: MonkeyTypes.FunboxMetadata[] = [
       "wordOrder:reverse",
     ],
   },
+  {
+    name: "ddoouubblleedd",
+    info: "TTyyppee eevveerryytthhiinngg ttwwiiccee..",
+    properties: ["noLigatures"],
+  },
 ];
 
 export function getAll(): MonkeyTypes.FunboxMetadata[] {

--- a/frontend/src/ts/test/funbox/funbox.ts
+++ b/frontend/src/ts/test/funbox/funbox.ts
@@ -505,6 +505,12 @@ FunboxList.setFunboxFunctions("zipf", {
   },
 });
 
+FunboxList.setFunboxFunctions("ddoouubblleedd", {
+  alterText(word: string): string {
+    return word.replace(/./gu, "$&$&");
+  },
+});
+
 export function toggleScript(...params: string[]): void {
   FunboxList.get(Config.funbox).forEach((funbox) => {
     if (funbox.functions?.toggleScript) funbox.functions.toggleScript(params);

--- a/frontend/static/funbox/_list.json
+++ b/frontend/static/funbox/_list.json
@@ -180,5 +180,10 @@
     "name": "backwards",
     "info": "...sdrawkcab epyt ot yrt woN",
     "canGetPb": true
+  },
+  {
+    "name": "ddoouubblleedd",
+    "info": "TTyyppee eevveerryytthhiinngg ttwwiiccee..",
+    "canGetPb": true
   }
 ]


### PR DESCRIPTION
### Description

This PR adds a new mode, `ddoouubblleedd`, that causes each letter of each word to be repeated.

I noticed some issues with compatibility detection while implementing this feature. I have chosen to be consistent with the existing state of affairs instead of trying to correct everything in one PR.

- The words produced by the mode are not understandable when pronounced by TTS. However, setting the `unspeakable` property makes the mode incompatible with all other unspeakable modes, which is not desirable. I have not marked the mode as `unspeakable` to be consistent with the existing `backwords` rule, which is also not `unspeakable` despite producing unintelligible text.
- This mode and all other modes that use `alterText`, such as `backwards`, `capitals`, and `rAnDoMcAsE`, are considered to be compatible with modes that overwrite the text using `pullSection` (`poetry` and `wikipedia`) despite being completely broken by these modes. `alterText` is never called for text generated by `pullSection`, and the modes have no effect. Fixing this should simply mean ensuring that `alterText` and `pullSection` modes are never used at the same time.