### PR TITLE
impr(language): Add @ to git words (tjkuson)

### DIFF
--- a/frontend/static/languages/git.json
+++ b/frontend/static/languages/git.json
@@ -49,6 +49,7 @@
     "archive",
     "bundle",
     "build",
-    "cherrypick"
+    "cherrypick",
+    "@"
   ]
 }


### PR DESCRIPTION
### Description

Adds `@` to the list of git words.

`@` is a commonly used alias for `HEAD`. See the [specifying revisions section](https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emem) of the git documentation for further refence.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title
