### PR TITLE
style: Change csv file name when saving data (vjgtigers)

### DIFF
--- a/frontend/src/html/pages/account.html
+++ b/frontend/src/html/pages/account.html
@@ -601,7 +601,7 @@
     <div class="group aboveHistory">
       <div class="button exportCSV">
         <i class="fas fa-file-csv"></i>
-        Export CSV
+        Export History
       </div>
     </div>
     <div id="ad-account-2-wrapper" class="ad advertisement ad-h">

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1259,7 +1259,7 @@ export async function downloadResultsCSV(
 
   const link = document.createElement("a");
   link.setAttribute("href", href);
-  link.setAttribute("download", "results.csv");
+  link.setAttribute("download", "results.dsv");
   document.body.appendChild(link); // Required for FF
 
   link.click();


### PR DESCRIPTION

### Description

when downloading history it saves as a csv file but the data is not separated by commas. while most csv viewers can still read it, it could cause a little bit of confusion. This pull request changes the file extension to dsv (delimiter separated values) and changed  "Export CSV" to "Export History".  However changing "item.charStats" and "item.tags" to be joined by a different delimiter and changing the main delimiter to commas would also work and could keep the csv extension.