### PR TITLE
fix: docker build hanging for frontend (fehmer)

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:hydrogen-alpine as builder
+FROM node:18.19.1-alpine3.19 as builder
 WORKDIR /app
 
 #copy

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:hydrogen-alpine as builder
+FROM node:18.19.1-alpine3.19 as builder
 WORKDIR /app
 
 #ENV


### PR DESCRIPTION
### Description

Docker build is hanging for `npm ci` on frontend. Use last working version of the node docker image for now.