### PR TITLE
impr(remove fancy typography): add low quotation mark (K0stov)

### DIFF
--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -183,6 +183,7 @@ export function cleanTypographySymbols(textToClean: string): string {
   const specials = {
     "“": '"', // &ldquo;	&#8220;
     "”": '"', // &rdquo;	&#8221;
+    "„": '"', // &bdquo;	&#8222;
     "’": "'", // &lsquo;	&#8216;
     "‘": "'", // &rsquo;	&#8217;
     ",": ",", // &sbquo;	&#8218;


### PR DESCRIPTION
### Description

Add the low quotation mark („) to the "Remove fancy typography" option. This symbol is common in Eastern European languages and functions the same as American “/British ‘.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title
