### PR TITLE
fix(docker-compose): use the user "node" for the frontend container (dirk-hub)

### DIFF
--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -7,4 +7,5 @@ services:
       - "3000:3000"
     volumes:
       - ../:/monkeytype
+    user: node
     entrypoint: 'bash -c "cd /monkeytype && npm run dev-fe"'


### PR DESCRIPTION
### Description

add `user: node` to the `docker-compose.yaml` so docker uses that user instead of the root user when bringing up the container, this makes npm have appropriate rights

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title
