### PR TITLE
feat: add testWords and wordsHistory to copy result stats

### DIFF
--- a/frontend/src/ts/commandline/commands.ts
+++ b/frontend/src/ts/commandline/commands.ts
@@ -101,8 +101,6 @@ import * as ShareTestSettingsPopup from "../popups/share-test-settings-popup";
 import * as TestStats from "../test/test-stats";
 import * as QuoteSearchPopup from "../popups/quote-search-popup";
 import * as FPSCounter from "../elements/fps-counter";
-import * as TestInput from "../test/test-input";
-import * as TestWords from "../test/test-words";
 
 Misc.getLayoutsList()
   .then((layouts) => {
@@ -422,16 +420,7 @@ export const commands: MonkeyTypes.CommandsSubgroup = {
       visible: false,
       exec: async (): Promise<void> => {
         navigator.clipboard
-          .writeText(
-            JSON.stringify({
-              ...(TestStats.getStats() as object),
-              testWords: TestWords.words.list.slice(
-                0,
-                TestInput.input.history.length
-              ),
-              wordsHistory: TestInput.input.history,
-            })
-          )
+          .writeText(JSON.stringify(TestStats.getStats()))
           .then(() => {
             Notifications.add("Copied to clipboard", 1);
           })

--- a/frontend/src/ts/commandline/commands.ts
+++ b/frontend/src/ts/commandline/commands.ts
@@ -101,6 +101,8 @@ import * as ShareTestSettingsPopup from "../popups/share-test-settings-popup";
 import * as TestStats from "../test/test-stats";
 import * as QuoteSearchPopup from "../popups/quote-search-popup";
 import * as FPSCounter from "../elements/fps-counter";
+import * as TestInput from "../test/test-input";
+import * as TestWords from "../test/test-words";
 
 Misc.getLayoutsList()
   .then((layouts) => {
@@ -420,7 +422,16 @@ export const commands: MonkeyTypes.CommandsSubgroup = {
       visible: false,
       exec: async (): Promise<void> => {
         navigator.clipboard
-          .writeText(JSON.stringify(TestStats.getStats()))
+          .writeText(
+            JSON.stringify({
+              ...(TestStats.getStats() as object),
+              testWords: TestWords.words.list.slice(
+                0,
+                TestInput.input.history.length
+              ),
+              wordsHistory: TestInput.input.history,
+            })
+          )
           .then(() => {
             Notifications.add("Copied to clipboard", 1);
           })

--- a/frontend/src/ts/test/test-stats.ts
+++ b/frontend/src/ts/test/test-stats.ts
@@ -60,6 +60,8 @@ export function getStats(): unknown {
     accuracy: TestInput.accuracy,
     keypressTimings: TestInput.keypressTimings,
     keyOverlap: TestInput.keyOverlap,
+    wordsHistory: TestWords.words.list.slice(0, TestInput.input.history.length),
+    inputHistory: TestInput.input.history,
   };
 
   try {


### PR DESCRIPTION
 ### Description

Add the test words and input history to "copy result stats" data:

```
{
    "lastResult": {...},
    "wordsHistory": ["people", "little"],        // words to be typed
    "inputHistory": ["poelpe", "little"]    // words actually typed
}
```
