### PR TITLE
fix: leaderboard discord properties being null  (fehmer)

### DIFF
--- a/backend/__tests__/dal/leaderboards.spec.ts
+++ b/backend/__tests__/dal/leaderboards.spec.ts
@@ -82,6 +82,26 @@ describe("LeaderboardsDal", () => {
         expectedLbEntry(4, rank4, "60"),
       ]);
     });
+    it("should not include discord properties for users without discord connection", async () => {
+      //GIVEN
+      const rank1 = await createUser(lbBests(pb(90), pb(100, 90, 2)), {
+        discordId: undefined,
+        discordAvatar: undefined,
+      });
+
+      //WHEN
+      await LeaderboardsDal.update("time", "60", "english");
+      const lb = (await LeaderboardsDal.get(
+        "time",
+        "60",
+        "english",
+        0
+      )) as SharedTypes.LeaderboardEntry[];
+
+      //THEN
+      expect(lb[0]).not.toHaveProperty("discordId");
+      expect(lb[0]).not.toHaveProperty("discordAvatar");
+    });
 
     it("should update public speedHistogram for time english 15", async () => {
       //GIVEN

--- a/backend/src/dal/leaderboards.ts
+++ b/backend/src/dal/leaderboards.ts
@@ -125,8 +125,12 @@ export async function update(
           $addFields: {
             [`${key}.uid`]: "$uid",
             [`${key}.name`]: "$name",
-            [`${key}.discordId`]: "$discordId",
-            [`${key}.discordAvatar`]: "$discordAvatar",
+            [`${key}.discordId`]: {
+              $ifNull: ["$discordId", "$$REMOVE"],
+            },
+            [`${key}.discordAvatar`]: {
+              $ifNull: ["$discordAvatar", "$$REMOVE"],
+            },
             [`${key}.rank`]: {
               $function: {
                 body: "function() {try {row_number+= 1;} catch (e) {row_number= 1;}return row_number;}",

--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -143,7 +143,7 @@ function updateFooter(lb: LbKey): void {
     side = "right";
   }
 
-  if (!Auth?.currentUser) {
+  if (Auth?.currentUser === undefined) {
     $(`#leaderboardsWrapper table.${side} tfoot`).html(`
     <tr>
       <td colspan="6" style="text-align:center;"></>
@@ -307,7 +307,6 @@ async function fillTable(lb: LbKey): Promise<void> {
     if (entry === undefined) {
       break;
     }
-    if (entry.hidden) return;
     let meClassString = "";
     if (entry.name === loggedInUserName) {
       meClassString = ' class="me"';
@@ -443,7 +442,7 @@ async function update(): Promise<void> {
   const lbRankRequests: Promise<
     Ape.HttpClientResponse<Ape.Leaderboards.GetRank>
   >[] = [];
-  if (Auth?.currentUser) {
+  if (Auth?.currentUser !== undefined) {
     lbRankRequests.push(
       ...timeModes.map(async (mode2) => {
         return Ape.leaderboards.getRank({
@@ -606,10 +605,7 @@ async function getAvatarUrls(
 ): Promise<(string | null)[]> {
   return Promise.allSettled(
     data.map(async (entry) =>
-      Misc.getDiscordAvatarUrl(
-        entry.discordId ?? undefined,
-        entry.discordAvatar ?? undefined
-      )
+      Misc.getDiscordAvatarUrl(entry.discordId, entry.discordAvatar)
     )
   ).then((promises) => {
     return promises.map((promise) => {
@@ -646,7 +642,7 @@ export function show(): void {
   }
   Skeleton.append(wrapperId);
   if (!Misc.isPopupVisible("leaderboardsWrapper")) {
-    if (Auth?.currentUser) {
+    if (Auth?.currentUser !== undefined) {
       $("#leaderboardsWrapper #leaderboards .rightTableJumpToMe").removeClass(
         "disabled"
       );

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1364,10 +1364,8 @@ export async function getDiscordAvatarUrl(
 ): Promise<string | null> {
   if (
     discordId === undefined ||
-    discordId === null ||
     discordId === "" ||
     discordAvatar === undefined ||
-    discordAvatar === null ||
     discordAvatar === ""
   ) {
     return null;

--- a/shared-types/types.d.ts
+++ b/shared-types/types.d.ts
@@ -448,11 +448,10 @@ declare namespace SharedTypes {
     consistency: number | "-";
     uid: string;
     name: string;
-    discordId: string | null | undefined;
-    discordAvatar: string | null | undefined;
+    discordId?: string;
+    discordAvatar?: string;
     rank: number;
     badgeId: number | null;
-    hidden?: boolean;
   }
 
   type PostResultResponse = {


### PR DESCRIPTION
### Description

`discordId` and `discordAvatar` should not be `null` on  `LeaderboardEntry`.