### PR TITLE
fix: ape key popup close button (andGuo)

### DIFF
--- a/frontend/src/ts/popups/simple-popups.ts
+++ b/frontend/src/ts/popups/simple-popups.ts
@@ -262,7 +262,7 @@ class SimplePopup {
   exec(): void {
     if (!this.canClose) return;
     const vals: string[] = [];
-    $.each($("#simplePopup input"), (_, el) => {
+    $.each($("#simplePopup input, #simplePopup textarea"), (_, el) => {
       if ($(el).is(":checkbox")) {
         vals.push($(el).is(":checked") ? "true" : "false");
       } else {
@@ -1363,10 +1363,10 @@ list["viewApeKey"] = new SimplePopup(
   (_thisPopup) => {
     _thisPopup.canClose = false;
     $("#simplePopup textarea").css("height", "110px");
-    $("#simplePopup .button").addClass("hidden");
+    $("#simplePopup .submitButton").addClass("hidden");
     setTimeout(() => {
       _thisPopup.canClose = true;
-      $("#simplePopup .button").removeClass("hidden");
+      $("#simplePopup .submitButton").removeClass("hidden");
     }, 5000);
   }
 );


### PR DESCRIPTION
### Description

- The current popup will not close since `<textarea>` tags are not scanned for input values. This made the popup form "incomplete". PR fixes this problem.
- Also made close button appear after timeout.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #

#5016

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
