### PR TITLE
refactor: settings groups

### DIFF
--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -64,7 +64,7 @@
       }
     }
 
-    &.autoSwitchThemeInputs {
+    &[data-config-name="autoSwitchThemeInputs"] {
       grid-template-areas: unset;
       grid-template-columns: 1fr 3fr 1fr 3fr;
       gap: 2rem;
@@ -82,7 +82,7 @@
       }
     }
 
-    &.customBackgroundFilter {
+    &[data-config-name="customBackgroundFilter"] {
       .groups {
         grid-area: buttons;
         display: grid;

--- a/frontend/src/styles/z_media-queries.scss
+++ b/frontend/src/styles/z_media-queries.scss
@@ -309,7 +309,7 @@
     .section {
       grid-template-columns: 1.5fr 1fr;
     }
-    .section.autoSwitchThemeInputs {
+    .section[data-config-name="autoSwitchThemeInputs"] {
       grid-template-columns: 1fr 3fr;
     }
   }
@@ -406,7 +406,7 @@
     }
   }
 
-  .pageSettings .section.customBackgroundFilter {
+  .pageSettings .section[data-config-name="customBackgroundFilter"] {
     .groups {
       grid-template-columns: 1fr;
     }
@@ -838,7 +838,7 @@
   }
 
   .pageSettings {
-    .section.customBackgroundFilter .groups .group {
+    .section[data-config-name="customBackgroundFilter"] .groups .group {
       grid-template-columns: auto 1fr;
       .title {
         grid-column: 1/3;

--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -193,7 +193,7 @@ function handleSpace(): void {
       f.functions.handleSpace();
     }
   }
-  Settings.groups["layout"]?.updateInput();
+  Settings.groups["layout"]?.updateUI();
 
   dontInsertSpace = true;
 

--- a/frontend/src/ts/elements/custom-background-filter.ts
+++ b/frontend/src/ts/elements/custom-background-filter.ts
@@ -77,13 +77,17 @@ function updateNumbers(): void {
   );
 }
 
+export function updateUI(): void {
+  syncSliders();
+  updateNumbers();
+}
+
 function loadConfig(config: SharedTypes.Config.CustomBackgroundFilter): void {
   filters.blur.value = config[0];
   filters.brightness.value = config[1];
   filters.saturate.value = config[2];
   filters.opacity.value = config[3];
-  updateNumbers();
-  syncSliders();
+  updateUI();
 }
 
 $(".section[data-config-name='customBackgroundFilter'] .blur input").on(

--- a/frontend/src/ts/elements/custom-background-filter.ts
+++ b/frontend/src/ts/elements/custom-background-filter.ts
@@ -48,29 +48,31 @@ export function apply(): void {
 }
 
 function syncSliders(): void {
-  $(".section.customBackgroundFilter .blur input").val(filters.blur.value);
-  $(".section.customBackgroundFilter .brightness input").val(
-    filters.brightness.value
+  $(".section[data-config-name='customBackgroundFilter'] .blur input").val(
+    filters.blur.value
   );
-  $(".section.customBackgroundFilter .saturate input").val(
+  $(
+    ".section[data-config-name='customBackgroundFilter'] .brightness input"
+  ).val(filters.brightness.value);
+  $(".section[data-config-name='customBackgroundFilter'] .saturate input").val(
     filters.saturate.value
   );
-  $(".section.customBackgroundFilter .opacity input").val(
+  $(".section[data-config-name='customBackgroundFilter'] .opacity input").val(
     filters.opacity.value
   );
 }
 
 function updateNumbers(): void {
-  $(".section.customBackgroundFilter .blur .value").html(
+  $(".section[data-config-name='customBackgroundFilter'] .blur .value").html(
     filters.blur.value.toFixed(1)
   );
-  $(".section.customBackgroundFilter .brightness .value").html(
-    filters.brightness.value.toFixed(1)
-  );
-  $(".section.customBackgroundFilter .saturate .value").html(
-    filters.saturate.value.toFixed(1)
-  );
-  $(".section.customBackgroundFilter .opacity .value").html(
+  $(
+    ".section[data-config-name='customBackgroundFilter'] .brightness .value"
+  ).html(filters.brightness.value.toFixed(1));
+  $(
+    ".section[data-config-name='customBackgroundFilter'] .saturate .value"
+  ).html(filters.saturate.value.toFixed(1));
+  $(".section[data-config-name='customBackgroundFilter'] .opacity .value").html(
     filters.opacity.value.toFixed(1)
   );
 }
@@ -84,41 +86,64 @@ function loadConfig(config: SharedTypes.Config.CustomBackgroundFilter): void {
   syncSliders();
 }
 
-$(".section.customBackgroundFilter .blur input").on("input", () => {
-  filters.blur.value = parseFloat(
-    $(".section.customBackgroundFilter .blur input").val() as string
-  );
-  updateNumbers();
-  apply();
-});
+$(".section[data-config-name='customBackgroundFilter'] .blur input").on(
+  "input",
+  () => {
+    filters.blur.value = parseFloat(
+      $(
+        ".section[data-config-name='customBackgroundFilter'] .blur input"
+      ).val() as string
+    );
+    updateNumbers();
+    apply();
+  }
+);
 
-$(".section.customBackgroundFilter .brightness input").on("input", () => {
-  filters.brightness.value = parseFloat(
-    $(".section.customBackgroundFilter .brightness input").val() as string
-  );
-  updateNumbers();
-  apply();
-});
+$(".section[data-config-name='customBackgroundFilter'] .brightness input").on(
+  "input",
+  () => {
+    filters.brightness.value = parseFloat(
+      $(
+        ".section[data-config-name='customBackgroundFilter'] .brightness input"
+      ).val() as string
+    );
+    updateNumbers();
+    apply();
+  }
+);
 
-$(".section.customBackgroundFilter .saturate input").on("input", () => {
-  filters.saturate.value = parseFloat(
-    $(".section.customBackgroundFilter .saturate input").val() as string
-  );
-  updateNumbers();
-  apply();
-});
+$(".section[data-config-name='customBackgroundFilter'] .saturate input").on(
+  "input",
+  () => {
+    filters.saturate.value = parseFloat(
+      $(
+        ".section[data-config-name='customBackgroundFilter'] .saturate input"
+      ).val() as string
+    );
+    updateNumbers();
+    apply();
+  }
+);
 
-$(".section.customBackgroundFilter .opacity input").on("input", () => {
-  filters.opacity.value = parseFloat(
-    $(".section.customBackgroundFilter .opacity input").val() as string
-  );
-  updateNumbers();
-  apply();
-});
+$(".section[data-config-name='customBackgroundFilter'] .opacity input").on(
+  "input",
+  () => {
+    filters.opacity.value = parseFloat(
+      $(
+        ".section[data-config-name='customBackgroundFilter'] .opacity input"
+      ).val() as string
+    );
+    updateNumbers();
+    apply();
+  }
+);
 
-$(".section.customBackgroundFilter input").on("input", () => {
-  void debouncedSave();
-});
+$(".section[data-config-name='customBackgroundFilter'] input").on(
+  "input",
+  () => {
+    void debouncedSave();
+  }
+);
 
 const debouncedSave = debounce(2000, async () => {
   const arr = Object.keys(filters).map(

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -82,15 +82,31 @@ async function initGroups(): Promise<void> {
     },
     () => {
       if (Config.keymapMode === "off") {
-        $(".pageSettings .section.keymapStyle").addClass("hidden");
-        $(".pageSettings .section.keymapLayout").addClass("hidden");
-        $(".pageSettings .section.keymapLegendStyle").addClass("hidden");
-        $(".pageSettings .section.keymapShowTopRow").addClass("hidden");
+        $(".pageSettings .section[data-config-name='keymapStyle']").addClass(
+          "hidden"
+        );
+        $(".pageSettings .section[data-config-name='keymapLayout']").addClass(
+          "hidden"
+        );
+        $(
+          ".pageSettings .section[data-config-name='keymapLegendStyle']"
+        ).addClass("hidden");
+        $(
+          ".pageSettings .section[data-config-name='keymapShowTopRow']"
+        ).addClass("hidden");
       } else {
-        $(".pageSettings .section.keymapStyle").removeClass("hidden");
-        $(".pageSettings .section.keymapLayout").removeClass("hidden");
-        $(".pageSettings .section.keymapLegendStyle").removeClass("hidden");
-        $(".pageSettings .section.keymapShowTopRow").removeClass("hidden");
+        $(".pageSettings .section[data-config-name='keymapStyle']").removeClass(
+          "hidden"
+        );
+        $(
+          ".pageSettings .section[data-config-name='keymapLayout']"
+        ).removeClass("hidden");
+        $(
+          ".pageSettings .section[data-config-name='keymapLegendStyle']"
+        ).removeClass("hidden");
+        $(
+          ".pageSettings .section[data-config-name='keymapShowTopRow']"
+        ).removeClass("hidden");
       }
     }
   ) as SettingsGroup<SharedTypes.ConfigValue>;
@@ -365,10 +381,12 @@ async function initGroups(): Promise<void> {
     undefined,
     () => {
       const customButton = $(
-        ".pageSettings .section.fontFamily .buttons .custom"
+        ".pageSettings .section[data-config-name='fontFamily'] .buttons .custom"
       );
       if (
-        $(".pageSettings .section.fontFamily .buttons .active").length === 0
+        $(
+          ".pageSettings .section[data-config-name='fontFamily'] .buttons .active"
+        ).length === 0
       ) {
         customButton.addClass("active");
         customButton.text(`Custom (${Config.fontFamily.replace(/_/g, " ")})`);
@@ -404,8 +422,8 @@ function reset(): void {
   $(".pageSettings .section.themes .allCustomThemes.buttons").empty();
   $(".pageSettings .section.languageGroups .buttons").empty();
   $(".pageSettings select").empty().select2("destroy");
-  $(".pageSettings .section.funbox .buttons").empty();
-  $(".pageSettings .section.fontFamily .buttons").empty();
+  $(".pageSettings .section[data-config-name='funbox'] .buttons").empty();
+  $(".pageSettings .section[data-config-name='fontFamily'] .buttons").empty();
 }
 
 let groupsInitialized = false;
@@ -418,7 +436,7 @@ async function fillSettingsPage(): Promise<void> {
 
   // Language Selection Combobox
   const languageEl = document.querySelector(
-    ".pageSettings .section.language select"
+    ".pageSettings .section[data-config-name='language'] select"
   ) as HTMLSelectElement;
   languageEl.innerHTML = "";
   let languageElHTML = "";
@@ -455,13 +473,13 @@ async function fillSettingsPage(): Promise<void> {
   await Misc.sleep(0);
 
   const layoutEl = document.querySelector(
-    ".pageSettings .section.layout select"
+    ".pageSettings .section[data-config-name='layout'] select"
   ) as HTMLSelectElement;
   layoutEl.innerHTML = `<option value='default'>off</option>`;
   let layoutElHTML = "";
 
   const keymapEl = document.querySelector(
-    ".pageSettings .section.keymapLayout select"
+    ".pageSettings .section[data-config-name='keymapLayout'] select"
   ) as HTMLSelectElement;
   keymapEl.innerHTML = `<option value='overrideSync'>emulator sync</option>`;
   let keymapElHTML = "";
@@ -501,13 +519,13 @@ async function fillSettingsPage(): Promise<void> {
   await Misc.sleep(0);
 
   const themeEl1 = document.querySelector(
-    ".pageSettings .section.autoSwitchThemeInputs select.light"
+    ".pageSettings .section[data-config-name='autoSwitchThemeInputs'] select.light"
   ) as HTMLSelectElement;
   themeEl1.innerHTML = "";
   let themeEl1HTML = "";
 
   const themeEl2 = document.querySelector(
-    ".pageSettings .section.autoSwitchThemeInputs select.dark"
+    ".pageSettings .section[data-config-name='autoSwitchThemeInputs'] select.dark"
   ) as HTMLSelectElement;
   themeEl2.innerHTML = "";
   let themeEl2HTML = "";
@@ -544,17 +562,21 @@ async function fillSettingsPage(): Promise<void> {
 
   await Misc.sleep(0);
 
-  $(`.pageSettings .section.autoSwitchThemeInputs select.light`)
+  $(
+    `.pageSettings .section[data-config-name='autoSwitchThemeInputs'] select.light`
+  )
     .val(Config.themeLight)
     .trigger("change.select2");
-  $(`.pageSettings .section.autoSwitchThemeInputs select.dark`)
+  $(
+    `.pageSettings .section[data-config-name='autoSwitchThemeInputs'] select.dark`
+  )
     .val(Config.themeDark)
     .trigger("change.select2");
 
   const funboxEl = document.querySelector(
-    ".pageSettings .section.funbox .buttons"
+    ".pageSettings .section[data-config-name='funbox'] .buttons"
   ) as HTMLDivElement;
-  funboxEl.innerHTML = `<div class="funbox button" funbox='none'>none</div>`;
+  funboxEl.innerHTML = `<div class="funbox button" data-config-value='none'>none</div>`;
   let funboxElHTML = "";
 
   let funboxList;
@@ -567,7 +589,7 @@ async function fillSettingsPage(): Promise<void> {
   if (funboxList) {
     for (const funbox of funboxList) {
       if (funbox.name === "mirror") {
-        funboxElHTML += `<div class="funbox button" funbox='${
+        funboxElHTML += `<div class="funbox button" data-config-value='${
           funbox.name
         }' aria-label="${
           funbox.info
@@ -576,7 +598,7 @@ async function fillSettingsPage(): Promise<void> {
           " "
         )}</div>`;
       } else if (funbox.name === "upside_down") {
-        funboxElHTML += `<div class="funbox button" funbox='${
+        funboxElHTML += `<div class="funbox button" data-config-value='${
           funbox.name
         }' aria-label="${
           funbox.info
@@ -585,7 +607,7 @@ async function fillSettingsPage(): Promise<void> {
           " "
         )}</div>`;
       } else {
-        funboxElHTML += `<div class="funbox button" funbox='${
+        funboxElHTML += `<div class="funbox button" data-config-value='${
           funbox.name
         }' aria-label="${
           funbox.info
@@ -602,7 +624,7 @@ async function fillSettingsPage(): Promise<void> {
 
   let isCustomFont = true;
   const fontsEl = document.querySelector(
-    ".pageSettings .section.fontFamily .buttons"
+    ".pageSettings .section[data-config-name='fontFamily'] .buttons"
   ) as HTMLDivElement;
   fontsEl.innerHTML = "";
 
@@ -624,7 +646,7 @@ async function fillSettingsPage(): Promise<void> {
         Config.fontFamily === font.name ? " active" : ""
       }" style="font-family:${
         font.display !== undefined ? font.display : font.name
-      }" fontFamily="${font.name.replace(/ /g, "_")}" tabindex="0"
+      }" data-config-value="${font.name.replace(/ /g, "_")}" tabindex="0"
         onclick="this.blur();">${
           font.display !== undefined ? font.display : font.name
         }</div>`;
@@ -640,13 +662,15 @@ async function fillSettingsPage(): Promise<void> {
     fontsEl.innerHTML = fontsElHTML;
   }
 
-  $(".pageSettings .section.customBackgroundSize input").val(
-    Config.customBackground
+  $(
+    ".pageSettings .section[data-config-name='customBackgroundSize'] input"
+  ).val(Config.customBackground);
+
+  $(".pageSettings .section[data-config-name='fontSize'] input").val(
+    Config.fontSize
   );
 
-  $(".pageSettings .section.fontSize input").val(Config.fontSize);
-
-  $(".pageSettings .section.customLayoutfluid input").val(
+  $(".pageSettings .section[data-config-name='customLayoutfluid'] input").val(
     Config.customLayoutfluid.replace(/#/g, " ")
   );
 
@@ -762,8 +786,12 @@ export function updateAuthSections(): void {
 }
 
 function setActiveFunboxButton(): void {
-  $(`.pageSettings .section.funbox .button`).removeClass("active");
-  $(`.pageSettings .section.funbox .button`).removeClass("disabled");
+  $(`.pageSettings .section[data-config-name='funbox'] .button`).removeClass(
+    "active"
+  );
+  $(`.pageSettings .section[data-config-name='funbox'] .button`).removeClass(
+    "disabled"
+  );
   Misc.getFunboxList()
     .then((funboxModes) => {
       funboxModes.forEach((funbox) => {
@@ -772,7 +800,7 @@ function setActiveFunboxButton(): void {
           !Config.funbox.split("#").includes(funbox.name)
         ) {
           $(
-            `.pageSettings .section.funbox .button[funbox='${funbox.name}']`
+            `.pageSettings .section[data-config-name='funbox'] .button[data-config-value='${funbox.name}']`
           ).addClass("disabled");
         }
       });
@@ -781,9 +809,9 @@ function setActiveFunboxButton(): void {
       Notifications.add(`Failed to update funbox buttons: ${e.message}`, -1);
     });
   Config.funbox.split("#").forEach((funbox) => {
-    $(`.pageSettings .section.funbox .button[funbox='${funbox}']`).addClass(
-      "active"
-    );
+    $(
+      `.pageSettings .section[data-config-name='funbox'] .button[data-config-value='${funbox}']`
+    ).addClass("active");
   });
 }
 
@@ -866,34 +894,48 @@ export async function update(groupUpdate = true): Promise<void> {
   ThemePicker.setCustomInputs(true);
   // ThemePicker.updateActiveButton();
 
-  $(".pageSettings .section.paceCaret input.customPaceCaretSpeed").val(
+  $(
+    ".pageSettings .section[data-config-name='paceCaret'] input.customPaceCaretSpeed"
+  ).val(
     getTypingSpeedUnit(Config.typingSpeedUnit).fromWpm(
       Config.paceCaretCustomSpeed
     )
   );
 
-  $(".pageSettings .section.minWpm input.customMinWpmSpeed").val(
+  $(
+    ".pageSettings .section[data-config-name='minWpm'] input.customMinWpmSpeed"
+  ).val(
     getTypingSpeedUnit(Config.typingSpeedUnit).fromWpm(Config.minWpmCustomSpeed)
   );
-  $(".pageSettings .section.minAcc input.customMinAcc").val(
+  $(".pageSettings .section[data-config-name='minAcc'] input.customMinAcc").val(
     Config.minAccCustom
   );
-  $(".pageSettings .section.minBurst input.customMinBurst").val(
+  $(
+    ".pageSettings .section[data-config-name='minBurst'] input.customMinBurst"
+  ).val(
     getTypingSpeedUnit(Config.typingSpeedUnit).fromWpm(
       Config.minBurstCustomSpeed
     )
   );
 
   if (Config.autoSwitchTheme) {
-    $(".pageSettings .section.autoSwitchThemeInputs").removeClass("hidden");
+    $(
+      ".pageSettings .section[data-config-name='autoSwitchThemeInputs']"
+    ).removeClass("hidden");
   } else {
-    $(".pageSettings .section.autoSwitchThemeInputs").addClass("hidden");
+    $(
+      ".pageSettings .section[data-config-name='autoSwitchThemeInputs']"
+    ).addClass("hidden");
   }
 
   if (Config.customBackground !== "") {
-    $(".pageSettings .section.customBackgroundFilter").removeClass("hidden");
+    $(
+      ".pageSettings .section[data-config-name='customBackgroundFilter']"
+    ).removeClass("hidden");
   } else {
-    $(".pageSettings .section.customBackgroundFilter").addClass("hidden");
+    $(
+      ".pageSettings .section[data-config-name='customBackgroundFilter']"
+    ).addClass("hidden");
   }
 
   if (Auth?.currentUser) {
@@ -930,13 +972,13 @@ function toggleSettingsGroup(groupName: string): void {
   }
 }
 
-$(".pageSettings .section.paceCaret").on(
+$(".pageSettings .section[data-config-name='paceCaret']").on(
   "focusout",
   "input.customPaceCaretSpeed",
   () => {
     const inputValue = parseInt(
       $(
-        ".pageSettings .section.paceCaret input.customPaceCaretSpeed"
+        ".pageSettings .section[data-config-name='paceCaret'] input.customPaceCaretSpeed"
       ).val() as string
     );
     const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
@@ -946,24 +988,30 @@ $(".pageSettings .section.paceCaret").on(
   }
 );
 
-$(".pageSettings .section.paceCaret").on("click", ".button.save", () => {
-  const inputValue = parseInt(
-    $(
-      ".pageSettings .section.paceCaret input.customPaceCaretSpeed"
-    ).val() as string
-  );
-  const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
-    inputValue
-  );
-  UpdateConfig.setPaceCaretCustomSpeed(newConfigValue);
-});
+$(".pageSettings .section[data-config-name='paceCaret']").on(
+  "click",
+  ".button.save",
+  () => {
+    const inputValue = parseInt(
+      $(
+        ".pageSettings .section[data-config-name='paceCaret'] input.customPaceCaretSpeed"
+      ).val() as string
+    );
+    const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
+      inputValue
+    );
+    UpdateConfig.setPaceCaretCustomSpeed(newConfigValue);
+  }
+);
 
-$(".pageSettings .section.minWpm").on(
+$(".pageSettings .section[data-config-name='minWpm']").on(
   "focusout",
   "input.customMinWpmSpeed",
   () => {
     const inputValue = parseInt(
-      $(".pageSettings .section.minWpm input.customMinWpmSpeed").val() as string
+      $(
+        ".pageSettings .section[data-config-name='minWpm'] input.customMinWpmSpeed"
+      ).val() as string
     );
     const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
       inputValue
@@ -972,38 +1020,58 @@ $(".pageSettings .section.minWpm").on(
   }
 );
 
-$(".pageSettings .section.minWpm").on("click", ".button.save", () => {
-  const inputValue = parseInt(
-    $(".pageSettings .section.minWpm input.customMinWpmSpeed").val() as string
-  );
-  const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
-    inputValue
-  );
-  UpdateConfig.setMinWpmCustomSpeed(newConfigValue);
-});
+$(".pageSettings .section[data-config-name='minWpm']").on(
+  "click",
+  ".button.save",
+  () => {
+    const inputValue = parseInt(
+      $(
+        ".pageSettings .section[data-config-name='minWpm'] input.customMinWpmSpeed"
+      ).val() as string
+    );
+    const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
+      inputValue
+    );
+    UpdateConfig.setMinWpmCustomSpeed(newConfigValue);
+  }
+);
 
-$(".pageSettings .section.minAcc").on("focusout", "input.customMinAcc", () => {
-  UpdateConfig.setMinAccCustom(
-    parseInt(
-      $(".pageSettings .section.minAcc input.customMinAcc").val() as string
-    )
-  );
-});
+$(".pageSettings .section[data-config-name='minAcc']").on(
+  "focusout",
+  "input.customMinAcc",
+  () => {
+    UpdateConfig.setMinAccCustom(
+      parseInt(
+        $(
+          ".pageSettings .section[data-config-name='minAcc'] input.customMinAcc"
+        ).val() as string
+      )
+    );
+  }
+);
 
-$(".pageSettings .section.minAcc").on("click", ".button.save", () => {
-  UpdateConfig.setMinAccCustom(
-    parseInt(
-      $(".pageSettings .section.minAcc input.customMinAcc").val() as string
-    )
-  );
-});
+$(".pageSettings .section[data-config-name='minAcc']").on(
+  "click",
+  ".button.save",
+  () => {
+    UpdateConfig.setMinAccCustom(
+      parseInt(
+        $(
+          ".pageSettings .section[data-config-name='minAcc'] input.customMinAcc"
+        ).val() as string
+      )
+    );
+  }
+);
 
-$(".pageSettings .section.minBurst").on(
+$(".pageSettings .section[data-config-name='minBurst']").on(
   "focusout",
   "input.customMinBurst",
   () => {
     const inputValue = parseInt(
-      $(".pageSettings .section.minBurst input.customMinBurst").val() as string
+      $(
+        ".pageSettings .section[data-config-name='minBurst'] input.customMinBurst"
+      ).val() as string
     );
     const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
       inputValue
@@ -1012,22 +1080,32 @@ $(".pageSettings .section.minBurst").on(
   }
 );
 
-$(".pageSettings .section.minBurst").on("click", ".button.save", () => {
-  const inputValue = parseInt(
-    $(".pageSettings .section.minBurst input.customMinBurst").val() as string
-  );
-  const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
-    inputValue
-  );
-  UpdateConfig.setMinBurstCustomSpeed(newConfigValue);
-});
+$(".pageSettings .section[data-config-name='minBurst']").on(
+  "click",
+  ".button.save",
+  () => {
+    const inputValue = parseInt(
+      $(
+        ".pageSettings .section[data-config-name='minBurst'] input.customMinBurst"
+      ).val() as string
+    );
+    const newConfigValue = getTypingSpeedUnit(Config.typingSpeedUnit).toWpm(
+      inputValue
+    );
+    UpdateConfig.setMinBurstCustomSpeed(newConfigValue);
+  }
+);
 
 //funbox
-$(".pageSettings .section.funbox").on("click", ".button", (e) => {
-  const funbox = $(e.currentTarget).attr("funbox") as string;
-  toggleFunbox(funbox);
-  setActiveFunboxButton();
-});
+$(".pageSettings .section[data-config-name='funbox']").on(
+  "click",
+  ".button",
+  (e) => {
+    const funbox = $(e.currentTarget).attr("data-config-value") as string;
+    toggleFunbox(funbox);
+    setActiveFunboxButton();
+  }
+);
 
 //tags
 $(".pageSettings .section.tags").on(
@@ -1076,34 +1154,36 @@ $(".pageSettings .section.apeKeys #showApeKeysPopup").on("click", () => {
   void ApeKeysPopup.show();
 });
 
-$(".pageSettings .section.customBackgroundSize .inputAndButton .save").on(
-  "click",
-  () => {
+$(
+  ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton .save"
+).on("click", () => {
+  UpdateConfig.setCustomBackground(
+    $(
+      ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton input"
+    ).val() as string
+  );
+});
+
+$(
+  ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton input"
+).on("keypress", (e) => {
+  if (e.key === "Enter") {
     UpdateConfig.setCustomBackground(
       $(
-        ".pageSettings .section.customBackgroundSize .inputAndButton input"
+        ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton input"
       ).val() as string
     );
   }
-);
+});
 
-$(".pageSettings .section.customBackgroundSize .inputAndButton input").on(
-  "keypress",
-  (e) => {
-    if (e.key === "Enter") {
-      UpdateConfig.setCustomBackground(
-        $(
-          ".pageSettings .section.customBackgroundSize .inputAndButton input"
-        ).val() as string
-      );
-    }
-  }
-);
-
-$(".pageSettings .section.fontSize .inputAndButton .save").on("click", () => {
+$(
+  ".pageSettings .section[data-config-name='fontSize'] .inputAndButton .save"
+).on("click", () => {
   const didConfigSave = UpdateConfig.setFontSize(
     parseFloat(
-      $(".pageSettings .section.fontSize .inputAndButton input").val() as string
+      $(
+        ".pageSettings .section[data-config-name='fontSize'] .inputAndButton input"
+      ).val() as string
     )
   );
   if (didConfigSave) {
@@ -1113,32 +1193,46 @@ $(".pageSettings .section.fontSize .inputAndButton .save").on("click", () => {
   }
 });
 
-$(".pageSettings .section.fontSize .inputAndButton input").on(
-  "keypress",
-  (e) => {
-    if (e.key === "Enter") {
-      const didConfigSave = UpdateConfig.setFontSize(
-        parseFloat(
-          $(
-            ".pageSettings .section.fontSize .inputAndButton input"
-          ).val() as string
-        )
-      );
-      if (didConfigSave) {
-        Notifications.add("Saved", 1, {
-          duration: 1,
-        });
-      }
+$(
+  ".pageSettings .section[data-config-name='fontSize'] .inputAndButton input"
+).on("keypress", (e) => {
+  if (e.key === "Enter") {
+    const didConfigSave = UpdateConfig.setFontSize(
+      parseFloat(
+        $(
+          ".pageSettings .section[data-config-name='fontSize'] .inputAndButton input"
+        ).val() as string
+      )
+    );
+    if (didConfigSave) {
+      Notifications.add("Saved", 1, {
+        duration: 1,
+      });
     }
   }
-);
+});
 
-$(".pageSettings .section.customLayoutfluid .inputAndButton .save").on(
-  "click",
-  () => {
+$(
+  ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton .save"
+).on("click", () => {
+  void UpdateConfig.setCustomLayoutfluid(
+    $(
+      ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton input"
+    ).val() as MonkeyTypes.CustomLayoutFluidSpaces
+  ).then((bool) => {
+    if (bool) {
+      Notifications.add("Custom layoutfluid saved", 1);
+    }
+  });
+});
+
+$(
+  ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton .input"
+).on("keypress", (e) => {
+  if (e.key === "Enter") {
     void UpdateConfig.setCustomLayoutfluid(
       $(
-        ".pageSettings .section.customLayoutfluid .inputAndButton input"
+        ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton input"
       ).val() as MonkeyTypes.CustomLayoutFluidSpaces
     ).then((bool) => {
       if (bool) {
@@ -1146,24 +1240,7 @@ $(".pageSettings .section.customLayoutfluid .inputAndButton .save").on(
       }
     });
   }
-);
-
-$(".pageSettings .section.customLayoutfluid .inputAndButton .input").on(
-  "keypress",
-  (e) => {
-    if (e.key === "Enter") {
-      void UpdateConfig.setCustomLayoutfluid(
-        $(
-          ".pageSettings .section.customLayoutfluid .inputAndButton input"
-        ).val() as MonkeyTypes.CustomLayoutFluidSpaces
-      ).then((bool) => {
-        if (bool) {
-          Notifications.add("Custom layoutfluid saved", 1);
-        }
-      });
-    }
-  }
-);
+});
 
 $(".pageSettings .quickNav .links a").on("click", (e) => {
   const settingsGroup = e.target.innerText;
@@ -1178,7 +1255,7 @@ $(".pageSettings .section.updateCookiePreferences .button").on("click", () => {
   CookiePopup.showSettings();
 });
 
-$(".pageSettings .section.autoSwitchThemeInputs").on(
+$(".pageSettings .section[data-config-name='autoSwitchThemeInputs']").on(
   "change",
   `select.light`,
   (e) => {
@@ -1190,7 +1267,7 @@ $(".pageSettings .section.autoSwitchThemeInputs").on(
   }
 );
 
-$(".pageSettings .section.autoSwitchThemeInputs").on(
+$(".pageSettings .section[data-config-name='autoSwitchThemeInputs']").on(
   "change",
   `select.dark`,
   (e) => {

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -740,8 +740,8 @@ export function updateDiscordSection(): void {
 }
 
 export function updateAuthSections(): void {
-  $(".pageSettings .section.passwordAuthSettings .button").addClass("hidden");
-  $(".pageSettings .section.googleAuthSettings .button").addClass("hidden");
+  $(".pageSettings .section.passwordAuthSettings button").addClass("hidden");
+  $(".pageSettings .section.googleAuthSettings button").addClass("hidden");
 
   const user = Auth?.currentUser;
   if (!user) return;
@@ -1253,7 +1253,7 @@ $(".pageSettings .quickNav .links a").on("click", (e) => {
   isOpen && toggleSettingsGroup(settingsGroup);
 });
 
-$(".pageSettings .section.updateCookiePreferences .button").on("click", () => {
+$(".pageSettings .section.updateCookiePreferences button").on("click", () => {
   CookiePopup.show();
   CookiePopup.showSettings();
 });

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -20,6 +20,7 @@ import { areFunboxesCompatible } from "../test/funbox/funbox-validation";
 import { get as getTypingSpeedUnit } from "../utils/typing-speed-units";
 
 import * as Skeleton from "../popups/skeleton";
+import * as CustomBackgroundFilter from "../elements/custom-background-filter";
 
 type SettingsGroups<T extends SharedTypes.ConfigValue> = Record<
   string,
@@ -943,6 +944,8 @@ export async function update(groupUpdate = true): Promise<void> {
   } else {
     hideAccountSection();
   }
+
+  CustomBackgroundFilter.updateUI();
 
   const modifierKey = window.navigator.userAgent.toLowerCase().includes("mac")
     ? "cmd"

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -50,7 +50,7 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setShowLiveWpm,
     "button",
     () => {
-      groups["keymapMode"]?.updateInput();
+      groups["keymapMode"]?.updateUI();
     }
   ) as SettingsGroup<SharedTypes.ConfigValue>;
   groups["showLiveAcc"] = new SettingsGroup(
@@ -78,7 +78,7 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setKeymapMode,
     "button",
     () => {
-      groups["showLiveWpm"]?.updateInput();
+      groups["showLiveWpm"]?.updateUI();
     },
     () => {
       if (Config.keymapMode === "off") {
@@ -132,7 +132,7 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setFreedomMode,
     "button",
     () => {
-      groups["confidenceMode"]?.updateInput();
+      groups["confidenceMode"]?.updateUI();
     }
   ) as SettingsGroup<SharedTypes.ConfigValue>;
   groups["strictSpace"] = new SettingsGroup(
@@ -150,8 +150,8 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setConfidenceMode,
     "button",
     () => {
-      groups["freedomMode"]?.updateInput();
-      groups["stopOnError"]?.updateInput();
+      groups["freedomMode"]?.updateUI();
+      groups["stopOnError"]?.updateUI();
     }
   ) as SettingsGroup<SharedTypes.ConfigValue>;
   groups["indicateTypos"] = new SettingsGroup(
@@ -239,7 +239,7 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setStopOnError,
     "button",
     () => {
-      groups["confidenceMode"]?.updateInput();
+      groups["confidenceMode"]?.updateUI();
     }
   ) as SettingsGroup<SharedTypes.ConfigValue>;
   groups["soundVolume"] = new SettingsGroup(
@@ -657,7 +657,7 @@ async function fillSettingsPage(): Promise<void> {
     groupsInitialized = true;
   } else {
     for (const groupKey of Object.keys(groups)) {
-      groups[groupKey]?.updateInput();
+      groups[groupKey]?.updateUI();
     }
   }
   setEventDisabled(false);
@@ -851,7 +851,7 @@ export async function update(groupUpdate = true): Promise<void> {
   // Object.keys(groups).forEach((group) => {
   if (groupUpdate) {
     for (const group of Object.keys(groups)) {
-      groups[group]?.updateInput();
+      groups[group]?.updateUI();
     }
   }
 

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -990,7 +990,7 @@ $(".pageSettings .section[data-config-name='paceCaret']").on(
 
 $(".pageSettings .section[data-config-name='paceCaret']").on(
   "click",
-  ".button.save",
+  "button.save",
   () => {
     const inputValue = parseInt(
       $(
@@ -1022,7 +1022,7 @@ $(".pageSettings .section[data-config-name='minWpm']").on(
 
 $(".pageSettings .section[data-config-name='minWpm']").on(
   "click",
-  ".button.save",
+  "button.save",
   () => {
     const inputValue = parseInt(
       $(
@@ -1052,7 +1052,7 @@ $(".pageSettings .section[data-config-name='minAcc']").on(
 
 $(".pageSettings .section[data-config-name='minAcc']").on(
   "click",
-  ".button.save",
+  "button.save",
   () => {
     UpdateConfig.setMinAccCustom(
       parseInt(
@@ -1082,7 +1082,7 @@ $(".pageSettings .section[data-config-name='minBurst']").on(
 
 $(".pageSettings .section[data-config-name='minBurst']").on(
   "click",
-  ".button.save",
+  "button.save",
   () => {
     const inputValue = parseInt(
       $(
@@ -1155,7 +1155,7 @@ $(".pageSettings .section.apeKeys #showApeKeysPopup").on("click", () => {
 });
 
 $(
-  ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton .save"
+  ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton button.save"
 ).on("click", () => {
   UpdateConfig.setCustomBackground(
     $(
@@ -1177,7 +1177,7 @@ $(
 });
 
 $(
-  ".pageSettings .section[data-config-name='fontSize'] .inputAndButton .save"
+  ".pageSettings .section[data-config-name='fontSize'] .inputAndButton button.save"
 ).on("click", () => {
   const didConfigSave = UpdateConfig.setFontSize(
     parseFloat(
@@ -1213,7 +1213,7 @@ $(
 });
 
 $(
-  ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton .save"
+  ".pageSettings .section[data-config-name='customLayoutfluid'] .inputAndButton button.save"
 ).on("click", () => {
   void UpdateConfig.setCustomLayoutfluid(
     $(

--- a/frontend/src/ts/popups/simple-popups.ts
+++ b/frontend/src/ts/popups/simple-popups.ts
@@ -1877,9 +1877,13 @@ $("#popups").on("click", "#apeKeysPopup table tbody tr .button.edit", (e) => {
   showPopup("editApeKey", [keyId]);
 });
 
-$(".pageSettings").on("click", ".section.fontFamily .button.custom", () => {
-  showPopup("applyCustomFont", []);
-});
+$(".pageSettings").on(
+  "click",
+  ".section[data-config-name='fontFamily'] .button.custom",
+  () => {
+    showPopup("applyCustomFont", []);
+  }
+);
 
 $(document).on("keydown", (event) => {
   if (event.key === "Escape" && isElementVisible("#simplePopupWrapper")) {

--- a/frontend/src/ts/settings/settings-group.ts
+++ b/frontend/src/ts/settings/settings-group.ts
@@ -66,7 +66,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
     if (this.setCallback) this.setCallback();
   }
 
-  updateInput(): void {
+  updateUI(): void {
     this.configValue = Config[this.configName as keyof typeof Config] as T;
     $(`.pageSettings .section.${this.configName} .button`).removeClass(
       "active"

--- a/frontend/src/ts/settings/settings-group.ts
+++ b/frontend/src/ts/settings/settings-group.ts
@@ -21,7 +21,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
     this.setCallback = setCallback;
     this.updateCallback = updateCallback;
 
-    this.updateInput();
+    this.updateUI();
 
     if (this.mode === "select") {
       $(".pageSettings").on(
@@ -62,7 +62,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
 
   setValue(value: T): void {
     this.configFunction(value);
-    this.updateInput();
+    this.updateUI();
     if (this.setCallback) this.setCallback();
   }
 

--- a/frontend/src/ts/settings/settings-group.ts
+++ b/frontend/src/ts/settings/settings-group.ts
@@ -42,7 +42,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
     } else if (this.mode === "button") {
       $(".pageSettings").on(
         "click",
-        `.section[data-config-name='${this.configName}'] .button`,
+        `.section[data-config-name='${this.configName}'] button`,
         (e) => {
           const target = $(e.currentTarget);
           if (
@@ -81,7 +81,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
   updateUI(): void {
     this.configValue = Config[this.configName as keyof typeof Config] as T;
     $(
-      `.pageSettings .section[data-config-name='${this.configName}'] .button`
+      `.pageSettings .section[data-config-name='${this.configName}'] button`
     ).removeClass("active");
     if (this.mode === "select") {
       $(`.pageSettings .section[data-config-name='${this.configName}'] select`)
@@ -91,7 +91,7 @@ export default class SettingsGroup<T extends SharedTypes.ConfigValue> {
       $(
         // this cant be an object?
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        `.pageSettings .section[data-config-name='${this.configName}'] .button[data-config-value='${this.configValue}']`
+        `.pageSettings .section[data-config-name='${this.configName}'] button[data-config-value='${this.configValue}']`
       ).addClass("active");
     }
     if (this.updateCallback) this.updateCallback();

--- a/frontend/src/ts/settings/theme-picker.ts
+++ b/frontend/src/ts/settings/theme-picker.ts
@@ -288,10 +288,10 @@ export function updateActiveTab(forced = false): void {
   // Set force to true only when some change for the active tab has taken place
   // Prevent theme buttons from being added twice by doing an update only when the state has changed
   const $presetTabButton = $(
-    ".pageSettings .section.themes .tabs .button[tab='preset']"
+    ".pageSettings .section.themes .tabs button[data-tab='preset']"
   );
   const $customTabButton = $(
-    ".pageSettings .section.themes .tabs .button[tab='custom']"
+    ".pageSettings .section.themes .tabs button[data-tab='custom']"
   );
 
   if (Config.customTheme) {
@@ -322,13 +322,13 @@ export function updateActiveTab(forced = false): void {
 // Add events to the DOM
 
 // Handle click on theme: preset or custom tab
-$(".pageSettings .section.themes .tabs .button").on("click", (e) => {
-  $(".pageSettings .section.themes .tabs .button").removeClass("active");
+$(".pageSettings .section.themes .tabs button").on("click", (e) => {
+  $(".pageSettings .section.themes .tabs button").removeClass("active");
   const $target = $(e.currentTarget);
   $target.addClass("active");
   // setCustomInputs();
   //test
-  if ($target.attr("tab") === "preset") {
+  if ($target.attr("data-tab") === "preset") {
     UpdateConfig.setCustomTheme(false);
   } else {
     UpdateConfig.setCustomTheme(true);

--- a/frontend/src/ts/settings/theme-picker.ts
+++ b/frontend/src/ts/settings/theme-picker.ts
@@ -120,12 +120,12 @@ export async function refreshButtons(): Promise<void> {
 
     if (!Auth?.currentUser) {
       $(
-        ".pageSettings .section.themes .customThemeEdit .saveCustomThemeButton"
+        ".pageSettings .section.themes .customThemeEdit #saveCustomThemeButton"
       ).text("save");
       return;
     } else {
       $(
-        ".pageSettings .section.themes .customThemeEdit .saveCustomThemeButton"
+        ".pageSettings .section.themes .customThemeEdit #saveCustomThemeButton"
       ).text("save as new");
     }
 
@@ -462,7 +462,7 @@ $("#shareCustomThemeButton").on("click", () => {
   ShareCustomThemePopup.show();
 });
 
-$(".pageSettings .saveCustomThemeButton").on("click", async () => {
+$(".pageSettings #saveCustomThemeButton").on("click", async () => {
   saveCustomThemeColors();
   if (Auth?.currentUser) {
     const newCustomTheme = {

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -1149,12 +1149,8 @@
         <span>theme</span>
       </div>
       <div class="tabs">
-        <div class="button" tab="preset" tabindex="0" onclick="this.blur();">
-          preset
-        </div>
-        <div class="button" tab="custom" tabindex="0" onclick="this.blur();">
-          custom
-        </div>
+        <button data-tab="preset">preset</button>
+        <button data-tab="custom">custom</button>
       </div>
       <!-- <div class='tabs'>
         <button tab="preset" class="tab">preset</button>

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -582,30 +582,9 @@
       </div>
       <div class="text">Change the volume of the sound effects.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="0.1"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          quiet
-        </div>
-        <div
-          class="button"
-          data-config-value="0.5"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          medium
-        </div>
-        <div
-          class="button"
-          data-config-value="1.0"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          loud
-        </div>
+        <button data-config-value="0.1">quiet</button>
+        <button data-config-value="0.5">medium</button>
+        <button data-config-value="1.0">loud</button>
       </div>
     </div>
     <div class="section fullWidth" data-config-name="playSoundOnClick">

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -132,7 +132,7 @@
     <span>behavior</span>
   </button>
   <div class="settingsGroup behavior">
-    <div class="section difficulty">
+    <div class="section" data-config-name="difficulty">
       <div class="groupTitle">
         <i class="fas fa-star"></i>
         <span>test difficulty</span>
@@ -145,7 +145,7 @@
       <div class="buttons">
         <div
           class="button"
-          difficulty="normal"
+          data-config-value="normal"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -153,7 +153,7 @@
         </div>
         <div
           class="button"
-          difficulty="expert"
+          data-config-value="expert"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -161,7 +161,7 @@
         </div>
         <div
           class="button"
-          difficulty="master"
+          data-config-value="master"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -169,7 +169,7 @@
         </div>
       </div>
     </div>
-    <div class="section quickRestart" id="quickRestart">
+    <div class="section" data-config-name="quickRestart">
       <div class="groupTitle">
         <i class="fas fa-redo-alt"></i>
         <span>quick restart</span>
@@ -190,7 +190,7 @@
       <div class="buttons">
         <div
           class="button"
-          quickRestart="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -198,7 +198,7 @@
         </div>
         <div
           class="button"
-          quickRestart="tab"
+          data-config-value="tab"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -206,7 +206,7 @@
         </div>
         <div
           class="button"
-          quickRestart="esc"
+          data-config-value="esc"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -214,7 +214,7 @@
         </div>
         <div
           class="button"
-          quickRestart="enter"
+          data-config-value="enter"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -223,7 +223,7 @@
       </div>
     </div>
 
-    <div class="section repeatQuotes" id="repeatQuotes">
+    <div class="section" data-config-name="repeatQuotes">
       <div class="groupTitle">
         <i class="fas fa-sync-alt"></i>
         <span>repeat quotes</span>
@@ -237,7 +237,7 @@
       <div class="buttons">
         <div
           class="button"
-          repeatQuotes="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -245,7 +245,7 @@
         </div>
         <div
           class="button"
-          repeatQuotes="typing"
+          data-config-value="typing"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -257,7 +257,7 @@
       </div>
     </div>
 
-    <div class="section blindMode">
+    <div class="section" data-config-name="blindMode">
       <div class="groupTitle">
         <i class="fas fa-eye-slash"></i>
         <span>blind mode</span>
@@ -269,7 +269,7 @@
       <div class="buttons">
         <div
           class="button"
-          blindMode="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -277,7 +277,7 @@
         </div>
         <div
           class="button"
-          blindMode="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -286,7 +286,7 @@
         </div>
       </div>
     </div>
-    <div class="section alwaysShowWordsHistory">
+    <div class="section" data-config-name="alwaysShowWordsHistory">
       <div class="groupTitle">
         <i class="fas fa-align-left"></i>
         <span>always show words history</span>
@@ -298,22 +298,18 @@
       <div class="buttons">
         <div
           class="button"
-          alwaysShowWordsHistory="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
           off
         </div>
-        <div
-          class="button"
-          alwaysShowWordsHistory="true"
-          onclick="this.blur();"
-        >
+        <div class="button" data-config-value="true" onclick="this.blur();">
           on
         </div>
       </div>
     </div>
-    <div class="section singleListCommandLine">
+    <div class="section" data-config-name="singleListCommandLine">
       <div class="groupTitle">
         <i class="fas fa-list"></i>
         <span>single list command line</span>
@@ -328,7 +324,7 @@
       <div class="buttons">
         <div
           class="button"
-          singleListCommandLine="manual"
+          data-config-value="manual"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -336,7 +332,7 @@
         </div>
         <div
           class="button"
-          singleListCommandLine="on"
+          data-config-value="on"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -344,7 +340,7 @@
         </div>
       </div>
     </div>
-    <div class="section minWpm" section="">
+    <div class="section" data-config-name="minWpm">
       <div class="groupTitle">
         <i class="fas fa-bomb"></i>
         <span>min speed</span>
@@ -363,17 +359,26 @@
             step="1"
             value=""
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
         <div class="buttons">
-          <div class="button" minWpm="off" tabindex="0" onclick="this.blur();">
+          <div
+            class="button"
+            data-config-value="off"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             off
           </div>
           <div
             class="button"
-            minWpm="custom"
+            data-config-value="custom"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -382,7 +387,7 @@
         </div>
       </div>
     </div>
-    <div class="section minAcc" section="">
+    <div class="section" data-config-name="minAcc">
       <div class="groupTitle">
         <i class="fas fa-bomb"></i>
         <span>min accuracy</span>
@@ -401,17 +406,26 @@
             step="1"
             value=""
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
         <div class="buttons">
-          <div class="button" minAcc="off" tabindex="0" onclick="this.blur();">
+          <div
+            class="button"
+            data-config-value="off"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             off
           </div>
           <div
             class="button"
-            minAcc="custom"
+            data-config-value="custom"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -420,7 +434,7 @@
         </div>
       </div>
     </div>
-    <div class="section minBurst" section="">
+    <div class="section" data-config-name="minBurst">
       <div class="groupTitle">
         <i class="fas fa-bomb"></i>
         <span>min burst</span>
@@ -441,14 +455,18 @@
             step="1"
             value=""
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
         <div class="buttons">
           <div
             class="button"
-            minBurst="off"
+            data-config-value="off"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -456,7 +474,7 @@
           </div>
           <div
             class="button"
-            minBurst="fixed"
+            data-config-value="fixed"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -464,7 +482,7 @@
           </div>
           <div
             class="button"
-            minBurst="flex"
+            data-config-value="flex"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -473,7 +491,7 @@
         </div>
       </div>
     </div>
-    <div class="section britishEnglish" section="">
+    <div class="section" data-config-name="britishEnglish">
       <div class="groupTitle">
         <i class="fas fa-language"></i>
         <span>british english</span>
@@ -486,7 +504,7 @@
       <div class="buttons">
         <div
           class="button"
-          britishEnglish="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -494,7 +512,7 @@
         </div>
         <div
           class="button"
-          britishEnglish="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -502,7 +520,7 @@
         </div>
       </div>
     </div>
-    <div class="section language">
+    <div class="section" data-config-name="language">
       <div class="groupTitle">
         <i class="fas fa-language"></i>
         <span>language</span>
@@ -512,7 +530,7 @@
         <select></select>
       </div>
     </div>
-    <div class="section funbox fullWidth">
+    <div class="section fullWidth" data-config-name="funbox">
       <div class="groupTitle">
         <i class="fas fa-gamepad"></i>
         <span>funbox</span>
@@ -525,7 +543,7 @@
       <div class="buttons"></div>
     </div>
     <div class="sectionSpacer"></div>
-    <div class="section customLayoutfluid">
+    <div class="section" data-config-name="customLayoutfluid">
       <div class="groupTitle">
         <i class="fas fa-tint"></i>
         <span>custom layoutfluid</span>
@@ -541,7 +559,11 @@
             class="input"
             tabindex="0"
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
@@ -554,7 +576,7 @@
     input
   </button>
   <div class="settingsGroup input">
-    <div class="section freedomMode">
+    <div class="section" data-config-name="freedomMode">
       <div class="groupTitle">
         <i class="fas fa-feather-alt"></i>
         <span>freedom mode</span>
@@ -565,7 +587,7 @@
       <div class="buttons">
         <div
           class="button"
-          freedomMode="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -573,7 +595,7 @@
         </div>
         <div
           class="button"
-          freedomMode="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -581,7 +603,7 @@
         </div>
       </div>
     </div>
-    <div class="section strictSpace">
+    <div class="section" data-config-name="strictSpace">
       <div class="groupTitle">
         <i class="fas fa-minus"></i>
         <span>strict space</span>
@@ -593,7 +615,7 @@
       <div class="buttons">
         <div
           class="button"
-          strictSpace="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -601,7 +623,7 @@
         </div>
         <div
           class="button"
-          strictSpace="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -609,7 +631,7 @@
         </div>
       </div>
     </div>
-    <div class="section oppositeShiftMode">
+    <div class="section" data-config-name="oppositeShiftMode">
       <div class="groupTitle">
         <i class="fas fa-exchange-alt"></i>
         <span>opposite shift mode</span>
@@ -632,7 +654,7 @@
       <div class="buttons">
         <div
           class="button"
-          oppositeShiftMode="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -640,7 +662,7 @@
         </div>
         <div
           class="button"
-          oppositeShiftMode="on"
+          data-config-value="on"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -648,7 +670,7 @@
         </div>
         <div
           class="button"
-          oppositeShiftMode="keymap"
+          data-config-value="keymap"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -656,7 +678,7 @@
         </div>
       </div>
     </div>
-    <div class="section stopOnError">
+    <div class="section" data-config-name="stopOnError">
       <div class="groupTitle">
         <i class="fas fa-hand-paper"></i>
         <span>stop on error</span>
@@ -669,7 +691,7 @@
       <div class="buttons">
         <div
           class="button"
-          stopOnError="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -677,7 +699,7 @@
         </div>
         <div
           class="button"
-          stopOnError="word"
+          data-config-value="word"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -685,7 +707,7 @@
         </div>
         <div
           class="button"
-          stopOnError="letter"
+          data-config-value="letter"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -693,7 +715,7 @@
         </div>
       </div>
     </div>
-    <div class="section confidenceMode">
+    <div class="section" data-config-name="confidenceMode">
       <div class="groupTitle">
         <i class="fas fa-backspace"></i>
         <span>confidence mode</span>
@@ -706,7 +728,7 @@
       <div class="buttons">
         <div
           class="button"
-          confidenceMode="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -715,7 +737,7 @@
 
         <div
           class="button"
-          confidenceMode="on"
+          data-config-value="on"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -723,7 +745,7 @@
         </div>
         <div
           class="button"
-          confidenceMode="max"
+          data-config-value="max"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -731,7 +753,7 @@
         </div>
       </div>
     </div>
-    <div class="section quickEnd">
+    <div class="section" data-config-name="quickEnd">
       <div class="groupTitle">
         <i class="fas fa-step-forward"></i>
         <span>quick end</span>
@@ -745,18 +767,23 @@
       <div class="buttons">
         <div
           class="button"
-          quickEnd="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
           off
         </div>
-        <div class="button" quickEnd="true" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="true"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           on
         </div>
       </div>
     </div>
-    <div class="section indicateTypos" section="">
+    <div class="section" data-config-name="indicateTypos">
       <div class="groupTitle">
         <i class="fas fa-exclamation"></i>
         <span>indicate typos</span>
@@ -768,7 +795,7 @@
       <div class="buttons">
         <div
           class="button"
-          indicateTypos="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -776,7 +803,7 @@
         </div>
         <div
           class="button"
-          indicateTypos="below"
+          data-config-value="below"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -784,7 +811,7 @@
         </div>
         <div
           class="button"
-          indicateTypos="replace"
+          data-config-value="replace"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -792,7 +819,7 @@
         </div>
       </div>
     </div>
-    <div class="section hideExtraLetters" section="">
+    <div class="section" data-config-name="hideExtraLetters">
       <div class="groupTitle">
         <i class="fas fa-eye-slash"></i>
         <span>hide extra letters</span>
@@ -805,7 +832,7 @@
       <div class="buttons">
         <div
           class="button"
-          hideExtraLetters="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -813,7 +840,7 @@
         </div>
         <div
           class="button"
-          hideExtraLetters="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -821,7 +848,7 @@
         </div>
       </div>
     </div>
-    <div class="section lazyMode">
+    <div class="section" data-config-name="lazyMode">
       <div class="groupTitle">
         <i class="fas fa-couch"></i>
         <span>lazy mode</span>
@@ -833,18 +860,23 @@
       <div class="buttons">
         <div
           class="button"
-          lazyMode="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
           off
         </div>
-        <div class="button" lazyMode="true" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="true"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           on
         </div>
       </div>
     </div>
-    <div class="section layout">
+    <div class="section" data-config-name="layout">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>layout emulator</span>
@@ -874,7 +906,7 @@
     sound
   </button>
   <div class="settingsGroup sound">
-    <div class="section soundVolume">
+    <div class="section" data-config-name="soundVolume">
       <div class="groupTitle">
         <i class="fas fa-volume-down"></i>
         <span>sound volume</span>
@@ -883,7 +915,7 @@
       <div class="buttons">
         <div
           class="button"
-          soundVolume="0.1"
+          data-config-value="0.1"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -891,7 +923,7 @@
         </div>
         <div
           class="button"
-          soundVolume="0.5"
+          data-config-value="0.5"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -899,7 +931,7 @@
         </div>
         <div
           class="button"
-          soundVolume="1.0"
+          data-config-value="1.0"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -907,7 +939,7 @@
         </div>
       </div>
     </div>
-    <div class="section playSoundOnClick fullWidth">
+    <div class="section fullWidth" data-config-name="playSoundOnClick">
       <div class="groupTitle">
         <i class="fas fa-volume-up"></i>
         <span>play sound on click</span>
@@ -916,7 +948,7 @@
       <div class="buttons">
         <div
           class="button"
-          playSoundOnClick="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -924,7 +956,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="1"
+          data-config-value="1"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -932,7 +964,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="2"
+          data-config-value="2"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -940,7 +972,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="3"
+          data-config-value="3"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -948,7 +980,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="4"
+          data-config-value="4"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -956,7 +988,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="5"
+          data-config-value="5"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -964,7 +996,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="6"
+          data-config-value="6"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -972,7 +1004,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="7"
+          data-config-value="7"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -980,7 +1012,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="8"
+          data-config-value="8"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -988,7 +1020,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="9"
+          data-config-value="9"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -996,7 +1028,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="10"
+          data-config-value="10"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1004,7 +1036,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="11"
+          data-config-value="11"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1012,7 +1044,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="12"
+          data-config-value="12"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1020,7 +1052,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="13"
+          data-config-value="13"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1028,7 +1060,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="14"
+          data-config-value="14"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1036,7 +1068,7 @@
         </div>
         <div
           class="button"
-          playSoundOnClick="15"
+          data-config-value="15"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1044,7 +1076,7 @@
         </div>
       </div>
     </div>
-    <div class="section playSoundOnError fullWidth">
+    <div class="section fullWidth" data-config-name="playSoundOnError">
       <div class="groupTitle">
         <i class="fas fa-volume-mute"></i>
         <span>play sound on error</span>
@@ -1056,7 +1088,7 @@
       <div class="buttons">
         <div
           class="button"
-          playSoundOnError="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1064,7 +1096,7 @@
         </div>
         <div
           class="button"
-          playSoundOnError="1"
+          data-config-value="1"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1072,7 +1104,7 @@
         </div>
         <div
           class="button"
-          playSoundOnError="2"
+          data-config-value="2"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1080,7 +1112,7 @@
         </div>
         <div
           class="button"
-          playSoundOnError="3"
+          data-config-value="3"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1088,7 +1120,7 @@
         </div>
         <div
           class="button"
-          playSoundOnError="4"
+          data-config-value="4"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1104,7 +1136,7 @@
     caret
   </button>
   <div class="settingsGroup caret">
-    <div class="section smoothCaret" section="">
+    <div class="section" data-config-name="smoothCaret">
       <div class="groupTitle">
         <i class="fas fa-i-cursor"></i>
         <span>smooth caret</span>
@@ -1115,7 +1147,7 @@
       <div class="buttons">
         <div
           class="button"
-          smoothCaret="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1123,7 +1155,7 @@
         </div>
         <div
           class="button"
-          smoothCaret="slow"
+          data-config-value="slow"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1131,7 +1163,7 @@
         </div>
         <div
           class="button"
-          smoothCaret="medium"
+          data-config-value="medium"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1139,7 +1171,7 @@
         </div>
         <div
           class="button"
-          smoothCaret="fast"
+          data-config-value="fast"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1147,7 +1179,7 @@
         </div>
       </div>
     </div>
-    <div class="section caretStyle" section="">
+    <div class="section" data-config-name="caretStyle">
       <div class="groupTitle">
         <i class="fas fa-i-cursor"></i>
         <span>caret style</span>
@@ -1156,7 +1188,7 @@
       <div class="buttons">
         <div
           class="button"
-          caretStyle="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1164,7 +1196,7 @@
         </div>
         <div
           class="button"
-          caretStyle="default"
+          data-config-value="default"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1172,7 +1204,7 @@
         </div>
         <div
           class="button"
-          caretStyle="block"
+          data-config-value="block"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1180,7 +1212,7 @@
         </div>
         <div
           class="button"
-          caretStyle="outline"
+          data-config-value="outline"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1188,7 +1220,7 @@
         </div>
         <div
           class="button"
-          caretStyle="underline"
+          data-config-value="underline"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1196,7 +1228,7 @@
         </div>
       </div>
     </div>
-    <div class="section paceCaret" section="">
+    <div class="section" data-config-name="paceCaret">
       <div class="groupTitle">
         <i class="fas fa-i-cursor"></i>
         <span>pace caret</span>
@@ -1217,14 +1249,18 @@
             step="1"
             value=""
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
         <div class="buttons">
           <div
             class="button"
-            paceCaret="off"
+            data-config-value="off"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1232,7 +1268,7 @@
           </div>
           <div
             class="button"
-            paceCaret="average"
+            data-config-value="average"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1240,7 +1276,7 @@
           </div>
           <div
             class="button"
-            paceCaret="pb"
+            data-config-value="pb"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1248,7 +1284,7 @@
           </div>
           <div
             class="button"
-            paceCaret="last"
+            data-config-value="last"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1256,7 +1292,7 @@
           </div>
           <div
             class="button"
-            paceCaret="daily"
+            data-config-value="daily"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1264,7 +1300,7 @@
           </div>
           <div
             class="button"
-            paceCaret="custom"
+            data-config-value="custom"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -1273,7 +1309,7 @@
         </div>
       </div>
     </div>
-    <div class="section repeatedPace" section="">
+    <div class="section" data-config-name="repeatedPace">
       <div class="groupTitle">
         <i class="fas fa-i-cursor"></i>
         <span>repeated pace</span>
@@ -1286,7 +1322,7 @@
       <div class="buttons">
         <div
           class="button"
-          repeatedPace="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1294,7 +1330,7 @@
         </div>
         <div
           class="button"
-          repeatedPace="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1302,7 +1338,7 @@
         </div>
       </div>
     </div>
-    <div class="section paceCaretStyle" section="">
+    <div class="section" data-config-name="paceCaretStyle">
       <div class="groupTitle">
         <i class="fas fa-i-cursor"></i>
         <span>pace caret style</span>
@@ -1313,7 +1349,7 @@
       <div class="buttons">
         <div
           class="button"
-          paceCaretStyle="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1321,7 +1357,7 @@
         </div>
         <div
           class="button"
-          paceCaretStyle="default"
+          data-config-value="default"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1329,7 +1365,7 @@
         </div>
         <div
           class="button"
-          paceCaretStyle="block"
+          data-config-value="block"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1337,7 +1373,7 @@
         </div>
         <div
           class="button"
-          paceCaretStyle="outline"
+          data-config-value="outline"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1345,7 +1381,7 @@
         </div>
         <div
           class="button"
-          paceCaretStyle="underline"
+          data-config-value="underline"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1365,7 +1401,7 @@
     appearance
   </button>
   <div class="settingsGroup appearance">
-    <div class="section timerStyle" section="">
+    <div class="section" data-config-name="timerStyle">
       <div class="groupTitle">
         <i class="fas fa-chart-pie"></i>
         <span>live progress style</span>
@@ -1376,7 +1412,7 @@
       <div class="buttons">
         <div
           class="button"
-          timerStyle="bar"
+          data-config-value="bar"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1384,7 +1420,7 @@
         </div>
         <div
           class="button"
-          timerStyle="text"
+          data-config-value="text"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1392,7 +1428,7 @@
         </div>
         <div
           class="button"
-          timerStyle="mini"
+          data-config-value="mini"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1400,7 +1436,7 @@
         </div>
       </div>
     </div>
-    <div class="section timerColor" section="">
+    <div class="section" data-config-name="timerColor">
       <div class="groupTitle">
         <i class="fas fa-chart-pie"></i>
         <span>live progress color</span>
@@ -1412,7 +1448,7 @@
       <div class="buttons">
         <div
           class="button"
-          timerColor="black"
+          data-config-value="black"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1420,7 +1456,7 @@
         </div>
         <div
           class="button"
-          timerColor="sub"
+          data-config-value="sub"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1428,7 +1464,7 @@
         </div>
         <div
           class="button"
-          timerColor="text"
+          data-config-value="text"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1436,7 +1472,7 @@
         </div>
         <div
           class="button"
-          timerColor="main"
+          data-config-value="main"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1444,7 +1480,7 @@
         </div>
       </div>
     </div>
-    <div class="section timerOpacity" section="">
+    <div class="section" data-config-name="timerOpacity">
       <div class="groupTitle">
         <i class="fas fa-chart-pie"></i>
         <span>live progress opacity</span>
@@ -1456,7 +1492,7 @@
       <div class="buttons">
         <div
           class="button"
-          timerOpacity="0.25"
+          data-config-value="0.25"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1464,7 +1500,7 @@
         </div>
         <div
           class="button"
-          timerOpacity="0.5"
+          data-config-value="0.5"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1472,7 +1508,7 @@
         </div>
         <div
           class="button"
-          timerOpacity="0.75"
+          data-config-value="0.75"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1480,7 +1516,7 @@
         </div>
         <div
           class="button"
-          timerOpacity="1"
+          data-config-value="1"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1488,7 +1524,7 @@
         </div>
       </div>
     </div>
-    <div class="section highlightMode fullWidth" section="">
+    <div class="section fullWidth" data-config-name="highlightMode">
       <div class="groupTitle">
         <i class="fas fa-highlighter"></i>
         <span>highlight mode</span>
@@ -1497,7 +1533,7 @@
       <div class="buttons">
         <div
           class="button"
-          highlightMode="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1505,7 +1541,7 @@
         </div>
         <div
           class="button"
-          highlightMode="letter"
+          data-config-value="letter"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1513,7 +1549,7 @@
         </div>
         <div
           class="button"
-          highlightMode="word"
+          data-config-value="word"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1521,7 +1557,7 @@
         </div>
         <div
           class="button"
-          highlightMode="next_word"
+          data-config-value="next_word"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1529,7 +1565,7 @@
         </div>
         <div
           class="button"
-          highlightMode="next_two_words"
+          data-config-value="next_two_words"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1537,7 +1573,7 @@
         </div>
         <div
           class="button"
-          highlightMode="next_three_words"
+          data-config-value="next_three_words"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1545,7 +1581,7 @@
         </div>
       </div>
     </div>
-    <div class="section tapeMode" section="">
+    <div class="section" data-config-name="tapeMode">
       <div class="groupTitle">
         <i class="fas fa-tape"></i>
         <span>tape mode</span>
@@ -1557,23 +1593,33 @@
         monospace font.
       </div>
       <div class="buttons">
-        <div class="button" tapeMode="off" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="off"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           off
         </div>
         <div
           class="button"
-          tapeMode="letter"
+          data-config-value="letter"
           tabindex="0"
           onclick="this.blur();"
         >
           letter
         </div>
-        <div class="button" tapeMode="word" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="word"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           word
         </div>
       </div>
     </div>
-    <div class="section smoothLineScroll">
+    <div class="section" data-config-name="smoothLineScroll">
       <div class="groupTitle">
         <i class="fas fa-align-left"></i>
         <span>smooth line scroll</span>
@@ -1584,7 +1630,7 @@
       <div class="buttons">
         <div
           class="button"
-          smoothLineScroll="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1592,7 +1638,7 @@
         </div>
         <div
           class="button"
-          smoothLineScroll="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1600,7 +1646,7 @@
         </div>
       </div>
     </div>
-    <div class="section showAllLines">
+    <div class="section" data-config-name="showAllLines">
       <div class="groupTitle">
         <i class="fas fa-align-left"></i>
         <span>show all lines</span>
@@ -1614,7 +1660,7 @@
       <div class="buttons">
         <div
           class="button"
-          showAllLines="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1622,7 +1668,7 @@
         </div>
         <div
           class="button"
-          showAllLines="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1630,7 +1676,7 @@
         </div>
       </div>
     </div>
-    <div class="section alwaysShowDecimalPlaces">
+    <div class="section" data-config-name="alwaysShowDecimalPlaces">
       <div class="groupTitle">
         <div class="textIcon">00</div>
         <span>always show decimal places</span>
@@ -1642,7 +1688,7 @@
       <div class="buttons">
         <div
           class="button"
-          alwaysShowDecimalPlaces="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1650,7 +1696,7 @@
         </div>
         <div
           class="button"
-          alwaysShowDecimalPlaces="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1658,7 +1704,7 @@
         </div>
       </div>
     </div>
-    <div class="section typingSpeedUnit">
+    <div class="section" data-config-name="typingSpeedUnit">
       <div class="groupTitle">
         <i class="fas fa-tachometer-alt"></i>
         <span>typing speed unit</span>
@@ -1667,7 +1713,7 @@
       <div class="buttons">
         <div
           class="button"
-          typingSpeedUnit="wpm"
+          data-config-value="wpm"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1675,7 +1721,7 @@
         </div>
         <div
           class="button"
-          typingSpeedUnit="cpm"
+          data-config-value="cpm"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1683,7 +1729,7 @@
         </div>
         <div
           class="button"
-          typingSpeedUnit="wps"
+          data-config-value="wps"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1691,7 +1737,7 @@
         </div>
         <div
           class="button"
-          typingSpeedUnit="cps"
+          data-config-value="cps"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1699,7 +1745,7 @@
         </div>
       </div>
     </div>
-    <div class="section startGraphsAtZero">
+    <div class="section" data-config-name="startGraphsAtZero">
       <div class="groupTitle">
         <i class="fas fa-chart-line"></i>
         <span>start graphs at zero</span>
@@ -1711,7 +1757,7 @@
       <div class="buttons">
         <div
           class="button"
-          startGraphsAtZero="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1719,7 +1765,7 @@
         </div>
         <div
           class="button"
-          startGraphsAtZero="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1727,7 +1773,7 @@
         </div>
       </div>
     </div>
-    <div class="section fontSize">
+    <div class="section" data-config-name="fontSize">
       <div class="groupTitle">
         <i class="fas fa-font"></i>
         <span>font size</span>
@@ -1741,13 +1787,17 @@
             class="input"
             tabindex="0"
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
       </div>
     </div>
-    <div class="section fontFamily fullWidth">
+    <div class="section fullWidth" data-config-name="fontFamily">
       <div class="groupTitle">
         <i class="fas fa-font"></i>
         <span>font family</span>
@@ -1755,31 +1805,56 @@
       <!-- <div class="text">Change the font family for the site</div> -->
       <div class="buttons"></div>
     </div>
-    <div class="section pageWidth">
+    <div class="section" data-config-name="pageWidth">
       <div class="groupTitle">
         <i class="fas fa-arrows-alt-h"></i>
         <span>page width</span>
       </div>
       <div class="text">Control the width of the content.</div>
       <div class="buttons">
-        <div class="button" pageWidth="100" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="100"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           100%
         </div>
-        <div class="button" pageWidth="125" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="125"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           125%
         </div>
-        <div class="button" pageWidth="150" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="150"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           150%
         </div>
-        <div class="button" pageWidth="200" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="200"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           200%
         </div>
-        <div class="button" pageWidth="max" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="max"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           max
         </div>
       </div>
     </div>
-    <div class="section keymapMode">
+    <div class="section" data-config-name="keymapMode">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>keymap</span>
@@ -1791,7 +1866,7 @@
       <div class="buttons">
         <div
           class="button"
-          keymapMode="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1799,7 +1874,7 @@
         </div>
         <div
           class="button"
-          keymapMode="static"
+          data-config-value="static"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1807,7 +1882,7 @@
         </div>
         <div
           class="button"
-          keymapMode="react"
+          data-config-value="react"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1815,7 +1890,7 @@
         </div>
         <div
           class="button"
-          keymapMode="next"
+          data-config-value="next"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1823,7 +1898,7 @@
         </div>
       </div>
     </div>
-    <div class="section keymapLayout">
+    <div class="section" data-config-name="keymapLayout">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>keymap layout</span>
@@ -1831,7 +1906,7 @@
       <div class="text">Controls which layout is displayed on the keymap.</div>
       <select></select>
     </div>
-    <div class="section keymapStyle fullWidth">
+    <div class="section fullWidth" data-config-name="keymapStyle">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>keymap style</span>
@@ -1840,7 +1915,7 @@
       <div class="buttons">
         <div
           class="button"
-          keymapStyle="staggered"
+          data-config-value="staggered"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1848,7 +1923,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="alice"
+          data-config-value="alice"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1856,7 +1931,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="matrix"
+          data-config-value="matrix"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1864,7 +1939,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="split"
+          data-config-value="split"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1872,7 +1947,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="split_matrix"
+          data-config-value="split_matrix"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1880,7 +1955,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="steno"
+          data-config-value="steno"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1888,7 +1963,7 @@
         </div>
         <div
           class="button"
-          keymapStyle="steno_matrix"
+          data-config-value="steno_matrix"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1896,7 +1971,7 @@
         </div>
       </div>
     </div>
-    <div class="section keymapLegendStyle fullWidth">
+    <div class="section fullWidth" data-config-name="keymapLegendStyle">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>keymap legend style</span>
@@ -1904,7 +1979,7 @@
       <div class="buttons">
         <div
           class="button"
-          keymapLegendStyle="lowercase"
+          data-config-value="lowercase"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1912,7 +1987,7 @@
         </div>
         <div
           class="button"
-          keymapLegendStyle="uppercase"
+          data-config-value="uppercase"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1920,7 +1995,7 @@
         </div>
         <div
           class="button"
-          keymapLegendStyle="blank"
+          data-config-value="blank"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1928,7 +2003,7 @@
         </div>
         <div
           class="button"
-          keymapLegendStyle="dynamic"
+          data-config-value="dynamic"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1936,7 +2011,7 @@
         </div>
       </div>
     </div>
-    <div class="section keymapShowTopRow fullWidth">
+    <div class="section fullWidth" data-config-name="keymapShowTopRow">
       <div class="groupTitle">
         <i class="fas fa-keyboard"></i>
         <span>keymap show top row</span>
@@ -1944,7 +2019,7 @@
       <div class="buttons">
         <div
           class="button"
-          keymapShowTopRow="always"
+          data-config-value="always"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1952,7 +2027,7 @@
         </div>
         <div
           class="button"
-          keymapShowTopRow="layout"
+          data-config-value="layout"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1960,7 +2035,7 @@
         </div>
         <div
           class="button"
-          keymapShowTopRow="never"
+          data-config-value="never"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -1985,7 +2060,7 @@
     theme
   </button>
   <div class="settingsGroup theme">
-    <div class="section flipTestColors">
+    <div class="section" data-config-name="flipTestColors">
       <div class="groupTitle">
         <i class="fas fa-adjust"></i>
         <span>flip test colors</span>
@@ -1998,7 +2073,7 @@
       <div class="buttons">
         <div
           class="button"
-          flipTestColors="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2006,7 +2081,7 @@
         </div>
         <div
           class="button"
-          flipTestColors="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2014,7 +2089,7 @@
         </div>
       </div>
     </div>
-    <div class="section colorfulMode">
+    <div class="section" data-config-name="colorfulMode">
       <div class="groupTitle">
         <i class="fas fa-fill-drip"></i>
         <span>colorful mode</span>
@@ -2026,7 +2101,7 @@
       <div class="buttons">
         <div
           class="button"
-          colorfulMode="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2034,7 +2109,7 @@
         </div>
         <div
           class="button"
-          colorfulMode="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2042,7 +2117,7 @@
         </div>
       </div>
     </div>
-    <div class="section customBackgroundSize">
+    <div class="section" data-config-name="customBackgroundSize">
       <div class="groupTitle">
         <i class="fas fa-image"></i>
         <span>custom background</span>
@@ -2061,14 +2136,18 @@
             tabindex="0"
             onClick="this.select();"
           />
-          <div class="button save" tabindex="0" onclick="this.blur();">
+          <div
+            class="button save no-auto-handle"
+            tabindex="0"
+            onclick="this.blur();"
+          >
             <i class="fas fa-save fa-fw"></i>
           </div>
         </div>
         <div class="buttons">
           <div
             class="button"
-            customBackgroundSize="cover"
+            data-config-value="cover"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -2076,7 +2155,7 @@
           </div>
           <div
             class="button"
-            customBackgroundSize="contain"
+            data-config-value="contain"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -2084,7 +2163,7 @@
           </div>
           <div
             class="button"
-            customBackGroundSize="max"
+            data-config-value="max"
             tabindex="0"
             onclick="this.blur();"
           >
@@ -2093,7 +2172,7 @@
         </div>
       </div>
     </div>
-    <div class="section customBackgroundFilter fullWidth">
+    <div class="section fullWidth" data-config-name="customBackgroundFilter">
       <div class="groupTitle">
         <i class="fas fa-sliders-h"></i>
         <span>custom background filter</span>
@@ -2122,7 +2201,7 @@
         </div>
       </div>
     </div>
-    <div class="section autoSwitchTheme">
+    <div class="section" data-config-name="autoSwitchTheme">
       <div class="groupTitle">
         <i class="fas fa-palette"></i>
         <span>auto switch theme</span>
@@ -2134,7 +2213,7 @@
       <div class="buttons">
         <div
           class="button"
-          autoSwitchTheme="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2142,7 +2221,7 @@
         </div>
         <div
           class="button"
-          autoSwitchTheme="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2150,13 +2229,13 @@
         </div>
       </div>
     </div>
-    <div class="section autoSwitchThemeInputs">
+    <div class="section" data-config-name="autoSwitchThemeInputs">
       <div>light</div>
       <div><select class="light"></select></div>
       <div>dark</div>
       <div><select class="dark"></select></div>
     </div>
-    <div class="section randomTheme fullWidth">
+    <div class="section fullWidth" data-config-name="randomTheme">
       <div class="groupTitle">
         <i class="fas fa-random"></i>
         <span>randomize theme</span>
@@ -2171,7 +2250,7 @@
       <div class="buttons">
         <div
           class="button"
-          randomTheme="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2179,7 +2258,7 @@
         </div>
         <div
           class="button"
-          randomTheme="on"
+          data-config-value="on"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2187,7 +2266,7 @@
         </div>
         <div
           class="button"
-          randomTheme="fav"
+          data-config-value="fav"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2195,7 +2274,7 @@
         </div>
         <div
           class="button"
-          randomTheme="light"
+          data-config-value="light"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2203,7 +2282,7 @@
         </div>
         <div
           class="button"
-          randomTheme="dark"
+          data-config-value="dark"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2211,7 +2290,7 @@
         </div>
         <div
           class="button"
-          randomTheme="custom"
+          data-config-value="custom"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2471,7 +2550,7 @@
     hide elements
   </button>
   <div class="settingsGroup hideElements">
-    <div class="section showLiveWpm">
+    <div class="section" data-config-name="showLiveWpm">
       <div class="groupTitle">
         <i class="fas fa-tachometer-alt"></i>
         <span>live speed</span>
@@ -2482,7 +2561,7 @@
       <div class="buttons">
         <div
           class="button"
-          showLiveWpm="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2490,7 +2569,7 @@
         </div>
         <div
           class="button"
-          showLiveWpm="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2498,7 +2577,7 @@
         </div>
       </div>
     </div>
-    <div class="section showLiveAcc">
+    <div class="section" data-config-name="showLiveAcc">
       <div class="groupTitle">
         <i class="fas fa-tachometer-alt"></i>
         <span>live accuracy</span>
@@ -2507,7 +2586,7 @@
       <div class="buttons">
         <div
           class="button"
-          showLiveAcc="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2515,7 +2594,7 @@
         </div>
         <div
           class="button"
-          showLiveAcc="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2523,7 +2602,7 @@
         </div>
       </div>
     </div>
-    <div class="section showLiveBurst">
+    <div class="section" data-config-name="showLiveBurst">
       <div class="groupTitle">
         <i class="fas fa-tachometer-alt"></i>
         <span>live burst</span>
@@ -2534,7 +2613,7 @@
       <div class="buttons">
         <div
           class="button"
-          showLiveBurst="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2542,7 +2621,7 @@
         </div>
         <div
           class="button"
-          showLiveBurst="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2550,7 +2629,7 @@
         </div>
       </div>
     </div>
-    <div class="section showTimerProgress">
+    <div class="section" data-config-name="showTimerProgress">
       <div class="groupTitle">
         <i class="fas fa-chart-pie"></i>
         <span>live progress</span>
@@ -2562,7 +2641,7 @@
       <div class="buttons">
         <div
           class="button"
-          showTimerProgress="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2570,7 +2649,7 @@
         </div>
         <div
           class="button"
-          showTimerProgress="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2578,7 +2657,7 @@
         </div>
       </div>
     </div>
-    <div class="section showKeyTips">
+    <div class="section" data-config-name="showKeyTips">
       <div class="groupTitle">
         <i class="fas fa-question"></i>
         <span>key tips</span>
@@ -2587,7 +2666,7 @@
       <div class="buttons">
         <div
           class="button"
-          showKeyTips="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2595,7 +2674,7 @@
         </div>
         <div
           class="button"
-          showKeyTips="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2603,7 +2682,7 @@
         </div>
       </div>
     </div>
-    <div class="section showOutOfFocusWarning">
+    <div class="section" data-config-name="showOutOfFocusWarning">
       <div class="groupTitle">
         <i class="fas fa-exclamation"></i>
         <span>out of focus warning</span>
@@ -2615,7 +2694,7 @@
       <div class="buttons">
         <div
           class="button"
-          showOutOfFocusWarning="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2623,7 +2702,7 @@
         </div>
         <div
           class="button"
-          showOutOfFocusWarning="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2631,7 +2710,7 @@
         </div>
       </div>
     </div>
-    <div class="section capsLockWarning">
+    <div class="section" data-config-name="capsLockWarning">
       <div class="groupTitle">
         <i class="fas fa-exclamation-triangle"></i>
         <span>caps lock warning</span>
@@ -2640,7 +2719,7 @@
       <div class="buttons">
         <div
           class="button"
-          capsLockWarning="false"
+          data-config-value="false"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2648,7 +2727,7 @@
         </div>
         <div
           class="button"
-          capsLockWarning="true"
+          data-config-value="true"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2656,7 +2735,7 @@
         </div>
       </div>
     </div>
-    <div class="section showAverage">
+    <div class="section" data-config-name="showAverage">
       <div class="groupTitle">
         <i class="fas fa-chart-bar"></i>
         <span>average</span>
@@ -2667,7 +2746,7 @@
       <div class="buttons">
         <div
           class="button"
-          showAverage="off"
+          data-config-value="off"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2675,7 +2754,7 @@
         </div>
         <div
           class="button"
-          showAverage="speed"
+          data-config-value="speed"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2683,7 +2762,7 @@
         </div>
         <div
           class="button"
-          showAverage="acc"
+          data-config-value="acc"
           tabindex="0"
           onclick="this.blur();"
         >
@@ -2691,7 +2770,7 @@
         </div>
         <div
           class="button"
-          showAverage="both"
+          data-config-value="both"
           tabindex="0"
           onclick="this.blur();"
         >

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -143,30 +143,9 @@
         single incorrect key (meaning you have to achieve 100% accuracy).
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="normal"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          normal
-        </div>
-        <div
-          class="button"
-          data-config-value="expert"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          expert
-        </div>
-        <div
-          class="button"
-          data-config-value="master"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          master
-        </div>
+        <button data-config-value="normal">normal</button>
+        <button data-config-value="expert">expert</button>
+        <button data-config-value="master">master</button>
       </div>
     </div>
     <div class="section" data-config-name="quickRestart">
@@ -188,38 +167,10 @@
         key.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="tab"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          tab
-        </div>
-        <div
-          class="button"
-          data-config-value="esc"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          esc
-        </div>
-        <div
-          class="button"
-          data-config-value="enter"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          enter
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="tab">tab</button>
+        <button data-config-value="esc">esc</button>
+        <button data-config-value="enter">enter</button>
       </div>
     </div>
 
@@ -235,22 +186,8 @@
       </div>
       <!-- , and 'always' will always repeat the quote (you will need to press <key>shift + tab</key> to move on to the next quote). -->
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="typing"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          typing
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="typing">typing</button>
         <!-- <div class="button" repeatQuotes="always" tabindex="0" onclick="this.blur();">
           always
         </div> -->
@@ -267,23 +204,11 @@
         speed. If enabled, quick end is recommended.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">
           ⠀
           <!-- On is missing on purpose. -->
-        </div>
+        </button>
       </div>
     </div>
     <div class="section" data-config-name="alwaysShowWordsHistory">
@@ -296,17 +221,8 @@
         test. Can cause slight lag with a lot of words.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div class="button" data-config-value="true" onclick="this.blur();">
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="singleListCommandLine">
@@ -322,22 +238,8 @@
         .
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="manual"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          manual
-        </div>
-        <div
-          class="button"
-          data-config-value="on"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="manual">manual</button>
+        <button data-config-value="on">on</button>
       </div>
     </div>
     <div class="section" data-config-name="minWpm">
@@ -359,31 +261,13 @@
             step="1"
             value=""
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
         <div class="buttons">
-          <div
-            class="button"
-            data-config-value="off"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            off
-          </div>
-          <div
-            class="button"
-            data-config-value="custom"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            custom
-          </div>
+          <button data-config-value="off">off</button>
+          <button data-config-value="custom">custom</button>
         </div>
       </div>
     </div>
@@ -406,31 +290,13 @@
             step="1"
             value=""
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
         <div class="buttons">
-          <div
-            class="button"
-            data-config-value="off"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            off
-          </div>
-          <div
-            class="button"
-            data-config-value="custom"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            custom
-          </div>
+          <button data-config-value="off">off</button>
+          <button data-config-value="custom">custom</button>
         </div>
       </div>
     </div>
@@ -455,39 +321,14 @@
             step="1"
             value=""
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
         <div class="buttons">
-          <div
-            class="button"
-            data-config-value="off"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            off
-          </div>
-          <div
-            class="button"
-            data-config-value="fixed"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            fixed
-          </div>
-          <div
-            class="button"
-            data-config-value="flex"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            flex
-          </div>
+          <button data-config-value="off">off</button>
+          <button data-config-value="fixed">fixed</button>
+          <button data-config-value="flex">flex</button>
         </div>
       </div>
     </div>
@@ -502,22 +343,8 @@
         find any issues, please let us know.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="language">
@@ -559,13 +386,9 @@
             class="input"
             tabindex="0"
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -585,22 +408,8 @@
         Allows you to delete any word, even if it was typed correctly.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="strictSpace">
@@ -613,22 +422,8 @@
         when this mode is enabled.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="oppositeShiftMode">
@@ -652,30 +447,9 @@
         opposite shift based on the "keymap layout" setting.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="on"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
-        <div
-          class="button"
-          data-config-value="keymap"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          keymap
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="on">on</button>
+        <button data-config-value="keymap">keymap</button>
       </div>
     </div>
     <div class="section" data-config-name="stopOnError">
@@ -689,30 +463,9 @@
         all mistakes.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="word"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          word
-        </div>
-        <div
-          class="button"
-          data-config-value="letter"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          letter
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="word">word</button>
+        <button data-config-value="letter">letter</button>
       </div>
     </div>
     <div class="section" data-config-name="confidenceMode">
@@ -726,31 +479,10 @@
         all.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
+        <button data-config-value="off">off</button>
 
-        <div
-          class="button"
-          data-config-value="on"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
-        <div
-          class="button"
-          data-config-value="max"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          max
-        </div>
+        <button data-config-value="on">on</button>
+        <button data-config-value="max">max</button>
       </div>
     </div>
     <div class="section" data-config-name="quickEnd">
@@ -765,22 +497,8 @@
         space.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="indicateTypos">
@@ -793,30 +511,9 @@
         letters and replace will replace the letters with the ones you typed.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="below"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          below
-        </div>
-        <div
-          class="button"
-          data-config-value="replace"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          replace
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="below">below</button>
+        <button data-config-value="replace">replace</button>
       </div>
     </div>
     <div class="section" data-config-name="hideExtraLetters">
@@ -830,22 +527,8 @@
         and nothing happens.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="lazyMode">
@@ -858,22 +541,8 @@
         letter equivalents.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="layout">
@@ -946,134 +615,22 @@
       </div>
       <div class="text">Plays a short sound when you press a key.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="1"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          click
-        </div>
-        <div
-          class="button"
-          data-config-value="2"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          beep
-        </div>
-        <div
-          class="button"
-          data-config-value="3"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          pop
-        </div>
-        <div
-          class="button"
-          data-config-value="4"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          nk creams
-        </div>
-        <div
-          class="button"
-          data-config-value="5"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          typewriter
-        </div>
-        <div
-          class="button"
-          data-config-value="6"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          osu
-        </div>
-        <div
-          class="button"
-          data-config-value="7"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hitmarker
-        </div>
-        <div
-          class="button"
-          data-config-value="8"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          sine
-        </div>
-        <div
-          class="button"
-          data-config-value="9"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          sawtooth
-        </div>
-        <div
-          class="button"
-          data-config-value="10"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          square
-        </div>
-        <div
-          class="button"
-          data-config-value="11"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          triangle
-        </div>
-        <div
-          class="button"
-          data-config-value="12"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          pentatonic
-        </div>
-        <div
-          class="button"
-          data-config-value="13"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          wholetone
-        </div>
-        <div
-          class="button"
-          data-config-value="14"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          fist fight
-        </div>
-        <div
-          class="button"
-          data-config-value="15"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          rubber keys
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="1">click</button>
+        <button data-config-value="2">beep</button>
+        <button data-config-value="3">pop</button>
+        <button data-config-value="4">nk creams</button>
+        <button data-config-value="5">typewriter</button>
+        <button data-config-value="6">osu</button>
+        <button data-config-value="7">hitmarker</button>
+        <button data-config-value="8">sine</button>
+        <button data-config-value="9">sawtooth</button>
+        <button data-config-value="10">square</button>
+        <button data-config-value="11">triangle</button>
+        <button data-config-value="12">pentatonic</button>
+        <button data-config-value="13">wholetone</button>
+        <button data-config-value="14">fist fight</button>
+        <button data-config-value="15">rubber keys</button>
       </div>
     </div>
     <div class="section fullWidth" data-config-name="playSoundOnError">
@@ -1086,46 +643,11 @@
         early.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="1"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          damage
-        </div>
-        <div
-          class="button"
-          data-config-value="2"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          triangle
-        </div>
-        <div
-          class="button"
-          data-config-value="3"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          square
-        </div>
-        <div
-          class="button"
-          data-config-value="4"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          missed punch
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="1">damage</button>
+        <button data-config-value="2">triangle</button>
+        <button data-config-value="3">square</button>
+        <button data-config-value="4">missed punch</button>
       </div>
     </div>
     <div class="sectionSpacer"></div>
@@ -1145,38 +667,10 @@
         The caret will move smoothly between letters and words.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="slow"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          slow
-        </div>
-        <div
-          class="button"
-          data-config-value="medium"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          medium
-        </div>
-        <div
-          class="button"
-          data-config-value="fast"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          fast
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="slow">slow</button>
+        <button data-config-value="medium">medium</button>
+        <button data-config-value="fast">fast</button>
       </div>
     </div>
     <div class="section" data-config-name="caretStyle">
@@ -1186,46 +680,11 @@
       </div>
       <div class="text">Change the style of the caret during the test.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="default"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          |
-        </div>
-        <div
-          class="button"
-          data-config-value="block"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          ▮
-        </div>
-        <div
-          class="button"
-          data-config-value="outline"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          ▯
-        </div>
-        <div
-          class="button"
-          data-config-value="underline"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          _
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="default">|</button>
+        <button data-config-value="block">▮</button>
+        <button data-config-value="outline">▯</button>
+        <button data-config-value="underline">_</button>
       </div>
     </div>
     <div class="section" data-config-name="paceCaret">
@@ -1249,63 +708,17 @@
             step="1"
             value=""
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
         <div class="buttons">
-          <div
-            class="button"
-            data-config-value="off"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            off
-          </div>
-          <div
-            class="button"
-            data-config-value="average"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            avg
-          </div>
-          <div
-            class="button"
-            data-config-value="pb"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            pb
-          </div>
-          <div
-            class="button"
-            data-config-value="last"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            last
-          </div>
-          <div
-            class="button"
-            data-config-value="daily"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            daily
-          </div>
-          <div
-            class="button"
-            data-config-value="custom"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            custom
-          </div>
+          <button data-config-value="off">off</button>
+          <button data-config-value="average">avg</button>
+          <button data-config-value="pb">pb</button>
+          <button data-config-value="last">last</button>
+          <button data-config-value="daily">daily</button>
+          <button data-config-value="custom">custom</button>
         </div>
       </div>
     </div>
@@ -1320,22 +733,8 @@
         pace caret if it's already enabled.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="paceCaretStyle">
@@ -1347,46 +746,11 @@
         Change the style of the pace caret during the test.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="default"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          |
-        </div>
-        <div
-          class="button"
-          data-config-value="block"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          ▮
-        </div>
-        <div
-          class="button"
-          data-config-value="outline"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          ▯
-        </div>
-        <div
-          class="button"
-          data-config-value="underline"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          _
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="default">|</button>
+        <button data-config-value="block">▮</button>
+        <button data-config-value="outline">▯</button>
+        <button data-config-value="underline">_</button>
       </div>
     </div>
     <div class="sectionSpacer"></div>
@@ -1410,30 +774,9 @@
         Change the style of the timer/word count during a timed test.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="bar"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          bar
-        </div>
-        <div
-          class="button"
-          data-config-value="text"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          text
-        </div>
-        <div
-          class="button"
-          data-config-value="mini"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          mini
-        </div>
+        <button data-config-value="bar">bar</button>
+        <button data-config-value="text">text</button>
+        <button data-config-value="mini">mini</button>
       </div>
     </div>
     <div class="section" data-config-name="timerColor">
@@ -1446,38 +789,10 @@
         number.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="black"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          black
-        </div>
-        <div
-          class="button"
-          data-config-value="sub"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          sub
-        </div>
-        <div
-          class="button"
-          data-config-value="text"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          text
-        </div>
-        <div
-          class="button"
-          data-config-value="main"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          main
-        </div>
+        <button data-config-value="black">black</button>
+        <button data-config-value="sub">sub</button>
+        <button data-config-value="text">text</button>
+        <button data-config-value="main">main</button>
       </div>
     </div>
     <div class="section" data-config-name="timerOpacity">
@@ -1514,14 +829,7 @@
         >
           0.75
         </div>
-        <div
-          class="button"
-          data-config-value="1"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          1
-        </div>
+        <button data-config-value="1">1</button>
       </div>
     </div>
     <div class="section fullWidth" data-config-name="highlightMode">
@@ -1531,54 +839,12 @@
       </div>
       <div class="text">Change what is highlighted during the test.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="letter"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          letter
-        </div>
-        <div
-          class="button"
-          data-config-value="word"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          word
-        </div>
-        <div
-          class="button"
-          data-config-value="next_word"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          next word
-        </div>
-        <div
-          class="button"
-          data-config-value="next_two_words"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          next two words
-        </div>
-        <div
-          class="button"
-          data-config-value="next_three_words"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          next three words
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="letter">letter</button>
+        <button data-config-value="word">word</button>
+        <button data-config-value="next_word">next word</button>
+        <button data-config-value="next_two_words">next two words</button>
+        <button data-config-value="next_three_words">next three words</button>
       </div>
     </div>
     <div class="section" data-config-name="tapeMode">
@@ -1593,30 +859,9 @@
         monospace font.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="letter"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          letter
-        </div>
-        <div
-          class="button"
-          data-config-value="word"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          word
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="letter">letter</button>
+        <button data-config-value="word">word</button>
       </div>
     </div>
     <div class="section" data-config-name="smoothLineScroll">
@@ -1628,22 +873,8 @@
         When enabled, the line transition will be animated.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="showAllLines">
@@ -1658,22 +889,8 @@
         speed to not be visible.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="alwaysShowDecimalPlaces">
@@ -1686,22 +903,8 @@
         need to hover over the stats.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="typingSpeedUnit">
@@ -1711,38 +914,10 @@
       </div>
       <div class="text">Display typing speed in the specified unit.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="wpm"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          wpm
-        </div>
-        <div
-          class="button"
-          data-config-value="cpm"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          cpm
-        </div>
-        <div
-          class="button"
-          data-config-value="wps"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          wps
-        </div>
-        <div
-          class="button"
-          data-config-value="cps"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          cps
-        </div>
+        <button data-config-value="wpm">wpm</button>
+        <button data-config-value="cpm">cpm</button>
+        <button data-config-value="wps">wps</button>
+        <button data-config-value="cps">cps</button>
       </div>
     </div>
     <div class="section" data-config-name="startGraphsAtZero">
@@ -1755,22 +930,8 @@
         Turning this off may exaggerate the value changes.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="fontSize">
@@ -1787,13 +948,9 @@
             class="input"
             tabindex="0"
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
       </div>
     </div>
@@ -1812,46 +969,11 @@
       </div>
       <div class="text">Control the width of the content.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="100"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          100%
-        </div>
-        <div
-          class="button"
-          data-config-value="125"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          125%
-        </div>
-        <div
-          class="button"
-          data-config-value="150"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          150%
-        </div>
-        <div
-          class="button"
-          data-config-value="200"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          200%
-        </div>
-        <div
-          class="button"
-          data-config-value="max"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          max
-        </div>
+        <button data-config-value="100">100%</button>
+        <button data-config-value="125">125%</button>
+        <button data-config-value="150">150%</button>
+        <button data-config-value="200">200%</button>
+        <button data-config-value="max">max</button>
       </div>
     </div>
     <div class="section" data-config-name="keymapMode">
@@ -1864,38 +986,10 @@
         pressed and Next shows what you need to press next.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="static"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          static
-        </div>
-        <div
-          class="button"
-          data-config-value="react"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          react
-        </div>
-        <div
-          class="button"
-          data-config-value="next"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          next
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="static">static</button>
+        <button data-config-value="react">react</button>
+        <button data-config-value="next">next</button>
       </div>
     </div>
     <div class="section" data-config-name="keymapLayout">
@@ -1913,62 +1007,13 @@
       </div>
       <!-- <div class="text">Displays the keymap in a different style.</div> -->
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="staggered"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          staggered
-        </div>
-        <div
-          class="button"
-          data-config-value="alice"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          alice
-        </div>
-        <div
-          class="button"
-          data-config-value="matrix"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          matrix
-        </div>
-        <div
-          class="button"
-          data-config-value="split"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          split
-        </div>
-        <div
-          class="button"
-          data-config-value="split_matrix"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          split matrix
-        </div>
-        <div
-          class="button"
-          data-config-value="steno"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          steno
-        </div>
-        <div
-          class="button"
-          data-config-value="steno_matrix"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          steno matrix
-        </div>
+        <button data-config-value="staggered">staggered</button>
+        <button data-config-value="alice">alice</button>
+        <button data-config-value="matrix">matrix</button>
+        <button data-config-value="split">split</button>
+        <button data-config-value="split_matrix">split matrix</button>
+        <button data-config-value="steno">steno</button>
+        <button data-config-value="steno_matrix">steno matrix</button>
       </div>
     </div>
     <div class="section fullWidth" data-config-name="keymapLegendStyle">
@@ -1977,38 +1022,10 @@
         <span>keymap legend style</span>
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="lowercase"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          lowercase
-        </div>
-        <div
-          class="button"
-          data-config-value="uppercase"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          uppercase
-        </div>
-        <div
-          class="button"
-          data-config-value="blank"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          blank
-        </div>
-        <div
-          class="button"
-          data-config-value="dynamic"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          dynamic
-        </div>
+        <button data-config-value="lowercase">lowercase</button>
+        <button data-config-value="uppercase">uppercase</button>
+        <button data-config-value="blank">blank</button>
+        <button data-config-value="dynamic">dynamic</button>
       </div>
     </div>
     <div class="section fullWidth" data-config-name="keymapShowTopRow">
@@ -2017,30 +1034,9 @@
         <span>keymap show top row</span>
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="always"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          always
-        </div>
-        <div
-          class="button"
-          data-config-value="layout"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          layout dependent
-        </div>
-        <div
-          class="button"
-          data-config-value="never"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          never
-        </div>
+        <button data-config-value="always">always</button>
+        <button data-config-value="layout">layout dependent</button>
+        <button data-config-value="never">never</button>
       </div>
     </div>
     <div class="sectionSpacer"></div>
@@ -2071,22 +1067,8 @@
         already typed text.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="colorfulMode">
@@ -2099,22 +1081,8 @@
         text color, making the website more colorful.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="customBackgroundSize">
@@ -2136,39 +1104,14 @@
             tabindex="0"
             onClick="this.select();"
           />
-          <div
-            class="button save no-auto-handle"
-            tabindex="0"
-            onclick="this.blur();"
-          >
+          <button class="save no-auto-handle">
             <i class="fas fa-save fa-fw"></i>
-          </div>
+          </button>
         </div>
         <div class="buttons">
-          <div
-            class="button"
-            data-config-value="cover"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            cover
-          </div>
-          <div
-            class="button"
-            data-config-value="contain"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            contain
-          </div>
-          <div
-            class="button"
-            data-config-value="max"
-            tabindex="0"
-            onclick="this.blur();"
-          >
-            max
-          </div>
+          <button data-config-value="cover">cover</button>
+          <button data-config-value="contain">contain</button>
+          <button data-config-value="max">max</button>
         </div>
       </div>
     </div>
@@ -2211,22 +1154,8 @@
         depending on the system theme.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
+        <button data-config-value="false">off</button>
+        <button data-config-value="true">on</button>
       </div>
     </div>
     <div class="section" data-config-name="autoSwitchThemeInputs">
@@ -2248,54 +1177,12 @@
         respectively. If set to 'custom', custom themes will be randomized.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="on"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
-        <div
-          class="button"
-          data-config-value="fav"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          favorite
-        </div>
-        <div
-          class="button"
-          data-config-value="light"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          light
-        </div>
-        <div
-          class="button"
-          data-config-value="dark"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          dark
-        </div>
-        <div
-          class="button"
-          data-config-value="custom"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          custom
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="on">on</button>
+        <button data-config-value="fav">favorite</button>
+        <button data-config-value="light">light</button>
+        <button data-config-value="dark">dark</button>
+        <button data-config-value="custom">custom</button>
       </div>
     </div>
     <div class="section themes fullWidth">
@@ -2559,22 +1446,8 @@
         Displays a live speed during the test. Updates once every second.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showLiveAcc">
@@ -2584,22 +1457,8 @@
       </div>
       <div class="text">Displays live accuracy during the test.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showLiveBurst">
@@ -2611,22 +1470,8 @@
         Displays live burst during the test of the last word you typed.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showTimerProgress">
@@ -2639,22 +1484,8 @@
         tests (word, quote or custom mode).
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showKeyTips">
@@ -2664,22 +1495,8 @@
       </div>
       <div class="text">Shows the keybind tips at the bottom of the page.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showOutOfFocusWarning">
@@ -2692,22 +1509,8 @@
         (not being able to type).
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="capsLockWarning">
@@ -2717,22 +1520,8 @@
       </div>
       <div class="text">Displays a warning when caps lock is on.</div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="false"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          hide
-        </div>
-        <div
-          class="button"
-          data-config-value="true"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          show
-        </div>
+        <button data-config-value="false">hide</button>
+        <button data-config-value="true">show</button>
       </div>
     </div>
     <div class="section" data-config-name="showAverage">
@@ -2744,38 +1533,10 @@
         Displays your average speed and/or accuracy over the last 10 tests.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="speed"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          speed
-        </div>
-        <div
-          class="button"
-          data-config-value="acc"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          acc
-        </div>
-        <div
-          class="button"
-          data-config-value="both"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          both
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="speed">speed</button>
+        <button data-config-value="acc">acc</button>
+        <button data-config-value="both">both</button>
       </div>
     </div>
     <div class="sectionSpacer"></div>
@@ -2829,38 +1590,10 @@
         (changes will take effect after a refresh).
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="off"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          off
-        </div>
-        <div
-          class="button"
-          data-config-value="result"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          result
-        </div>
-        <div
-          class="button"
-          data-config-value="on"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          on
-        </div>
-        <div
-          class="button"
-          data-config-value="sellout"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          sellout
-        </div>
+        <button data-config-value="off">off</button>
+        <button data-config-value="result">result</button>
+        <button data-config-value="on">on</button>
+        <button data-config-value="sellout">sellout</button>
       </div>
     </div>
     <div class="section apeKeys needsAccount hidden">

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -1365,11 +1365,9 @@
               </div>
             </div>
             <div class="customThemeButtons">
-              <div class="button" id="loadCustomColorsFromPreset">
-                load from preset
-              </div>
-              <div class="button" id="shareCustomThemeButton">share</div>
-              <div class="button saveCustomThemeButton">save as new</div>
+              <button id="loadCustomColorsFromPreset">load from preset</button>
+              <button id="shareCustomThemeButton">share</button>
+              <button id="saveCustomThemeButton">save as new</button>
             </div>
           </div>
         </div>

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -1510,22 +1510,8 @@
       </div>
       <div class="text">Import or export the settings as JSON.</div>
       <div class="buttons">
-        <div
-          class="button"
-          id="importSettingsButton"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          import
-        </div>
-        <div
-          class="button"
-          id="exportSettingsButton"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          export
-        </div>
+        <button id="importSettingsButton">import</button>
+        <button id="exportSettingsButton">export</button>
       </div>
     </div>
     <div class="section" data-config-name="ads">
@@ -1569,14 +1555,7 @@
         More endpoints will be added in the future.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          id="showApeKeysPopup"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          open
-        </div>
+        <button id="showApeKeysPopup">open</button>
       </div>
     </div>
     <div class="section updateCookiePreferences">
@@ -1589,7 +1568,7 @@
         change your preferences here.
       </div>
       <div class="buttons">
-        <div class="button" tabindex="0" onclick="this.blur();">open</div>
+        <button>open</button>
       </div>
     </div>
     <div class="section setStreakHourOffset needsAccount hidden">
@@ -1605,14 +1584,9 @@
         <span class="red">You can only do this once!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="setStreakHourOffset"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        <button class="danger" id="setStreakHourOffset">
           update hour offset
-        </div>
+        </button>
       </div>
     </div>
     <div class="section updateAccountName needsAccount hidden">
@@ -1625,14 +1599,7 @@
         days.
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="updateAccountName"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          update name
-        </div>
+        <button class="danger" id="updateAccountName">update name</button>
       </div>
     </div>
     <div class="section passwordAuthSettings needsAccount hidden">
@@ -1644,30 +1611,11 @@
         Add password authentication, update your password or email.
       </div>
       <div class="buttons vertical">
-        <div
-          class="button danger"
-          id="addPasswordAuth"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        <button class="danger" id="addPasswordAuth">
           add password authentication
-        </div>
-        <div
-          class="button danger"
-          id="emailPasswordAuth"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          update email
-        </div>
-        <div
-          class="button danger"
-          id="passPasswordAuth"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          update password
-        </div>
+        </button>
+        <button class="danger" id="emailPasswordAuth">update email</button>
+        <button class="danger" id="passPasswordAuth">update password</button>
       </div>
     </div>
     <div class="section googleAuthSettings needsAccount hidden">
@@ -1677,22 +1625,12 @@
       </div>
       <div class="text">Add or remove Google authentication.</div>
       <div class="buttons vertical">
-        <div
-          class="button danger"
-          id="addGoogleAuth"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        <button class="danger" id="addGoogleAuth">
           add google authentication
-        </div>
-        <div
-          class="button danger"
-          id="removeGoogleAuth"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        </button>
+        <button class="danger" id="removeGoogleAuth">
           remove google authentication
-        </div>
+        </button>
       </div>
     </div>
     <div class="section revokeAllTokens">
@@ -1707,14 +1645,7 @@
         <span class="red">This will log you out of all devices.</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="revokeAllTokens"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          revoke all tokens
-        </div>
+        <button class="danger" id="revokeAllTokens">revoke all tokens</button>
       </div>
     </div>
     <div class="section resetSettings">
@@ -1728,14 +1659,7 @@
         <span class="red">You can't undo this action!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="resetSettingsButton"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          reset settings
-        </div>
+        <button class="danger" id="resetSettingsButton">reset settings</button>
       </div>
     </div>
     <div class="section resetPersonalBests needsAccount hidden">
@@ -1750,14 +1674,9 @@
         <span class="red">You can't undo this action!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="resetPersonalBestsButton"
-          tabindex="0"
-          onclick="this.blur();"
-        >
+        <button class="danger" id="resetPersonalBestsButton">
           reset personal bests
-        </div>
+        </button>
       </div>
     </div>
     <div class="section optOutOfLeaderboards needsAccount hidden">
@@ -1772,14 +1691,7 @@
         <span class="red">You can't undo this action!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="optOutOfLeaderboardsButton"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          opt out
-        </div>
+        <button class="danger" id="optOutOfLeaderboardsButton">opt out</button>
       </div>
     </div>
     <div class="section resetAccount needsAccount hidden">
@@ -1793,14 +1705,7 @@
         <span class="red">You can't undo this action!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="resetAccount"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          reset account
-        </div>
+        <button class="danger" id="resetAccount">reset account</button>
       </div>
     </div>
     <div class="section deleteAccount needsAccount hidden">
@@ -1814,14 +1719,7 @@
         <span class="red">You can't undo this action!</span>
       </div>
       <div class="buttons">
-        <div
-          class="button danger"
-          id="deleteAccount"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          delete account
-        </div>
+        <button class="danger" id="deleteAccount">delete account</button>
       </div>
     </div>
   </div>

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -2815,7 +2815,7 @@
         </div>
       </div>
     </div>
-    <div class="section ads">
+    <div class="section" data-config-name="ads">
       <div class="groupTitle">
         <i class="fas fa-ad"></i>
         <span>ads</span>
@@ -2829,16 +2829,36 @@
         (changes will take effect after a refresh).
       </div>
       <div class="buttons">
-        <div class="button" ads="off" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="off"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           off
         </div>
-        <div class="button" ads="result" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="result"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           result
         </div>
-        <div class="button" ads="on" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="on"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           on
         </div>
-        <div class="button" ads="sellout" tabindex="0" onclick="this.blur();">
+        <div
+          class="button"
+          data-config-value="sellout"
+          tabindex="0"
+          onclick="this.blur();"
+        >
           sellout
         </div>
       </div>

--- a/frontend/static/html/pages/settings.html
+++ b/frontend/static/html/pages/settings.html
@@ -784,30 +784,9 @@
         number.
       </div>
       <div class="buttons">
-        <div
-          class="button"
-          data-config-value="0.25"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          0.25
-        </div>
-        <div
-          class="button"
-          data-config-value="0.5"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          0.5
-        </div>
-        <div
-          class="button"
-          data-config-value="0.75"
-          tabindex="0"
-          onclick="this.blur();"
-        >
-          0.75
-        </div>
+        <button data-config-value="0.25">0.25</button>
+        <button data-config-value="0.5">0.5</button>
+        <button data-config-value="0.75">0.75</button>
         <button data-config-value="1">1</button>
       </div>
     </div>


### PR DESCRIPTION
### Description

 - use `button` element instead of `div` with a `button` class (to improve accesibility)
 - use `data-` properties instead of classes for storing data

This removes a lot of repeated code in the `.html` file