### PR TITLE
impr: provide all-time LB results during LB update (fehmer)

### DIFF
--- a/backend/src/dal/leaderboards.ts
+++ b/backend/src/dal/leaderboards.ts
@@ -13,19 +13,28 @@ export async function get(
   skip: number,
   limit = 50
 ): Promise<SharedTypes.LeaderboardEntry[] | false> {
-  if (leaderboardUpdating[`${language}_${mode}_${mode2}`]) return false;
+  //if (leaderboardUpdating[`${language}_${mode}_${mode2}`]) return false;
+
   if (limit > 50 || limit <= 0) limit = 50;
   if (skip < 0) skip = 0;
-  const preset = await db
-    .collection<SharedTypes.LeaderboardEntry>(
-      `leaderboards.${language}.${mode}.${mode2}`
-    )
-    .find()
-    .sort({ rank: 1 })
-    .skip(skip)
-    .limit(limit)
-    .toArray();
-  return preset;
+  try {
+    const preset = await db
+      .collection<SharedTypes.LeaderboardEntry>(
+        `leaderboards.${language}.${mode}.${mode2}`
+      )
+      .find()
+      .sort({ rank: 1 })
+      .skip(skip)
+      .limit(limit)
+      .toArray();
+    return preset;
+  } catch (e) {
+    if (e.error === 175) {
+      //QueryPlanKilled, collection was removed during the query
+      return false;
+    }
+    throw e;
+  }
 }
 
 type GetRankResponse = {


### PR DESCRIPTION
Try to provide LB results during the LB update. There is a very small time-frame where already running queries might fail during the update. For now we keep the 503 error in this cases and monitor how often this happens on production.