### PR TITLE
impr(funbox): add 46 group languages to wikipedia (realcyguy)

### DIFF
--- a/frontend/src/ts/test/wikipedia.ts
+++ b/frontend/src/ts/test/wikipedia.ts
@@ -4,7 +4,62 @@ import { Section } from "../utils/misc";
 
 export async function getTLD(
   languageGroup: MonkeyTypes.LanguageGroup
-): Promise<"en" | "es" | "fr" | "de" | "pt" | "it" | "nl" | "pl"> {
+): Promise<
+  | "en"
+  | "es"
+  | "fr"
+  | "de"
+  | "pt"
+  | "ar"
+  | "it"
+  | "la"
+  | "af"
+  | "ko"
+  | "ru"
+  | "pl"
+  | "cs"
+  | "sk"
+  | "uk"
+  | "lt"
+  | "id"
+  | "el"
+  | "tr"
+  | "th"
+  | "ta"
+  | "sl"
+  | "hr"
+  | "nl"
+  | "da"
+  | "hu"
+  | "no"
+  | "nn"
+  | "he"
+  | "ms"
+  | "ro"
+  | "fi"
+  | "et"
+  | "cy"
+  | "fa"
+  | "kk"
+  | "vi"
+  | "sv"
+  | "sr"
+  | "ka"
+  | "ca"
+  | "bg"
+  | "eo"
+  | "bn"
+  | "ur"
+  | "hy"
+  | "my"
+  | "hi"
+  | "mk"
+  | "uz"
+  | "be"
+  | "az"
+  | "lv"
+  | "eu"
+> {
   // language group to tld
   switch (languageGroup.name) {
     case "english":
@@ -22,14 +77,152 @@ export async function getTLD(
     case "portuguese":
       return "pt";
 
+    case "arabic":
+      return "ar";
+
     case "italian":
       return "it";
+
+    case "latin":
+      return "la";
+
+    case "afrikaans":
+      return "af";
+
+    case "korean":
+      return "ko";
+
+    case "russian":
+      return "ru";
+
+    case "polish":
+      return "pl";
+
+    case "czech":
+      return "cs";
+
+    case "slovak":
+      return "sk";
+
+    case "ukrainian":
+      return "uk";
+
+    case "lithuanian":
+      return "lt";
+
+    case "indonesian":
+      return "id";
+
+    case "greek":
+      return "el";
+
+    case "turkish":
+      return "tr";
+
+    case "thai":
+      return "th";
+
+    case "tamil":
+      return "ta";
+
+    case "slovenian":
+      return "sl";
+
+    case "croatian":
+      return "hr";
 
     case "dutch":
       return "nl";
 
-    case "polish":
-      return "pl";
+    case "danish":
+      return "da";
+
+    case "hungarian":
+      return "hu";
+
+    case "norwegian_bokmal":
+      return "no";
+
+    case "norwegian_nynorsk":
+      return "nn";
+
+    case "hebrew":
+      return "he";
+
+    case "malay":
+      return "ms";
+
+    case "romanian":
+      return "ro";
+
+    case "finnish":
+      return "fi";
+
+    case "estonian":
+      return "et";
+
+    case "welsh":
+      return "cy";
+
+    case "persian":
+      return "fa";
+
+    case "kazakh":
+      return "kk";
+
+    case "vietnamese":
+      return "vi";
+
+    case "swedish":
+      return "sv";
+
+    case "serbian":
+      return "sr";
+
+    case "georgian":
+      return "ka";
+
+    case "catalan":
+      return "ca";
+
+    case "bulgarian":
+      return "bg";
+
+    case "esperanto":
+      return "eo";
+
+    case "bangla":
+      return "bn";
+
+    case "urdu":
+      return "ur";
+
+    case "armenian":
+      return "hy";
+
+    case "myanmar":
+      return "my";
+
+    case "hindi":
+      return "hi";
+
+    case "macedonian":
+      return "mk";
+
+    case "uzbek":
+      return "uz";
+
+    case "belarusian":
+      return "be";
+
+    case "azerbaijani":
+      return "az";
+
+    case "latvian":
+      return "lv";
+
+    case "euskera":
+      return "eu";
 
     default:
       return "en";


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR --> Add the corresponding Wikipedia subdomains to many language groups. I excluded Wikipedias with less than 100,000 articles and Chinese.
### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
