### PR TITLE
chore: expire security.txt 2024-06-03

### DIFF
--- a/frontend/static/.well-known/security.txt
+++ b/frontend/static/.well-known/security.txt
@@ -1,6 +1,6 @@
 Contact: mailto:contact@monkeytype.com
 Contact: message @Miodec on discord.gg/monkeytype
-Expires: 2023-06-03T21:00:00.000Z
+Expires: 2024-06-03T21:00:00.000Z
 Preferred-Languages: en
 Canonical: https://monkeytype.com/.well-known/security.txt
 Policy: https://monkeytype.com/security-policy


### PR DESCRIPTION
Changing the expiry date for security.txt to something that isn't already passed.

Unfortunately, the RFC requires having an expiry date. Long-term, there should probably be a better solution than someone manually updating this (or not) every year, but as it's technically broken now I've stuck with the quickest fix again (cf #3074).