### PR TITLE
test: add test to remove accents in lazy mode

### DIFF
--- a/frontend/__tests__/test/lazy-mode.spec.ts
+++ b/frontend/__tests__/test/lazy-mode.spec.ts
@@ -16,6 +16,10 @@ describe("lazy-mode", () => {
       const result = replaceAccents("Héllö", [["ö", "oe"]]);
       expect(result).toBe("Helloe");
     });
+    it("should remove accent if empty", () => {
+      const result = replaceAccents("خصوصًا", [["ٌ", ""]]);
+      expect(result).toBe("خصوصا");
+    });
     it("should ignore empty word", () => {
       const result = replaceAccents("");
       expect(result).toBe("");


### PR DESCRIPTION
### Description

Test for bug in lazy mode not removing accents if the replacement is empty. Fix in commit 1c8b5ff
