### PR TITLE
fix(leaderboard modal): language dropdown resets after reopening lb (ykahveci)

### DIFF
--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -691,31 +691,37 @@ export function show(): void {
         {
           value: "english",
           text: "english",
-          selected: true,
+          selected: currentLanguage === "english",
         },
         {
           value: "spanish",
           text: "spanish",
+          selected: currentLanguage === "spanish",
         },
         {
           value: "german",
           text: "german",
+          selected: currentLanguage === "german",
         },
         {
           value: "french",
           text: "french",
+          selected: currentLanguage === "french",
         },
         {
           value: "portuguese",
           text: "portuguese",
+          selected: currentLanguage === "portuguese",
         },
         {
           value: "indonesian",
           text: "indonesian",
+          selected: currentLanguage === "indonesian",
         },
         {
           value: "italian",
           text: "italian",
+          selected: currentLanguage === "italian",
         },
       ],
       events: {

--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -688,42 +688,18 @@ export function show(): void {
         // contentPosition: "relative",
       },
       data: [
-        {
-          value: "english",
-          text: "english",
-          selected: currentLanguage === "english",
-        },
-        {
-          value: "spanish",
-          text: "spanish",
-          selected: currentLanguage === "spanish",
-        },
-        {
-          value: "german",
-          text: "german",
-          selected: currentLanguage === "german",
-        },
-        {
-          value: "french",
-          text: "french",
-          selected: currentLanguage === "french",
-        },
-        {
-          value: "portuguese",
-          text: "portuguese",
-          selected: currentLanguage === "portuguese",
-        },
-        {
-          value: "indonesian",
-          text: "indonesian",
-          selected: currentLanguage === "indonesian",
-        },
-        {
-          value: "italian",
-          text: "italian",
-          selected: currentLanguage === "italian",
-        },
-      ],
+        "english",
+        "spanish",
+        "german",
+        "french",
+        "portuguese",
+        "indonesian",
+        "italian",
+      ].map((lang) => ({
+        value: lang,
+        text: lang,
+        selected: lang === currentLanguage,
+      })),
       events: {
         afterChange: (newVal): void => {
           currentLanguage = newVal[0]?.value as string;


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [X] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [X] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [X] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #5417

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
