### PR TITLE
feat: Update _list.json to add Portuguese from Portugal layouts, both ISO and ANSI (diogozarro)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1616,6 +1616,28 @@
     "row5": [" "]
     }
   },
+  "portuguese_pt_qwerty_iso":{
+    "keymapShowTopRow": false,
+    "type": "iso",
+    "keys": {
+      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "«»"],
+      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`"],
+      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª", "~^"],
+      "row4": ["<>", "zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
+      "row5": [" "]
+    }
+  },
+  "portuguese_pt_qwerty_ansi":{
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "<>"],
+      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`", "~^"],
+      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª"],
+      "row4": ["zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
+      "row5": [" "]
+    }
+  },
   "swedish_qwerty": {
     "keymapShowTopRow": false,
     "matrixShowRightColumn": true,

--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -120,28 +120,6 @@
       "row5": [" "]
     }
   },
-  "portuguese_pt_qwerty_iso":{
-    "keymapShowTopRow": false,
-    "type": "iso",
-    "keys": {
-      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "«»"],
-      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`"],
-      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª", "~^"],
-      "row4": ["<>", "zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
-      "row5": [" "]
-    }
-  },
-  "portuguese_pt_qwerty_ansi":{
-    "keymapShowTopRow": false,
-    "type": "ansi",
-    "keys": {
-      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "<>"],
-      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`", "~^"],
-      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª"],
-      "row4": ["zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
-      "row5": [" "]
-    }
-  },
   "qwertz": {
     "keymapShowTopRow": false,
     "type": "iso",

--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -120,6 +120,28 @@
       "row5": [" "]
     }
   },
+  "portuguese_pt_qwerty_iso":{
+    "keymapShowTopRow": false,
+    "type": "iso",
+    "keys": {
+      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "«»"],
+      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`"],
+      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª", "~^"],
+      "row4": ["<>", "zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
+      "row5": [" "]
+    }
+  },
+  "portuguese_pt_qwerty_ansi":{
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["\\|", "1!", "2\"", "3#", "4$", "5%", "6&", "7/", "8(", "9)", "0=", "'?", "<>"],
+      "row2": ["qQ", "wW", "eE", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "+*", "´`", "~^"],
+      "row3": ["aA", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "çÇ", "ºª"],
+      "row4": ["zZ", "xX", "cC", "vV", "bB", "nN", "mM", ",;", ".:", "-_"],
+      "row5": [" "]
+    }
+  },
   "qwertz": {
     "keymapShowTopRow": false,
     "type": "iso",


### PR DESCRIPTION
### Description


Added Portuguese from Portugal qwerty layouts, both ISO and ANSI
![image](https://github.com/monkeytypegame/monkeytype/assets/45295000/4f7626c0-2873-4b5f-8d0e-8f31992d31bb)

