### PR TITLE
impr(results filters): allow deselecting options in multiselect dropdowns of results filters (NadAlaba)

### DIFF
--- a/frontend/src/styles/inputs.scss
+++ b/frontend/src/styles/inputs.scss
@@ -248,6 +248,15 @@ select:-webkit-autofill:focus {
         }
       }
     }
+    .ss-max {
+      height: 100%;
+      color: var(--bg-color);
+      background: var(--main-color);
+      border-radius: calc(var(--roundness) / 2);
+      display: flex;
+      align-items: center;
+      padding: 0.35em 0.5em;
+    }
   }
 }
 

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -711,6 +711,18 @@ $(".pageAccount .topFilters button.toggleAdvancedFilters").on("click", () => {
   );
 });
 
+function adjustScrollposition(
+  group: keyof SharedTypes.ResultFilters,
+  topItem: number = 0
+): void {
+  const slimSelect = groupSelects[group];
+  if (slimSelect === undefined) return;
+  const listElement = slimSelect.render.content.list;
+  const topListItem = listElement.children.item(topItem) as HTMLElement;
+
+  listElement.scrollTop = topListItem.offsetTop - listElement.offsetTop;
+}
+
 function selectBeforeChangeFn(
   group: keyof SharedTypes.ResultFilters,
   selectedOptions: Option[],
@@ -815,6 +827,9 @@ export async function appendButtons(
               oldSelectedOptions
             );
           },
+          beforeOpen: (): void => {
+            adjustScrollposition("funbox");
+          },
         },
       });
     }
@@ -869,6 +884,9 @@ export async function appendButtons(
               oldSelectedOptions
             );
           },
+          beforeOpen: (): void => {
+            adjustScrollposition("funbox");
+          },
         },
       });
     }
@@ -918,6 +936,9 @@ export async function appendButtons(
               selectedOptions,
               oldSelectedOptions
             );
+          },
+          beforeOpen: (): void => {
+            adjustScrollposition("funbox");
           },
         },
       });

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -355,7 +355,7 @@ export function updateActive(): void {
 
       if (groupsUsingSelect.includes(group)) {
         const option = $(
-          `.pageAccount .group.filterButtons .filterGroup[group="${group}"] option[filter="${filter}"]`
+          `.pageAccount .group.filterButtons .filterGroup[group="${group}"] option[value="${filter}"]`
         );
         if (filterValue === true) {
           option.prop("selected", true);

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -391,24 +391,19 @@ export function updateActive(): void {
 
     if (everythingSelected) {
       for (const data of newData) {
-        //@ts-expect-error
-        if (data.value !== "all") {
-          //@ts-expect-error
-          data.selected = false;
-        } else {
-          //@ts-expect-error
-          data.selected = true;
+        if ("value" in data) {
+          if (data.value === "all") data.selected = true;
+          else data.selected = false;
         }
       }
     } else {
       for (const data of newData) {
-        //@ts-expect-error
-        if (group[data.value] === true) {
-          //@ts-expect-error
-          data.selected = true;
-        } else {
-          //@ts-expect-error
-          data.selected = false;
+        if ("value" in data) {
+          if (group[data.value as keyof typeof group] === true) {
+            data.selected = true;
+          } else {
+            data.selected = false;
+          }
         }
       }
     }

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -828,7 +828,7 @@ export async function appendButtons(
             );
           },
           beforeOpen: (): void => {
-            adjustScrollposition("funbox");
+            adjustScrollposition("language");
           },
         },
       });
@@ -938,7 +938,7 @@ export async function appendButtons(
             );
           },
           beforeOpen: (): void => {
-            adjustScrollposition("funbox");
+            adjustScrollposition("tags");
           },
         },
       });

--- a/frontend/src/ts/account/result-filters.ts
+++ b/frontend/src/ts/account/result-filters.ts
@@ -389,7 +389,12 @@ export function updateActive(): void {
 
     const newData = ss.store.getData();
 
+    const allOption = $(
+      `.pageAccount .group.filterButtons .filterGroup[group="${id}"] option[value="all"]`
+    );
+
     if (everythingSelected) {
+      allOption.prop("selected", true);
       for (const data of newData) {
         if ("value" in data) {
           if (data.value === "all") data.selected = true;
@@ -398,6 +403,8 @@ export function updateActive(): void {
       }
       ss.store.setData(newData);
       ss.render.renderValues();
+    } else {
+      allOption.prop("selected", false);
     }
 
     for (const data of newData) {


### PR DESCRIPTION
### Motivation:
- **Simplify exclusions:** If a user needed to see results from all funboxes except gibberish, they'd need to select all items one by one except for gibberish, which is a tedious process given that there are almost 40 items to select.
- **Simplify cancellations:** When a user selects more than 20 items, the values shown get replaced by one item `21 selected`, so if a user was seeing the results from 22 funboxes, and clicked on another item by mistake, the only way to cancel that last selection is by selecting the all option, then deleting it, then selecting the 20-something items one by one.
### Changes:
1. Handle typescript errors in a different way from `@ts-expect-error`.
2. Allow deselecting items in the tags, funbox, and language dropdowns of results filters.
Now if all items are selected, all options in the dropdown list would be selected, but only one value will be shown above, the `all` value.
To achieve this distinction between the options and the values, the callback of the `beforeChange` event now returns false to stop execution of other change event callbacks, and control the behavior of the select element.
Also, `closeOnSelect` is now `false` because it is expected from users to select multiple items before finishing, since it is a mutliselect.
3. Mark the html element of the all option as `selected` whenever all options are selected.
4. Query the html elements of options by the `value` attribute instead of `filter`: This is needed to query the html element of tag options, because their `value=tag._id`s don't equal their `filter=tag.name`s, and the `ResultFilters`  is populated with `option.value`s, which are used to query the option elements.
5. Make the dropdowns scroll to top by default when opening them, to make the `all` option -which is probably the most used option- visible: This is needed because dropdown selects scroll to the last selected element by default, and after making all options selected when everything is selected, the dropdown would scroll the bottom.
6. Style the class `.ss-max` -which will appear when more than 20 items are selected- similar to `.ss-value-text`, but round all corners.