### PR TITLE
fix: accept layout with dash (mart-e)

### DIFF
--- a/backend/src/api/schemas/config-schema.ts
+++ b/backend/src/api/schemas/config-schema.ts
@@ -77,7 +77,7 @@ const CONFIG_SCHEMA = joi.object({
   keymapLegendStyle: joi
     .string()
     .valid("lowercase", "uppercase", "blank", "dynamic"),
-  keymapLayout: joi.string().valid().max(50).token(),
+  keymapLayout: joi.string().valid().max(50),
   keymapShowTopRow: joi.string().valid("always", "layout", "never"),
   fontFamily: joi
     .string()


### PR DESCRIPTION
### Description

It is not possible to load seht-drai and ergo-l keyboard layout.

To reproduce : switch layout to seht-drai or ergo-l:

> `Failed to save config: "config.keymapLayout" must only contain alpha-numeric and underscore characters (ergo-l)`

Note that an alternative would be to rename those two layers to use an underscore instead of dash I guess.

### Checks

- [ ] Adding quotes?
- [ ] Adding a language or a theme?
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title
- [ ] Tested
