### PR TITLE
fix: Trigger hide() function on any key press (Bretis2019)

### DIFF
--- a/frontend/src/ts/elements/alerts.ts
+++ b/frontend/src/ts/elements/alerts.ts
@@ -463,8 +463,8 @@ $("#alertsPopupWrapper .accountAlerts .list").on(
   }
 );
 
-$(document).on("keydown", (e) => {
-  if (e.key === "Escape" && isPopupVisible(wrapperId)) {
+$(document).on("keydown", () => {
+  if (isPopupVisible(wrapperId)) {
     hide();
   }
 });


### PR DESCRIPTION
### Description

This PR modifies the keydown event handler to trigger the hide() function on the alerts panel for any key press, ensuring that tests can't be started with it still open.

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
  - https://github.com/monkeytypegame/monkeytype/issues/5142
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #5142

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
