### PR TITLE
fix(about): "amount" to "number" (borisnezlobin)

### DIFF
--- a/frontend/static/html/pages/about.html
+++ b/frontend/static/html/pages/about.html
@@ -99,7 +99,7 @@
   <div class="section">
     <div class="title">stats</div>
     <p>
-      wpm - total amount of characters in the correctly typed words (including
+      wpm - total number of characters in the correctly typed words (including
       spaces), divided by 5 and normalised to 60 seconds.
     </p>
     <p>


### PR DESCRIPTION
### Description
Change "amount" to "number" on About page (# of characters is countable)
<img width="350" alt="image" src="https://github.com/monkeytypegame/monkeytype/assets/146669165/6a534f8e-14a9-4132-89e6-8defa109f62e">


### Checks

- [ ] Adding a language or a theme?
    - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
    - [ ] If is a theme, did you add the theme.css?
        - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
    - none related
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside round brackets at the end of the PR title