### PR TITLE
chore(husky): run `nvm use` only when needed in pre-push hook (@NadAlaba)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,9 +6,8 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 
-nvm use
-
 if [ $(git branch --no-color | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/') = "master" ] && [ $(git remote get-url origin) = "https://github.com/monkeytypegame/monkeytype" ]; then
+  nvm use
   echo "Running tests before pushing to master..."
   npm run test
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
### Description

`nvm use` does not work on nvm-windows, and there is no need for it to run every time anyone pushes to any branch.
![pre-push-hook](https://github.com/monkeytypegame/monkeytype/assets/37968805/5a2d5622-0e1d-4a89-9765-f0fcd40a8406)
