### PR TITLE
impr(csv export): change main delimiter from | to , (vjgtigers)

### DIFF
--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1230,7 +1230,7 @@ export async function downloadResultsCSV(
       item.acc,
       item.rawWpm,
       item.consistency,
-      item.charStats.join(","),
+      item.charStats.join(";"),
       item.mode,
       item.mode2,
       item.quoteLength,
@@ -1246,11 +1246,11 @@ export async function downloadResultsCSV(
       item.lazyMode,
       item.blindMode,
       item.bailedOut,
-      item.tags.join(","),
+      item.tags.join(";"),
       item.timestamp,
     ]),
   ]
-    .map((e) => e.join("|"))
+    .map((e) => e.join(","))
     .join("\n");
 
   const blob = new Blob([csvString], { type: "text/csv" });


### PR DESCRIPTION
### Description

changed the main delimiter from "|" to  "," and changed delimiters in "item.charStats" and "item.tags" from "," to ";". This will prevent possible error with csv viewers not registering "|" as the delimiter.

updated from pull request  [#5248] 
[#5248] can now be deleted