### PR TITLE
Create code_css.json impr(quotes)

### DIFF
--- a/frontend/static/code_css.json
+++ b/frontend/static/code_css.json
@@ -1,0 +1,17 @@
+{
+  "language": "code_css",
+  "groups": [
+    [0, 100],
+    [101, 300],
+    [301, 600],
+    [601, 9999]
+  ],
+  "quotes": [
+  {
+    "text": ".container {display: flex; justify-content: center; align-items: center; height: 100vh; flex-direction: row;}",
+    "source": "puts things in center using flexbox :)",
+    "id": 1,
+    "length": 109
+  }
+  ]
+}


### PR DESCRIPTION
### I added a quote for code-css which says
`
.container {display: flex; justify-content: center; align-items: center; height: 100vh; flex-direction: row;}
`
### because there was no css quotes