### PR TITLE
impr: changed fps text color from hardcoded values to match user theme (vjgtigers)

### DIFF
--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -385,9 +385,9 @@ key {
   text-align: center;
   z-index: 999999999;
   &.main {
-    color: rgb(30, 255, 0);
+    color: var(--text-color);
   }
   &.error {
-    color: red;
+    color: var(--error-color);
   }
 }


### PR DESCRIPTION
### Description

changed the fpsCounter css settings to change the fps text color from the hard coded green/red to theme text/error colors 
