### PR TITLE
feat(theme): Add transgender theme (madimadica)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1216,5 +1216,12 @@
     "mainColor": "#5a65ea",
     "subColor": "#565861",
     "textColor": "#dcdee3"
+  },
+  {
+    "name": "transgender",
+    "bgColor": "#ffffff",
+    "mainColor": "#5bcefa",
+    "subColor": "#f5a9b8",
+    "textColor": "#5bcefa"
   }
 ]

--- a/frontend/static/themes/transgender.css
+++ b/frontend/static/themes/transgender.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #ffffff;
+  --main-color: #5bcefa;
+  --caret-color: #000000;
+  --sub-color: #f5a9b8;
+  --sub-alt-color: #eeeeee;
+  --text-color: #5bcefa;
+  --error-color: #ff0000;
+  --error-extra-color: #8b0000;
+  --colorful-error-color: #ff0000;
+  --colorful-error-extra-color: #8b0000;
+}


### PR DESCRIPTION
Added transgender theme based on official color scheme for the blue/pink/white (#5BCEFA/#F5A9B8/#FFFFFF)
Added `transgender.css` and edited `_list.json`

Colorful mode does not change the appearance (it's already colorful!)



![trans_pr_home](https://github.com/monkeytypegame/monkeytype/assets/145222821/4ae849b1-a387-4270-82ec-c3d1a64ea251)
![trans_pr_results](https://github.com/monkeytypegame/monkeytype/assets/145222821/a272d0bb-4178-42f7-b46d-efdc445051c2)
![trans_pr_settings](https://github.com/monkeytypegame/monkeytype/assets/145222821/8e7401a6-ff83-4e9c-b7bb-cf5c364c3c47)
![trans_pr_typing](https://github.com/monkeytypegame/monkeytype/assets/145222821/e256a1c9-fa6e-4fb4-acee-dd47f9f9a554)
