### PR TITLE
fix: too many decimals showing on profile page for some users (fehmer)

### DIFF
--- a/frontend/__tests__/utils/numbers.spec.ts
+++ b/frontend/__tests__/utils/numbers.spec.ts
@@ -1,0 +1,49 @@
+import * as Numbers from "../../src/ts/utils/numbers";
+
+describe("numbers", () => {
+  describe("abbreviateNumber", () => {
+    it("should round to one decimal by default", () => {
+      expect(Numbers.abbreviateNumber(1)).toEqual("1.0");
+      expect(Numbers.abbreviateNumber(1.5)).toEqual("1.5");
+      expect(Numbers.abbreviateNumber(1.55)).toEqual("1.6");
+
+      expect(Numbers.abbreviateNumber(1000)).toEqual("1.0k");
+      expect(Numbers.abbreviateNumber(1010)).toEqual("1.0k");
+      expect(Numbers.abbreviateNumber(1099)).toEqual("1.1k");
+    });
+    it("should round to full numbers", () => {
+      expect(Numbers.abbreviateNumber(1, 0)).toEqual("1");
+      expect(Numbers.abbreviateNumber(1.5, 0)).toEqual("2");
+      expect(Numbers.abbreviateNumber(1.55, 0)).toEqual("2");
+
+      expect(Numbers.abbreviateNumber(1000, 0)).toEqual("1k");
+      expect(Numbers.abbreviateNumber(1010, 0)).toEqual("1k");
+      expect(Numbers.abbreviateNumber(1099, 0)).toEqual("1k");
+    });
+
+    it("should round to two decimals", () => {
+      expect(Numbers.abbreviateNumber(1, 2)).toEqual("1.00");
+      expect(Numbers.abbreviateNumber(1.5, 2)).toEqual("1.50");
+      expect(Numbers.abbreviateNumber(1.55, 2)).toEqual("1.55");
+
+      expect(Numbers.abbreviateNumber(1000, 2)).toEqual("1.00k");
+      expect(Numbers.abbreviateNumber(1010, 2)).toEqual("1.01k");
+      expect(Numbers.abbreviateNumber(1099, 2)).toEqual("1.10k");
+    });
+    it("should use suffixes", () => {
+      let number = 1;
+      expect(Numbers.abbreviateNumber(number)).toEqual("1.0");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0k");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0m");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0b");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0t");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0q");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0Q");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0s");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0S");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0o");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0n");
+      expect(Numbers.abbreviateNumber((number *= 1000))).toEqual("1.0d");
+    });
+  });
+});

--- a/frontend/src/ts/utils/numbers.ts
+++ b/frontend/src/ts/utils/numbers.ts
@@ -146,7 +146,7 @@ export function getNumberWithMagnitude(num: number): {
  */
 export function abbreviateNumber(num: number, decimalPoints = 1): string {
   if (num < 1000) {
-    return num.toString();
+    return num.toFixed(decimalPoints);
   }
 
   const exp = Math.floor(Math.log(num) / Math.log(1000));


### PR DESCRIPTION
For some users too many decimal places are shown on the profile page:
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/27e548dc-ce59-4a7d-8ba1-d07b08fd6112)

The `user.xp` value for this user is not a `Long` as expected. Result from the `GET profile` call:
```json
{
  xp: 14852507.822024472
}
```
While wo do round the XP value to a full number in the [UserDal.incrementXp](https://github.com/monkeytypegame/monkeytype/blob/master/backend/src/dal/user.ts#L604) method this will not fix existing non-long values to be rounded in the database.

This PR fixes the `Numbers.abbreviateNumber` method not handling the `decimalPoints` parameter on values `<1000` but not fixing the inconsistencies in the database.