### PR TITLE
feat(layout): gallium v2 (AurimasAnskaitis)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1562,6 +1562,17 @@
       "row5": [" "]
     }
   },
+  "gallium_v2": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+"],
+      "row2": ["bB", "lL", "dD", "cC", "vV", "jJ", "fF", "oO", "uU", ",<", "[{", "]}", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", "/?"],
+      "row4": ["xX", "qQ", "mM", "wW", "zZ", "kK", "pP", "'\"", ";:", ".>"],
+      "row5": [" "]
+    }
+  },
   "maya": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description

Gallium v2 is very appreciated and popular layout, would be nice to have it.
It seems this is all what is needed. If not, please let me know.

Layout itself was taken from Alt Layouts discord

```
gallium-v2 (GalileoBlues) (6 likes)
  b l d c v  j f o u ,
  n r t s g  y h a e i
  x q m w z  k p ' ; .

MONKEYRACER:
  Alt: 32.63%
  Rol: 44.64%   (In/Out: 19.56% | 25.08%)
  One:  2.65%   (In/Out:  0.45% |  2.21%)
  Rtl: 47.29%   (In/Out: 20.00% | 27.29%)
  Red:  2.27%   (Bad:     0.22%)

  SFB: 0.85%
  SFS: 5.06%    (Red/Alt: 0.81% | 4.26%)

  LH/RH: 46.56% | 53.44%
```