### PR TITLE
docs: fix a typo and apply styling to the whole doc (Warrobot10)

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -38,8 +38,8 @@
 
 ## Account System
 
-user signup/login is disabled by default. To allow users to signup you'll need to setup a Firebase project. 
-stop the running docker containers using `docker compose down` before making any changes.
+User signup/login is disabled by default. To allow users to signup you'll need to setup a Firebase project. 
+Stop the running docker containers using `docker compose down` before making any changes.
 
 ### Setup Firebase
 
@@ -123,7 +123,7 @@ stop the running docker containers using `docker compose down` before making any
 
 ## Enable daily leaderboards
 
-to enable daily leaderboards update the `backend-configuration.json` file and add/modify
+To enable daily leaderboards update the `backend-configuration.json` file and add/modify
 ```json
 {
     "dailyLeaderboards": {
@@ -154,7 +154,7 @@ to enable daily leaderboards update the `backend-configuration.json` file and ad
 
 ### env file
 
-all settings are described in the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env) file.
+All settings are described in the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env) file.
 
 ### serviceAccountKey.json
 
@@ -162,16 +162,16 @@ contains your firebase config, only needed if you want to allow users to signup.
 
 ### backend-configuration.json
 
-configuration of the backend. 
+Configuration of the backend. 
 
-if you don't want to update this file manually you can
+If you don't want to update this file manually you can
 
 - open the backend url in your browser, e.g. `http://localhost:5005/configure/`
 - adjust the settings and click `Save Changes`
 - open the configuration in your browser, e.g. `http://localhost:5005/configuration`
 - copy everything from `data` into the `backend-configuration.json` file.
 
-example output from `http://localhost:5005/configuration`:
+Example output from `http://localhost:5005/configuration`:
 ```json
 {
     "message": "Configuration retrieved",
@@ -184,7 +184,7 @@ example output from `http://localhost:5005/configuration`:
 }
 ```
 
-example content from `backend-configuration.json`:
+Example content from `backend-configuration.json`:
 ```
 {
     "maintenance": false,
@@ -193,7 +193,7 @@ example content from `backend-configuration.json`:
 }
 ```
 
-if you have `curl` and `jq` installed you can also run `curl -wO- http://localhost:5005/configuration | jq ".data" > backend-configuration.json` to update the configuration file.
+If you have `curl` and `jq` installed you can also run `curl -wO- http://localhost:5005/configuration | jq ".data" > backend-configuration.json` to update the configuration file.
 
 
 > [!NOTE]

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -33,13 +33,13 @@
 - create an `.env` file, you can copy the content from the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env).
 - download the [backend-configuration.json](https://github.com/monkeytypegame/monkeytype/tree/master/docker/backend-configuration.json)
 - run `docker compose up -d`
-- After the command exits successfully you can access [http://localhost:8080](http://localhost:8080)
+- after the command exits successfully you can access [http://localhost:8080](http://localhost:8080)
 
 
 ## Account System
 
-User signup/login is disabled by default. To allow users to signup you'll need to setup a Firebase project. 
-Stop the running docker containers using `docker compose down` before making any changes.
+user signup/login is disabled by default. To allow users to signup you'll need to setup a Firebase project. 
+stop the running docker containers using `docker compose down` before making any changes.
 
 ### Setup Firebase
 
@@ -68,7 +68,7 @@ Stop the running docker containers using `docker compose down` before making any
 - update the `.env` file
   - open the [firebase console](https://console.firebase.google.com/) and open your project
   - open the project settings by clicking the `⚙` icon on the sidebar and `Project settings`
-  - If there is no app in your project create a new web-app `</>`
+  - if there is no app in your project create a new web-app `</>`
     - nickname `monkeytype`
     - uncheck `set up firebase hosting`
     - click `Register app` 
@@ -123,7 +123,7 @@ Stop the running docker containers using `docker compose down` before making any
 
 ## Enable daily leaderboards
 
-To enable daily leaderboards update the `backend-configuration.json` file and add/modify
+to enable daily leaderboards update the `backend-configuration.json` file and add/modify
 ```json
 {
     "dailyLeaderboards": {
@@ -154,24 +154,24 @@ To enable daily leaderboards update the `backend-configuration.json` file and ad
 
 ### env file
 
-All settings are described in the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env) file.
+all settings are described in the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env) file.
 
 ### serviceAccountKey.json
 
-Contains your firebase config, only needed if you want to allow users to signup.
+contains your firebase config, only needed if you want to allow users to signup.
 
 ### backend-configuration.json
 
-Configuration of the backend. 
+configuration of the backend. 
 
-If you don't want to update this file manually you can
+if you don't want to update this file manually you can
 
 - open the backend url in your browser, e.g. `http://localhost:5005/configure/`
 - adjust the settings and click `Save Changes`
 - open the configuration in your browser, e.g. `http://localhost:5005/configuration`
 - copy everything from `data` into the `backend-configuration.json` file.
 
-Example output from `http://localhost:5005/configuration`:
+example output from `http://localhost:5005/configuration`:
 ```json
 {
     "message": "Configuration retrieved",
@@ -184,7 +184,7 @@ Example output from `http://localhost:5005/configuration`:
 }
 ```
 
-Example content from `backend-configuration.json`:
+example content from `backend-configuration.json`:
 ```
 {
     "maintenance": false,
@@ -193,7 +193,7 @@ Example content from `backend-configuration.json`:
 }
 ```
 
-If you have the `curl` and `jq` installed you can also run `curl -wO- http://localhost:5005/configuration | jq ".data" > backend-configuration.json` to update the configuration file.
+if you have `curl` and `jq` installed you can also run `curl -wO- http://localhost:5005/configuration | jq ".data" > backend-configuration.json` to update the configuration file.
 
 
 > [!NOTE]

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -158,7 +158,7 @@ All settings are described in the [example.env](https://github.com/monkeytypegam
 
 ### serviceAccountKey.json
 
-contains your firebase config, only needed if you want to allow users to signup.
+Contains your firebase config, only needed if you want to allow users to signup.
 
 ### backend-configuration.json
 


### PR DESCRIPTION
### Description
Some of selfhosting was written in a laidback style (no caps at the start of a sentence), but it was only like that for small patches around the doc, so I changed the rest to match. Also fixed a typo. 

### Checks
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title