### PR TITLE
feat: show users login email on accounts page (fehmer)

### DIFF
--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -124,6 +124,7 @@ export async function initSnapshot(): Promise<
     snap.maxStreak = userData?.streak?.maxLength ?? 0;
     snap.filterPresets = userData.resultFilterPresets ?? [];
     snap.isPremium = userData?.isPremium;
+    snap.email = userData?.email;
 
     const hourOffset = userData?.streak?.hourOffset;
     snap.streakHourOffset =

--- a/frontend/src/ts/elements/profile.ts
+++ b/frontend/src/ts/elements/profile.ts
@@ -68,7 +68,10 @@ export async function update(
     details.find(".allBadges").empty().append(restHtml);
   }
 
-  details.find(".name").text(profile.name);
+  details
+    .find(".name")
+    .text(profile.name)
+    .attr("aria-label", profile.email ?? "");
 
   if (banned) {
     details

--- a/frontend/src/ts/types/types.d.ts
+++ b/frontend/src/ts/types/types.d.ts
@@ -608,6 +608,7 @@ declare namespace MonkeyTypes {
     streakHourOffset?: number;
     lbOptOut?: boolean;
     isPremium?: boolean;
+    email?: string;
   }
 
   interface UserDetails {

--- a/frontend/static/html/pages/account.html
+++ b/frontend/static/html/pages/account.html
@@ -29,7 +29,7 @@
             <div class="avatar"></div>
           </div>
           <div>
-            <div class="name">-</div>
+            <div class="name" data-balloon-pos="up">-</div>
             <div class="badges"></div>
             <div class="allBadges"></div>
             <div class="joined" data-balloon-pos="up">-</div>


### PR DESCRIPTION
### Description

Add users login/email address as tooltip on the name on the accounts page. 

This would help if users forgot their login email but are still logged in.

![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/544fcdd6-1f1b-45af-af74-ec6aea5f2b39)
