### PR TITLE
docs: utilize blockquote color highlights (unrealapex)

### DIFF
--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -25,7 +25,9 @@ This contribution guide is for cases in which you need to test the functionality
 
 ### Git
 
-**IMPORTANT: If you are on Windows, run `git config --global core.autocrlf false` before cloning this repo to prevent CRLF errors.**
+
+> [!WARNING]
+> If you are on Windows, run `git config --global core.autocrlf false` before cloning this repo to prevent CRLF errors.** 
 
 Git is optional but we recommend you utilize it. Monkeytype uses the Git source control management (SCM) system for its version control. Assuming you don't have experience typing commands in the command line, we suggest installing [Sourcetree](https://www.sourcetreeapp.com/). You will be able to utilize the power of Git without needing to remember any cryptic commands. Using a Git client such as Sourcetree won't give you access to the full functionality of Git, but provides an easy-to-understand graphical user interface (GUI). Once you have downloaded Sourcetree, run the installer. While installing Sourcetree, keep your eyes peeled for the option to also install Git with Sourcetree. This is the option you will need to look for in order to install Git. **Make sure to click yes in the installer to install Git with Sourcetree.**
 
@@ -145,7 +147,8 @@ npm run dev
 
 These commands will start a local development website on [port 3000](http://localhost:3000) and a local development server on [port 5005](http://localhost:5005). They will automatically rebuild the website/server when you make changes in the `src/` directory. Use <kbd>Ctrl+C</kbd> to stop them.
 
-Note: Rebuilding doesn't happen instantaneously and depends on your machine, so be patient for changes to appear.
+> [!NOTE]
+> Rebuilding doesn't happen instantaneously and depends on your machine, so be patient for changes to appear.
 
 If you are on a UNIX system and you get a spawn error, run npm with `sudo`.
 

--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -147,6 +147,8 @@ These commands will start a local development website on [port 3000](http://loca
 
 Note: Rebuilding doesn't happen instantaneously and depends on your machine, so be patient for changes to appear.
 
+If you are on a UNIX system and you get a spawn error, run npm with `sudo`.
+
 ## Standards and Guidelines
 
 Code style is enforced by [Prettier](https://prettier.io/docs/en/install.html), which automatically runs every time you make a commit.

--- a/CONTRIBUTING_ADVANCED.md
+++ b/CONTRIBUTING_ADVANCED.md
@@ -27,7 +27,7 @@ This contribution guide is for cases in which you need to test the functionality
 
 
 > [!WARNING]
-> If you are on Windows, run `git config --global core.autocrlf false` before cloning this repo to prevent CRLF errors.** 
+> **If you are on Windows, run `git config --global core.autocrlf false` before cloning this repo to prevent CRLF errors.** 
 
 Git is optional but we recommend you utilize it. Monkeytype uses the Git source control management (SCM) system for its version control. Assuming you don't have experience typing commands in the command line, we suggest installing [Sourcetree](https://www.sourcetreeapp.com/). You will be able to utilize the power of Git without needing to remember any cryptic commands. Using a Git client such as Sourcetree won't give you access to the full functionality of Git, but provides an easy-to-understand graphical user interface (GUI). Once you have downloaded Sourcetree, run the installer. While installing Sourcetree, keep your eyes peeled for the option to also install Git with Sourcetree. This is the option you will need to look for in order to install Git. **Make sure to click yes in the installer to install Git with Sourcetree.**
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -196,4 +196,6 @@ Example content from `backend-configuration.json`:
 If you have the `curl` and `jq` installed you can also run `curl -wO- http://localhost:5005/configuration | jq ".data" > backend-configuration.json` to update the configuration file.
 
 
-_Note:_ The configuration is applied on container startup only. You have to restart the container for your changes to become active.
+> [!NOTE]
+> The configuration is applied on container startup only. You have to restart the container for your changes to become active.
+


### PR DESCRIPTION
Use Github Flavored Markdown's blockquote color highlights to make notes and warnings more clear.