### PR TITLE
fix: misaligned tooltip in terms-of-service (extoplasm)

### DIFF
--- a/frontend/src/terms-of-service.html
+++ b/frontend/src/terms-of-service.html
@@ -341,14 +341,16 @@
             contact@monkeytype.com
           </a>
         </p>
-        Discord:
-        <span
-          aria-label="Click To Copy"
-          data-balloon-pos="up"
-          onclick="copyUserName()"
-        >
-          @miodec
-        </span>
+        <p>
+          Discord:
+          <span
+            aria-label="Click To Copy"
+            data-balloon-pos="up"
+            onclick="copyUserName()"
+          >
+            @miodec
+          </span>
+        </p>
       </main>
       <p>
         Terms based on


### PR DESCRIPTION
### Description

fixed misaligned tooltip in terms-of-service.html, like #5443 

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
*see above*
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
