### PR TITLE
impr: remove non-profane word

### DIFF
--- a/backend/src/constants/profanities.ts
+++ b/backend/src/constants/profanities.ts
@@ -297,7 +297,6 @@ export const profanities = [
   "chraa",
   "chuj",
   "cunt",
-  "d4mn",
   "daygo",
   "dego",
   "dick",


### PR DESCRIPTION
### Description

removed "d4mn" (previously excluded "damn") for consistency.