### PR TITLE
chore: fix frontend not starting in dev mode if backend is in maintenance (fehmer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "prettier": "2.5.1",
         "release-it": "16.1.4",
         "typescript": "5.3.3",
-        "wait-for-localhost-cli": "3.1.0"
+        "wait-for-localhost-cli": "3.2.0"
       },
       "engines": {
         "node": "18.19.1",
@@ -10349,9 +10349,9 @@
       "dev": true
     },
     "node_modules/wait-for-localhost": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wait-for-localhost/-/wait-for-localhost-4.0.1.tgz",
-      "integrity": "sha512-/q7fnGj3ATD4myCqlH3ZB/soX3cFZAztMvZgxOv0bZ7+8MsBUQrxIVrUkLsmro0qZAI5L9/QLGhJ0RsTfCmIbQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/wait-for-localhost/-/wait-for-localhost-4.1.0.tgz",
+      "integrity": "sha512-i3yX7qgAnxFXWOS6Om7SNi19HRygFvCGh0iy0nOsrYOSiIlhUqoUuzLoW4jHVYS4dzNGzRU100uwTyluOMWcjw==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -10361,13 +10361,13 @@
       }
     },
     "node_modules/wait-for-localhost-cli": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/wait-for-localhost-cli/-/wait-for-localhost-cli-3.1.0.tgz",
-      "integrity": "sha512-v26IpcWadNJVyDoDVaV5QRtaok7uEcmwWsIaehJwc3tQ6YDXY/EDPQm1E7lbTcUYE/+N/rVI7jk1nSjZWexKrw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/wait-for-localhost-cli/-/wait-for-localhost-cli-3.2.0.tgz",
+      "integrity": "sha512-Qeb/137B3PSiQSddXMGS40i7w2G2pWJ/01bJLQ4pk+WZ7V3+i7fIbKajf6/MPcBqYPJvNdYWAuTJ53ahhqZBog==",
       "dev": true,
       "dependencies": {
         "meow": "^10.1.1",
-        "wait-for-localhost": "^4.0.0"
+        "wait-for-localhost": "^4.1.0"
       },
       "bin": {
         "wait-for-localhost": "cli.js"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "npm run test-be && npm run test-fe",
     "test-be": "cd backend && npm run test",
     "test-fe": "cd frontend && npm run test",
-    "dev": "concurrently --kill-others \"wait-for-localhost 5005 && npm run dev-fe\" \"npm run dev-be\"",
+    "dev": "concurrently --kill-others \"wait-for-localhost 5005 --status-codes 200,503 && npm run dev-fe\" \"npm run dev-be\"",
     "dev-be": "cd backend && npm run dev",
     "dev-fe": "cd frontend && npm run dev",
     "live": "concurrently --kill-others \"cd frontend && npm run live\" \"cd backend && npm run start\"",
@@ -60,7 +60,7 @@
     "prettier": "2.5.1",
     "release-it": "16.1.4",
     "typescript": "5.3.3",
-    "wait-for-localhost-cli": "3.1.0"
+    "wait-for-localhost-cli": "3.2.0"
   },
   "lint-staged": {
     "*.{json,scss,css,html}": [


### PR DESCRIPTION
When backend is in maintenance mode it responds with HTTP status code `503`. `wait-for-localhost-cli` is waiting for `200` before starting the frontend.

Fixed by updating `wait-for-localhost-cli` and passing `--status-codes 200,503`.
