### PR TITLE
build(backend): fix dev script flags not being processed (NadAlaba)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,7 @@
     "clean": "tsc --build --clean",
     "start": "npm run build && node ./build/server.js",
     "test": "jest --verbose --collect-coverage --runInBand",
-    "dev": "ts-node-dev ./src/server.ts -- --inspect --transpileOnly",
+    "dev": "ts-node-dev --transpile-only --inspect -- ./src/server.ts",
     "knip": "knip",
     "docker-db-only": "docker compose -f docker/compose.db-only.yml up",
     "docker": "docker compose -f docker/compose.yml up"


### PR DESCRIPTION
### Description

Backend dev script `"dev": "ts-node-dev ./src/server.ts -- --inspect --transpileOnly"` doesn't process the flags `--inspect` or `--transpileOnly`.

Changing it to `"dev": "ts-node-dev --transpile-only --inspect -- ./src/server.ts"` as [ts-node-dev](https://www.npmjs.com/package/ts-node-dev) suggests processes both:
> ts-node-dev [node-dev|ts-node flags] [ts-node-dev flags] [node cli flags] [--] [script] [script arguments]