### PR TITLE
fix(9009.css): removed double colorful-error-color (Taz03)

### DIFF
--- a/frontend/static/themes/9009.css
+++ b/frontend/static/themes/9009.css
@@ -6,7 +6,7 @@
   --sub-alt-color: #d3cfc1;
   --text-color: #080909;
   --error-color: #c87e74;
-  --colorful-error-color: #a56961;
+  --error-extra-color: #a56961;
   --colorful-error-color: #c87e74;
   --colorful-error-extra-color: #a56961;
 }
@@ -16,7 +16,7 @@
 }
 
 .word letter.incorrect.extra {
-  color: var(--colorful-error-color);
+  color: var(--error-extra-color);
 }
 
 .word.error {


### PR DESCRIPTION
### Description

The css has double `colorful-error-color` and no `error-extra-color`

### Checks

- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title
