### PR TITLE
impr: Hide input fields indicators on Sign Up page after logged out (underscoore)

### DIFF
--- a/frontend/src/ts/pages/login.ts
+++ b/frontend/src/ts/pages/login.ts
@@ -344,6 +344,11 @@ export const page = new Page(
   },
   async () => {
     $(".pageLogin input").val("");
+    nameIndicator.hide();
+    emailIndicator.hide();
+    verifyEmailIndicator.hide();
+    passwordIndicator.hide();
+    verifyPasswordIndicator.hide();
     Skeleton.remove("pageLogin");
   },
   async () => {


### PR DESCRIPTION
### Description

Sign-up and Sig-In input fields are preserved indicators when the user signs out.

<!-- Please describe the change(s) made in your PR -->

invoked `.hide` on all the indicators when the user performs logged out. So, the previous state of input field indicators gets hidden, and when the user again starts providing details then after the indicators behave again. 

Issue screenshot:
![image](https://github.com/monkeytypegame/monkeytype/assets/21233349/c9c633b2-0329-49e9-804f-16f8d84ce8ad)


