### PR TITLE
fix(language): two words concatenated on one line (penguin-teal)

### DIFF
--- a/frontend/static/languages/code_c.json
+++ b/frontend/static/languages/code_c.json
@@ -162,7 +162,7 @@
     "strncpy",
     "strcat",
     "strncat",
-    "strlenstrnlen_s",
+    "strlen",
     "strcmp",
     "strncmp",
     "strcoll",


### PR DESCRIPTION
### Description

Remove extra `strlen_s` concatenated onto the `strlen` (`strlenstrlen_s` isn't anything) in language Code C.