### PR TITLE
fix: update the background image and hide the scrollbar in the funbox space_balls (yunfachi)

### DIFF
--- a/frontend/static/funbox/space_balls.css
+++ b/frontend/static/funbox/space_balls.css
@@ -17,9 +17,10 @@ body {
 }
 
 main {
-  transform: rotateX(35deg);
+  perspective: 500px;
+  overflow: hidden;
 }
 
-#contentWrapper {
-  perspective: 500px;
+main .page {
+  transform: rotateX(35deg);
 }

--- a/frontend/static/funbox/space_balls.css
+++ b/frontend/static/funbox/space_balls.css
@@ -11,7 +11,7 @@
 }
 
 body {
-  background-image: url("https://thumbs.gfycat.com/SlimyClassicAsianconstablebutterfly-size_restricted.gif");
+  background-image: url("https://media0.giphy.com/media/5VD0q2EDp2gvNQVCIN/giphy.gif");
   background-size: cover;
   background-position: center;
 }


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->

### Checks

- [ ] Adding a language or a theme?
    - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
    - [ ] If is a theme, did you add the theme.css?
        - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->

The first commit updates the background image URL, resolving an issue where the previous GIF was not loading due to the gfycat service being discontinued.
The second commit hides the Y-axis scrollbar that appears after rotating the page using `transform: rotateX(35deg);`.