### PR TITLE
fix: leaderboard tables having different column width (fehmer)

### DIFF
--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -887,17 +887,17 @@
               <tr>
                 <td width="1%">#</td>
                 <td>name</td>
-                <td class="alignRight" width="15%">
+                <td class="alignRight" width="1%">
                   wpm
                   <br />
                   <div class="sub">accuracy</div>
                 </td>
-                <td class="alignRight" width="15%">
+                <td class="alignRight" width="1%">
                   raw
                   <br />
                   <div class="sub">consistency</div>
                 </td>
-                <td class="alignRight" width="22%">date</td>
+                <td class="alignRight" width="110px">date</td>
               </tr>
             </thead>
             <tbody></tbody>

--- a/frontend/static/html/popups.html
+++ b/frontend/static/html/popups.html
@@ -897,7 +897,7 @@
                   <br />
                   <div class="sub">consistency</div>
                 </td>
-                <td class="alignRight" width="110px">date</td>
+                <td class="alignRight" width="125px">date</td>
               </tr>
             </thead>
             <tbody></tbody>
@@ -940,7 +940,7 @@
                   <br />
                   <div class="sub">consistency</div>
                 </td>
-                <td class="alignRight" width="110px">date</td>
+                <td class="alignRight" width="120px">date</td>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
### Description

Use same column width on 15 and 60 seconds leaderboards to fix different row hights.