### PR TITLE
fix(docker-compose): remove version from docker compose (dirk-hub)

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   monkeytype-redis:
     container_name: monkeytype-redis

--- a/frontend/docker-compose.yaml
+++ b/frontend/docker-compose.yaml
@@ -7,4 +7,5 @@ services:
       - "3000:3000"
     volumes:
       - ../:/monkeytype
+    user: node
     entrypoint: 'bash -c "cd /monkeytype && npm run dev-fe"'


### PR DESCRIPTION
### Description

This pr removes the now obsolete `version:` line from the backend docker compose yaml.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [ ] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [ ] Make sure to include your GitHub username inside parentheses at the end of the PR title
