### PR TITLE
fix: prevent print dialog to open with ctrl-shift-p (fehmer)

### DIFF
--- a/frontend/src/ts/event-handlers/global.ts
+++ b/frontend/src/ts/event-handlers/global.ts
@@ -19,6 +19,7 @@ document.addEventListener("keydown", async (e) => {
       e.shiftKey) ||
     (e.key.toLowerCase() === "p" && (e.metaKey || e.ctrlKey) && e.shiftKey)
   ) {
+    e.preventDefault();
     const popupVisible = Misc.isAnyPopupVisible();
     const miniResultPopupVisible = Misc.isElementVisible(
       ".pageAccount .miniResultChartWrapper"


### PR DESCRIPTION
### Description

Prevent the print dialog to show up when trying to open the command line with `ctrl-shift-p` on chrome.