### PR TITLE
fix: prepone non-ascii characters removal for Wikipedia (FortPile)

### DIFF
--- a/frontend/src/ts/test/wikipedia.ts
+++ b/frontend/src/ts/test/wikipedia.ts
@@ -106,15 +106,16 @@ export async function getSection(language: string): Promise<Section> {
           // Remove invisible characters
           sectionText = sectionText.replace(/[\u200B-\u200D\uFEFF]/g, "");
 
+          // Remove non-ascii characters for English articles
+          if (urlTLD === "en") {
+            sectionText = sectionText.replace(/[^\x20-\x7E]+/g, "");
+          }
+
           // Convert all whitespace to space
           sectionText = sectionText.replace(/\s+/g, " ");
 
           // Removing whitespace before and after text
           sectionText = sectionText.trim();
-
-          if (urlTLD === "en") {
-            sectionText = sectionText.replace(/[^\x20-\x7E]+/g, "");
-          }
 
           const words = sectionText.split(" ");
 


### PR DESCRIPTION
### Description

Very simple.

When using the Wikipedia funbox, there would be occasional consecutive spaces (like '  '). As you would have guessed, the cursor glitched in the event of one.
This (from my observations) is caused by the algorithm after fetching having to remove all non-ASCII characters (most notably '–' involved with dates) AFTER cleaning whitespaces with the regex `/\s+/g`.
This process is now moved back.

I'm pretty sure this is the only source causing this issue. Otherwise, we could also clear all elements of `words` with an empty string after `const words = sectionText.split(" ");`.

### Checks

- [ ] Adding a language or a theme?
    - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
    - [ ] If is a theme, did you add the theme.css?
        - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside round brackets at the end of the PR title