### PR TITLE
perf: Improve leaderboard performance by adding better index (fehmer)

### DIFF
--- a/backend/src/dal/leaderboards.ts
+++ b/backend/src/dal/leaderboards.ts
@@ -265,7 +265,7 @@ async function createIndex(key: string): Promise<void> {
   await db.collection("users").createIndex(index, partial);
 }
 
-export async function setup(): Promise<void> {
+export async function createIndicies(): Promise<void> {
   await createIndex("lbPersonalBests.time.15.english");
   await createIndex("lbPersonalBests.time.60.english");
 }

--- a/backend/src/dal/leaderboards.ts
+++ b/backend/src/dal/leaderboards.ts
@@ -138,7 +138,7 @@ export async function update(
           },
         },
       ],
-      { allowDiskUse: false }
+      { allowDiskUse: true }
     )
     .toArray();
   const end1 = performance.now();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,7 +13,7 @@ import Logger from "./utils/logger";
 import * as EmailClient from "./init/email-client";
 import { init as initFirebaseAdmin } from "./init/firebase-admin";
 
-import { setup as leaderboardDbSetup } from "./dal/leaderboards";
+import { createIndicies as leaderboardDbSetup } from "./dal/leaderboards";
 
 async function bootServer(port: number): Promise<Server> {
   try {
@@ -65,7 +65,7 @@ async function bootServer(port: number): Promise<Server> {
     jobs.forEach((job) => job.start());
     Logger.success("Cron jobs started");
 
-    Logger.info("Setup leaderboard...");
+    Logger.info("Setting up leaderboard indicies...");
     await leaderboardDbSetup();
 
     recordServerVersion(version);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,8 @@ import Logger from "./utils/logger";
 import * as EmailClient from "./init/email-client";
 import { init as initFirebaseAdmin } from "./init/firebase-admin";
 
+import { setup as leaderboardDbSetup } from "./dal/leaderboards";
+
 async function bootServer(port: number): Promise<Server> {
   try {
     Logger.info(`Starting server version ${version}`);
@@ -62,6 +64,9 @@ async function bootServer(port: number): Promise<Server> {
     Logger.info("Starting cron jobs...");
     jobs.forEach((job) => job.start());
     Logger.success("Cron jobs started");
+
+    Logger.info("Setup leaderboard...");
+    await leaderboardDbSetup();
 
     recordServerVersion(version);
   } catch (error) {


### PR DESCRIPTION
### Description

Add a partial index for each leaderboard containing all users appicable for that leaderboard. The index covers all fields used by the query/result   (covered query), so .we don't need to fetch any documents. The index is pre-sorted by the correct fields (wpm, app, timestamp) so there is no sorting to be done during the query.
