### PR TITLE
feat(layouts): add graphite_angle_vc (rdavison)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1716,6 +1716,17 @@
       "row5": [" "]
     }
 },
+  "graphite_angle_vc": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "[{", "]}"],
+      "row2": ["bB", "lL", "dD", "wW", "zZ", "'_", "fF", "oO", "uU", "jJ", ";:", "=+", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", ",?"],
+      "row4": ["qQ", "mM", "vV", "cC", "xX", "pP", "kK", ".>", "-\"", "/<"],
+      "row5": [" "]
+    }
+  },
   "graphite_angle_kp": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
Added graphite_angle_vc layout to layout emulator.

This is a variant of graphite which is very well optimized for users who are not interested in ever using an ergonomic keyboard. It includes the PK swap on the right hand, the VC swap on the left hand, an XQ swap on the left hand, and then an angle mod which moves X to the center of the keyboard.

The purpose of the VC swap is to leave the C in the original graphite position. This position is very nice for preserving alt fingering compatibility on SC (you can use LM LI). A benefit of having X in the middle of the board is that it is easy to alt XC with LI LM. Also, since this version of the layout is really intended for row stagger keyboards, the position of the letter X on the qwerty B key means that it should be equidistant on both hands, meaning you can also use the right index to break the nasty XT lateral stretch in trigrams like EXT (using RR RI LM instead of RR LI LM).

The PK swap allows one to easily alt PH in the same way as they would SC on the left hand.