### PR TITLE
impr: add backtick in javascript language when punctuation is enabled (ascodeasice)

### DIFF
--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -229,7 +229,11 @@ export async function punctuateWord(
     ) {
       word = Misc.randomElementFromArray(specialsC);
     } else {
-      word = Misc.randomElementFromArray(specials);
+      if (Config.language.startsWith("code_javascript")) {
+        word = Misc.randomElementFromArray([...specials, "`"]);
+      } else {
+        word = Misc.randomElementFromArray(specials);
+      }
     }
   } else if (
     Math.random() < 0.5 &&

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -123,6 +123,11 @@ export async function punctuateWord(
       const r = Math.random();
       const brackets = ["()", "{}", "[]", "<>"];
 
+      // add `word` in javascript
+      if (Config.language.startsWith("code_javascript")) {
+        brackets.push("``");
+      }
+
       const index = Math.floor(r * brackets.length);
       const bracket = brackets[index];
 

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -121,15 +121,12 @@ export async function punctuateWord(
   } else if (Math.random() < 0.012 && lastChar !== "," && lastChar !== ".") {
     if (currentLanguage === "code") {
       const r = Math.random();
-      if (r < 0.25) {
-        word = `(${word})`;
-      } else if (r < 0.5) {
-        word = `{${word}}`;
-      } else if (r < 0.75) {
-        word = `[${word}]`;
-      } else {
-        word = `<${word}>`;
-      }
+      const brackets = ["()", "{}", "[]", "<>"];
+
+      const index = Math.floor(r * brackets.length);
+      const bracket = brackets[index];
+
+      word = `${bracket[0]}${word}${bracket[1]}`;
     } else {
       word = `(${word})`;
     }


### PR DESCRIPTION
### Description

This PR makes that: 
When using `code_javascript` or `code_javascript_1k` language with punctuation, the word can contain
- \`word-wrapped-in-ticks\` 
- `   (single tick as a word)

This code changes the `punctuateWord` function, adding some conditions for javascript language.

### Checks

- [x] Adding a language or a theme?
    - [x] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
    - [x] If is a theme, did you add the theme.css?
        - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside round brackets at the end of the PR title

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
