### PR TITLE
impr: Formatting for popup that sets custom timed test duration and custom word test duration is a little more consistent (wiichicken)

### DIFF
--- a/frontend/src/html/popups.html
+++ b/frontend/src/html/popups.html
@@ -683,7 +683,15 @@
       <br />
       <br />
       You can start an infinite test by inputting 0. Then, to stop the test, use
-      the Bail Out feature (esc or ctrl/cmd + shift + p > Bail Out)
+      the Bail Out feature (
+      <key>esc</key>
+      or
+      <key>ctrl/cmd</key>
+      +
+      <key>shift</key>
+      +
+      <key>p</key>
+      > Bail Out)
     </div>
     <button>ok</button>
   </form>


### PR DESCRIPTION


### Description

These two popups had inconsistent formatting, so I fixed them:
![vivaldi_4BQM41fn61](https://github.com/monkeytypegame/monkeytype/assets/50886841/49ccd1ba-a758-4d96-9157-b09027ccf804)
Note how this one highlights the keys.
![vivaldi_QxcwuChXOS](https://github.com/monkeytypegame/monkeytype/assets/50886841/834fddb0-5d15-4ce7-b6f1-6dab502c857d)
This one does not highlight the keys.

I changed it, and now both popups should highlight the keys.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->