### PR TITLE
fix: command line shortcut on mac (tusharsadhwani)

### DIFF
--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -959,14 +959,10 @@ export async function update(groupUpdate = true): Promise<void> {
 
   CustomBackgroundFilter.updateUI();
 
-  const modifierKey = window.navigator.userAgent.toLowerCase().includes("mac")
-    ? "cmd"
-    : "ctrl";
-
   const commandKey = Config.quickRestart === "esc" ? "tab" : "esc";
   $(".pageSettings .tip").html(`
     tip: You can also change all these settings quickly using the
-    command line (<key>${commandKey}</key> or <key>${modifierKey}</key> + <key>shift</key> + <key>p</key>)`);
+    command line (<key>${commandKey}</key> or <key>ctrl</key> + <key>shift</key> + <key>p</key>)`);
 }
 function toggleSettingsGroup(groupName: string): void {
   const groupEl = $(`.pageSettings .settingsGroup.${groupName}`);

--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -26,14 +26,10 @@ export function clearFontPreview(): void {
 }
 
 function updateKeytips(): void {
-  const modifierKey = window.navigator.userAgent.toLowerCase().includes("mac")
-    ? "cmd"
-    : "ctrl";
-
   const commandKey = Config.quickRestart === "esc" ? "tab" : "esc";
   $("footer .keyTips").html(`
     <key>${Config.quickRestart}</key> - restart test<br>
-    <key>${commandKey}</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
+    <key>${commandKey}</key> or <key>ctrl</key>+<key>shift</key>+<key>p</key> - command line`);
 }
 
 if (isDevEnvironment()) {


### PR DESCRIPTION
### Description

On MacOS on Firefox, <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> opens a new private tab. So the shortcut shown on the screen doesn't work:

<img width="271" alt="Screenshot 2024-05-12 at 7 38 50 PM" src="https://github.com/monkeytypegame/monkeytype/assets/43412083/34e75af2-b1fb-4373-996f-6e203614346c">

Instead, using <kbd>cmd</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> works on every browser, including Chrome, Safari and Firefox.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
