### PR TITLE
fix: remove °C from estonian language (fehmer)

### DIFF
--- a/frontend/static/languages/estonian_10k.json
+++ b/frontend/static/languages/estonian_10k.json
@@ -957,7 +957,6 @@
     "nimi",
     "sellised",
     "käia",
-    "°C",
     "pikk",
     "ühest",
     "inglise",

--- a/frontend/static/languages/estonian_1k.json
+++ b/frontend/static/languages/estonian_1k.json
@@ -957,7 +957,6 @@
     "nimi",
     "sellised",
     "käia",
-    "°C",
     "pikk",
     "ühest",
     "inglise",


### PR DESCRIPTION
### Description

Fixes #5177.