### PR TITLE
fix: remove invalid java keyword  (fehmer)

### DIFF
--- a/frontend/static/languages/code_java.json
+++ b/frontend/static/languages/code_java.json
@@ -60,7 +60,6 @@
     "put",
     "set",
     "with",
-    "throwas",
     "build",
     "add",
     "subtract",


### PR DESCRIPTION
### Description

`throwas` is not a java keyword.