### PR TITLE
fix: issue where '\n\n' was not rendering correctly in custom text (SpaceWaffles5827)

### DIFF
--- a/frontend/src/ts/modals/custom-text.ts
+++ b/frontend/src/ts/modals/custom-text.ts
@@ -268,7 +268,7 @@ function cleanUpText(): string[] {
 
   if (state.replaceControlCharactersEnabled) {
     text = text.replace(/([^\\]|^)\\t/gm, "$1\t");
-    text = text.replace(/\\n/g, ' \n');
+    text = text.replace(/\\n/g, " \n");
     text = text.replace(/([^\\]|^)\\n/gm, "$1\n");
     text = text.replace(/\\\\t/gm, "\\t");
     text = text.replace(/\\\\n/gm, "\\n");

--- a/frontend/src/ts/modals/custom-text.ts
+++ b/frontend/src/ts/modals/custom-text.ts
@@ -268,6 +268,7 @@ function cleanUpText(): string[] {
 
   if (state.replaceControlCharactersEnabled) {
     text = text.replace(/([^\\]|^)\\t/gm, "$1\t");
+    text = text.replace(/\\n/g, ' \n');
     text = text.replace(/([^\\]|^)\\n/gm, "$1\n");
     text = text.replace(/\\\\t/gm, "\\t");
     text = text.replace(/\\\\n/gm, "\\n");


### PR DESCRIPTION
### Description

Modified the behavior of custom text input. Previously, when entering `\n\n`, users would get one new line and a `\n` character. Now, I've adjusted it so that entering `\n\n` results in two new lines. This was achieved by appending a space to `\n` characters before other operations.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

Closes #5347
