### PR TITLE
fix: typed letters not visible in tts funbox if highlight=off (@fehmer)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -790,12 +790,15 @@ export async function updateWordElement(
     const funbox = FunboxList.get(Config.funbox).find(
       (f) => f.functions?.getWordHtml
     );
+    const isTts = FunboxList.get(Config.funbox).find((it) => it.name === "tts");
+
     for (let i = 0; i < input.length; i++) {
       const charCorrect = currentWord[i] === input[i];
 
       let correctClass = "correct";
       if (Config.highlightMode === "off") {
         correctClass = "";
+        if (isTts) correctClass = "visible";
       }
 
       let currentLetter = currentWord[i] as string;

--- a/frontend/static/funbox/tts.css
+++ b/frontend/static/funbox/tts.css
@@ -5,3 +5,15 @@
 #words .word {
   color: transparent !important;
 }
+
+#words .word letter.visible {
+  color: var(--sub-color) !important;
+}
+
+#words.flipped .word letter.visible {
+  color: var(--text-color) !important;
+}
+
+#words.flipped.colorfulMode .word letter.visible {
+  color: var(--main-color) !important;
+}


### PR DESCRIPTION
I am not sure this is on purpose or not. If you choose highlight=off in tts funbox you cannot see what you typed.
