### PR TITLE
impr(funbox): add ` (grave accent, 96) and ~ (tilde, 126) to specials (fitzsim)

### DIFF
--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -689,6 +689,8 @@ export function getSpecials(): string {
   const randLen = randomIntFromRange(1, 7);
   let ret = "";
   const specials = [
+    "`",
+    "~",
     "!",
     "@",
     "#",


### PR DESCRIPTION
I wanted to practice backtick (grave accent) and tilde, but they are not currently included when the "specials" funbox setting is enabled.