### PR TITLE
docs: correct navigation of Firebase > Build > Authentication > Sign-in UI (underscoore)

### DIFF
--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -46,7 +46,7 @@ The account system will not let you create an account without a Firebase project
 
 1. Enable Firebase Authentication
 
-   - In the Firebase console, go to `Authentication > Sign-in method`
+   - In the Firebase console, go to `Build > Authentication > Sign-in method`
    - Click on `Email/Password`, enable it, and save
    - Click on `Google`, add a support email, and save
 


### PR DESCRIPTION
### Description

The Firebase configuration section in [advance contribution](https://github.com/monkeytypegame/monkeytype/blob/master/CONTRIBUTING_ADVANCED.md) is not up to dated as per the [Firebase](https://firebase.google.com/) UI. The path to navigate to the `Authentication` UI is not clear even to the person who is setting put for the first time.

This change makes sure that new contributor can setup firebase easily or at least navigate easily,