### PR TITLE
fix(privacy-policy): Remove incorrect date in privacy policy (kacperwyczawski)

### DIFF
--- a/frontend/static/privacy-policy.html
+++ b/frontend/static/privacy-policy.html
@@ -394,8 +394,7 @@
         <p>
           Monkeytype keeps its privacy policy under regular review and places
           any updates on this web page. The Monkeytype privacy policy may be
-          subject to change at any given time without notice. This privacy
-          policy was last updated on 27 September 2022.
+          subject to change at any given time without notice.
         </p>
         <!-- TODO: add way to view when file was last committed to using the GitHub api-->
 


### PR DESCRIPTION
### Description

I removed incorrect date in privacy policy. Correct one is on the top of the page ([line 117](https://github.com/monkeytypegame/monkeytype/blob/0751375ab6bc9b43bffeab28d407a06504ea1269/frontend/static/privacy-policy.html#L117)).

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [ ] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [ ] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->



<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
