### PR TITLE
chore: configure vscode-jest extension (fehmer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ node_modules_bak/
 #vs code
 .vscode
 *.code-workspace
+!monkeytype.code-workspace
 
 .idea
 

--- a/monkeytype.code-workspace
+++ b/monkeytype.code-workspace
@@ -1,0 +1,26 @@
+{
+	"folders": [
+		{
+			"name":"backend",
+			"path":"backend",
+		},
+		{
+			"name":"frontend",
+			"path":"frontend",
+		},
+		{
+			"name":"root",
+			"path": "./"
+		}
+	],
+	"settings": {
+		 "files.exclude": {
+            "frontend": true,
+            "backend": true,
+        },
+        "jest.disabledWorkspaceFolders": [
+            "root"
+        ]
+		
+	}
+}


### PR DESCRIPTION
### Description

To use [jest extension](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest) in vscode some settings are needed. This PR add a workspace file. To get the extension to work open the workspace file in vscode.