### PR TITLE
impr: replace ß in all variations of swiss german (Jeanot-Zubler)

### DIFF
--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -780,7 +780,7 @@ export async function getNextWord(
   randomWord = applyLazyModeToWord(randomWord, language);
   randomWord = await applyBritishEnglishToWord(randomWord, previousWordRaw);
 
-  if (Config.language === "swiss_german") {
+  if (Config.language.startsWith("swiss_german")) {
     randomWord = randomWord.replace(/ß/g, "ss");
   }
 


### PR DESCRIPTION
### Description

Replace the german character [`ß`](https://de.wikipedia.org/wiki/%C3%9F) with `ss` for all variations of swiss german, including `swiss_german_1k` and `swiss_german_2k`.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

### Relates to
Initial implementation of the feature resulted from Issue #3699