### PR TITLE
fix: alternate command line keyboard shortcut (unrealapex)

### DIFF
--- a/frontend/src/html/footer.html
+++ b/frontend/src/html/footer.html
@@ -10,9 +10,7 @@
     <br />
     <key>ctrl/cmd</key>
     +
-    <key>shift</key>
-    +
-    <key>p</key>
+    <key>k</key>
     or
     <key>esc</key>
     - Command Line

--- a/frontend/src/html/pages/about.html
+++ b/frontend/src/html/pages/about.html
@@ -87,9 +87,7 @@
       command line by pressing
       <key>ctrl/cmd</key>
       +
-      <key>shift</key>
-      +
-      <key>p</key>
+      <key>k</key>
       or
       <key>esc</key>
       - there you can access all the functionality you need without touching

--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -6,9 +6,7 @@
     tip: You can also change all these settings quickly using the command line (
     <key>ctrl/cmd</key>
     +
-    <key>shift</key>
-    +
-    <key>p</key>
+    <key>k</key>
     or
     <key>esc</key>
     )

--- a/frontend/src/html/popups.html
+++ b/frontend/src/html/popups.html
@@ -665,9 +665,7 @@
       or
       <key>ctrl/cmd</key>
       +
-      <key>shift</key>
-      +
-      <key>p</key>
+      <key>k</key>
       > Bail Out)
     </div>
     <button>ok</button>
@@ -688,9 +686,7 @@
       or
       <key>ctrl/cmd</key>
       +
-      <key>shift</key>
-      +
-      <key>p</key>
+      <key>k</key>
       > Bail Out)
     </div>
     <button>ok</button>

--- a/frontend/src/ts/event-handlers/global.ts
+++ b/frontend/src/ts/event-handlers/global.ts
@@ -18,7 +18,7 @@ document.addEventListener("keydown", async (e) => {
       Config.quickRestart === "esc" &&
       TestWords.hasTab &&
       e.shiftKey) ||
-    (e.key.toLowerCase() === "p" && (e.metaKey || e.ctrlKey) && e.shiftKey)
+    (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey))
   ) {
     e.preventDefault();
     const popupVisible = Misc.isAnyPopupVisible();

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -968,7 +968,7 @@ export async function update(groupUpdate = true): Promise<void> {
   const commandKey = Config.quickRestart === "esc" ? "tab" : "esc";
   $(".pageSettings .tip").html(`
     tip: You can also change all these settings quickly using the
-    command line (<key>${commandKey}</key> or <key>${modifierKey}</key> + <key>shift</key> + <key>p</key>)`);
+    command line (<key>${commandKey}</key> or <key>${modifierKey}</key> + <key>k</key>)`);
 }
 function toggleSettingsGroup(groupName: string): void {
   const groupEl = $(`.pageSettings .settingsGroup.${groupName}`);

--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -35,7 +35,7 @@ function updateKeytips(): void {
   const commandKey = Config.quickRestart === "esc" ? "tab" : "esc";
   $("footer .keyTips").html(`
     <key>${Config.quickRestart}</key> - restart test<br>
-    <key>${commandKey}</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
+    <key>${commandKey}</key> or <key>${modifierKey}</key>+<key>k</key> - command line`);
 }
 
 if (isDevEnvironment()) {


### PR DESCRIPTION
Change the alternate keyboard shortcut to open the command palette from <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd> to <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>k</kbd> to prevent conflict with Firefox' built in shortcut.


Closes #5233 

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
