### PR TITLE
impr(profile): add level percentage when hovering over progress bar (vjgtigers)

### DIFF
--- a/frontend/src/html/header.html
+++ b/frontend/src/html/header.html
@@ -114,7 +114,7 @@
       <div class="avatar hidden"></div>
       <div class="text"></div>
       <div class="levelAndBar">
-        <div class="level">1</div>
+        <div class="level" data-balloon-pos="up">1</div>
         <div class="xpBar">
           <div class="bar"></div>
           <div class="xpGain"></div>

--- a/frontend/src/html/pages/account.html
+++ b/frontend/src/html/pages/account.html
@@ -46,7 +46,7 @@
           </div>
           <div class="levelAndBar">
             <div class="level" data-balloon-pos="up">-</div>
-            <div class="xpBar">
+            <div class="xpBar" data-balloon-pos="up">
               <div class="bar" style="width: 0%"></div>
             </div>
             <div class="xp" data-balloon-pos="up">-/-</div>

--- a/frontend/src/html/pages/profile.html
+++ b/frontend/src/html/pages/profile.html
@@ -38,7 +38,7 @@
           </div>
           <div class="levelAndBar">
             <div class="level" data-balloon-pos="up">-</div>
-            <div class="xpBar">
+            <div class="xpBar" data-balloon-pos="up">
               <div class="bar" style="width: 0%"></div>
             </div>
             <div class="xp" data-balloon-pos="up">-/-</div>

--- a/frontend/src/styles/nav.scss
+++ b/frontend/src/styles/nav.scss
@@ -72,7 +72,7 @@ nav {
 
       .xpBar {
         opacity: 0;
-        pointer-events: none;
+        pointer-events: auto;
         position: absolute;
         height: 0.25em;
         bottom: -0.5em;

--- a/frontend/src/styles/nav.scss
+++ b/frontend/src/styles/nav.scss
@@ -72,7 +72,7 @@ nav {
 
       .xpBar {
         opacity: 0;
-        pointer-events: auto;
+        pointer-events: none;
         position: absolute;
         height: 0.25em;
         bottom: -0.5em;

--- a/frontend/src/styles/profile.scss
+++ b/frontend/src/styles/profile.scss
@@ -415,9 +415,9 @@
         gap: 1rem;
         align-items: center;
         .xpBar {
-          pointer-events: none;
+          pointer-events: auto;
           height: 0.5rem;
-          bottom: -0.25rem;
+          bottom: 0rem;
           width: 100%;
           left: 0;
           background: var(--bg-color);

--- a/frontend/src/styles/profile.scss
+++ b/frontend/src/styles/profile.scss
@@ -414,6 +414,10 @@
         grid-template-columns: auto 1fr auto;
         gap: 1rem;
         align-items: center;
+        .level,
+        .xp {
+          line-height: 0;
+        }
         .xpBar {
           pointer-events: auto;
           height: 0.5rem;

--- a/frontend/src/ts/elements/profile.ts
+++ b/frontend/src/ts/elements/profile.ts
@@ -299,16 +299,17 @@ export async function update(
       `${Misc.abbreviateNumber(xpToDisplay)}/${Misc.abbreviateNumber(
         xpForLevel
       )}`
+    )
+    .attr(
+      "aria-label",
+      `${Misc.abbreviateNumber(xpForLevel - xpToDisplay)} xp until next level`
     );
   details
     .find(".xpBar .bar")
     .css("width", `${(xpToDisplay / xpForLevel) * 100}%`);
   details
-    .find(".xp")
-    .attr(
-      "aria-label",
-      `${Misc.abbreviateNumber(xpForLevel - xpToDisplay)} xp until next level`
-    );
+    .find(".xpBar")
+    .attr("aria-label", `${((xpToDisplay / xpForLevel) * 100).toFixed(2)}%`);
 
   //lbs
 

--- a/frontend/src/ts/elements/profile.ts
+++ b/frontend/src/ts/elements/profile.ts
@@ -308,7 +308,9 @@ export async function update(
     )
     .attr(
       "aria-label",
-      `${Misc.abbreviateNumber(xpForLevel - xpToDisplay)} xp until next level`
+      `${Numbers.abbreviateNumber(
+        xpForLevel - xpToDisplay
+      )} xp until next level`
     );
   details
     .find(".xpBar .bar")

--- a/frontend/src/ts/pages/profile.ts
+++ b/frontend/src/ts/pages/profile.ts
@@ -29,8 +29,8 @@ function reset(): void {
 	          <div class="streak" data-balloon-pos="up">-</div>
           </div>
           <div class="levelAndBar">
-            <div class="level">-</div>
-            <div class="xpBar">
+            <div class="level" data-balloon-pos="up">-</div>
+            <div class="xpBar" data-balloon-pos="up">
               <div class="bar" style="width: 0%;"></div>
             </div>
             <div class="xp" data-balloon-pos="up">-/-</div>


### PR DESCRIPTION
### Description

Added code so when the users mouse hovers over the progress bar the percent complete of that level is displayed

Also:
    added "data-balloon-pos="up""  so that the total user xp on profile view will new appear


Closes #

pull [#5269]
messed up the branch when changing and couldn't fix it




on account and profile view page:

![Screenshot 2024-04-02 220658](https://github.com/monkeytypegame/monkeytype/assets/51890836/a728efb6-33f1-428e-a02b-920a726eef64)




on profile view page:

![Screenshot 2024-04-02 220744](https://github.com/monkeytypegame/monkeytype/assets/51890836/68b5d10b-00b4-4d6a-bcd5-421d7c4204bc)



