### PR TITLE
fix: ligatures not displayed correctly with dark_note theme  (fehmer)

### DIFF
--- a/frontend/static/themes/dark_note.css
+++ b/frontend/static/themes/dark_note.css
@@ -111,7 +111,7 @@ body::before {
   position: relative;
 }
 
-#wordsWrapper .word letter::after {
+#words:not(.withLigatures) .word letter::after {
   content: "";
   position: absolute;
   top: 50%;


### PR DESCRIPTION
### Description

Workaround for #4913.
