### PR TITLE
feat(theme): add blissful_bloom theme (NipulM)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1195,5 +1195,12 @@
     "mainColor": "#c13117",
     "subColor": "#717977",
     "textColor": "#490909"
+  },
+  {
+    "name": "blissful_bloom",
+    "bgColor": "#a3de83",
+    "mainColor": "#085f63",
+    "subColor": "#8a4f7d",
+    "textColor": "#fdffe4"
   }
 ]

--- a/frontend/static/themes/blissful_bloom.css
+++ b/frontend/static/themes/blissful_bloom.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #a3de83;
+    --main-color: #085f63;
+    --caret-color: #7d5448;
+    --sub-color: #8a4f7d;
+    --sub-alt-color: #d0bca7;
+    --text-color: #fdffe4;
+    --error-color: #fa4659;
+    --error-extra-color: #b12525;
+    --colorful-error-color: #fa4659;
+    --colorful-error-extra-color: #b12525;
+  }


### PR DESCRIPTION
Description
- Added blissful_bloom.css
- Updated _list.json with blissful_bloom theme

<img width="1436" alt="Screenshot 2024-02-25 at 22 38 03" src="https://github.com/monkeytypegame/monkeytype/assets/125451160/dae32e89-e941-4344-81b4-c53d431ecfaa">
<img width="1440" alt="Screenshot 2024-02-25 at 22 36 58" src="https://github.com/monkeytypegame/monkeytype/assets/125451160/8fd7d2fc-5d3c-4c85-80b1-16b9a6c03b34">
