### PR TITLE
fix: fix tags personal bests handling of missing numbers flag (fehmer)

### DIFF
--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -404,44 +404,11 @@ export async function deleteCustomTheme(themeId: string): Promise<boolean> {
   return true;
 }
 
-async function _getUserHighestWpm<M extends SharedTypes.Config.Mode>(
-  mode: M,
-  mode2: SharedTypes.Config.Mode2<M>,
-  punctuation: boolean,
-  language: string,
-  difficulty: SharedTypes.Config.Difficulty,
-  lazyMode: boolean
-): Promise<number> {
-  function cont(): number {
-    let topWpm = 0;
-
-    dbSnapshot?.results?.forEach((result) => {
-      if (
-        result.mode === mode &&
-        `${result.mode2}` === `${mode2 as string | number}` && //using template strings here because legacy results can have numbers in mode2
-        result.punctuation === punctuation &&
-        result.language === language &&
-        result.difficulty === difficulty &&
-        (result.lazyMode === lazyMode ||
-          (result.lazyMode === undefined && !lazyMode))
-      ) {
-        if (result.wpm > topWpm) {
-          topWpm = result.wpm;
-        }
-      }
-    });
-    return topWpm;
-  }
-
-  const retval = !dbSnapshot || dbSnapshot.results === undefined ? 0 : cont();
-
-  return retval;
-}
-
 export async function getUserAverage10<M extends SharedTypes.Config.Mode>(
   mode: M,
   mode2: SharedTypes.Config.Mode2<M>,
   punctuation: boolean,
+  numbers: boolean,
   language: string,
   difficulty: SharedTypes.Config.Difficulty,
   lazyMode: boolean
@@ -469,7 +436,8 @@ export async function getUserAverage10<M extends SharedTypes.Config.Mode>(
       for (const result of snapshot.results) {
         if (
           result.mode === mode &&
-          result.punctuation === punctuation &&
+          (result.punctuation ?? false) === punctuation &&
+          (result.numbers ?? false) === numbers &&
           result.language === language &&
           result.difficulty === difficulty &&
           (result.lazyMode === lazyMode ||
@@ -525,6 +493,7 @@ export async function getUserDailyBest<M extends SharedTypes.Config.Mode>(
   mode: M,
   mode2: SharedTypes.Config.Mode2<M>,
   punctuation: boolean,
+  numbers: boolean,
   language: string,
   difficulty: SharedTypes.Config.Difficulty,
   lazyMode: boolean
@@ -547,7 +516,8 @@ export async function getUserDailyBest<M extends SharedTypes.Config.Mode>(
       for (const result of snapshot.results) {
         if (
           result.mode === mode &&
-          result.punctuation === punctuation &&
+          (result.punctuation ?? false) === punctuation &&
+          (result.numbers ?? false) === numbers &&
           result.language === language &&
           result.difficulty === difficulty &&
           (result.lazyMode === lazyMode ||

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -273,6 +273,7 @@ export async function getUserResults(offset?: number): Promise<boolean> {
     }
     if (result.numbers === undefined) result.numbers = false;
     if (result.punctuation === undefined) result.punctuation = false;
+    if (result.numbers === undefined) result.numbers = false;
     if (result.quoteLength === undefined) result.quoteLength = -1;
     if (result.restartCount === undefined) result.restartCount = 0;
     if (result.incompleteTestSeconds === undefined) {
@@ -742,8 +743,8 @@ export async function getLocalTagPB<M extends SharedTypes.Config.Mode>(
   ret =
     personalBests.find(
       (pb) =>
-        pb.punctuation === punctuation &&
-        pb.numbers === numbers &&
+        (pb.punctuation ?? false) === punctuation &&
+        (pb.numbers ?? false) === numbers &&
         pb.difficulty === difficulty &&
         pb.language === language &&
         (pb.lazyMode === lazyMode || (pb.lazyMode === undefined && !lazyMode))
@@ -797,8 +798,8 @@ export async function saveLocalTagPB<M extends SharedTypes.Config.Mode>(
         ] as unknown as SharedTypes.PersonalBest[]
       ).forEach((pb) => {
         if (
-          pb.punctuation === punctuation &&
-          pb.numbers === numbers &&
+          (pb.punctuation ?? false) === punctuation &&
+          (pb.numbers ?? false) === numbers &&
           pb.difficulty === difficulty &&
           pb.language === language &&
           (pb.lazyMode === lazyMode || (pb.lazyMode === undefined && !lazyMode))

--- a/frontend/src/ts/elements/last-10-average.ts
+++ b/frontend/src/ts/elements/last-10-average.ts
@@ -14,6 +14,7 @@ export async function update(): Promise<void> {
       Config.mode,
       mode2 as never,
       Config.punctuation,
+      Config.numbers,
       Config.language,
       Config.difficulty,
       Config.lazyMode

--- a/frontend/src/ts/test/pace-caret.ts
+++ b/frontend/src/ts/test/pace-caret.ts
@@ -80,6 +80,7 @@ export async function init(): Promise<void> {
       Config.mode,
       mode2,
       Config.punctuation,
+      Config.numbers,
       Config.language,
       Config.difficulty,
       Config.lazyMode
@@ -90,6 +91,7 @@ export async function init(): Promise<void> {
       Config.mode,
       mode2,
       Config.punctuation,
+      Config.numbers,
       Config.language,
       Config.difficulty,
       Config.lazyMode


### PR DESCRIPTION
### Description

Personal bests on tags are still broken if the backend is missing the `numbers` flag.