### PR TITLE
fix: typo in spanish quote id 154 (TortitasT)

### DIFF
--- a/frontend/static/quotes/spanish.json
+++ b/frontend/static/quotes/spanish.json
@@ -886,7 +886,7 @@
     {
       "text": "La vida es como montar en bicicleta. Para mantener el equilibrio tienes que avanzar.",
       "source": "Albert Einstein",
-      "length": 83,
+      "length": 84,
       "id": 154
     },
     {

--- a/frontend/static/quotes/spanish.json
+++ b/frontend/static/quotes/spanish.json
@@ -884,7 +884,7 @@
       "id": 153
     },
     {
-      "text": "La vida es como montar en bicicleta. Para mantener el equilibrio tienes que avanza.",
+      "text": "La vida es como montar en bicicleta. Para mantener el equilibrio tienes que avanzar.",
       "source": "Albert Einstein",
       "length": 83,
       "id": 154


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->
I added a letter that was missing from quote id 154 at the Spanish quotes file.

### Checks

- [ ] Adding a language or a theme?
    - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
    - [ ] If is a theme, did you add the theme.css?
        - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
