### PR TITLE
fix: test activity calendar months having wrong indentation (@fehmer)

### DIFF
--- a/frontend/src/ts/elements/test-activity-calendar.ts
+++ b/frontend/src/ts/elements/test-activity-calendar.ts
@@ -72,21 +72,19 @@ export class TestActivityCalendar implements MonkeyTypes.TestActivityCalendar {
       start: this.startDay,
       end: this.endDay,
     });
-
     const results: MonkeyTypes.TestActivityMonth[] = [];
 
     for (let i = 0; i < months.length; i++) {
       const month: Date = months[i] as Date;
-      let start =
-        i === 0 ? new UTCDateMini(this.startDay) : startOfMonth(month);
-      let end =
-        i === months.length - 1
-          ? new UTCDateMini(this.endDay)
-          : endOfMonth(start);
+      let start = i === 0 ? this.startDay : startOfMonth(month);
+      let end = i === months.length - 1 ? this.endDay : endOfMonth(start);
 
-      if (!isSunday(start))
+      if (!isSunday(start)) {
         start = (i === 0 ? previousSunday : nextSunday)(start);
-      if (!isSaturday(end)) end = nextSaturday(end);
+      }
+      if (!isSaturday(end)) {
+        end = nextSaturday(end);
+      }
 
       const weeks = differenceInWeeks(end, start, { roundingMethod: "ceil" });
       if (weeks > 2) {


### PR DESCRIPTION
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/d4f41119-5c15-46fa-8f13-2e301c64a319)

