### PR TITLE
fix: enter quick restart not working on test page (fehmer)

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -969,7 +969,8 @@ $(document).on("keydown", async (event) => {
       activeElement?.tagName === "A" ||
       activeElement?.classList.contains("button") ||
       activeElement?.classList.contains("textButton") ||
-      activeElement?.tagName === "INPUT";
+      (activeElement?.tagName === "INPUT" &&
+        activeElement?.id !== "wordsInput");
 
     if (activeElementIsButton) return;
 


### PR DESCRIPTION
### Description

fix `enter` not restarting the test while on test page