### PR TITLE
fix(test): apply highlight mode in loading and test (mitjans)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -155,9 +155,12 @@ ConfigEvent.subscribe((eventKey, eventValue, nosave) => {
   if (eventKey === "theme") void applyBurstHeatmap();
 
   if (eventValue === undefined) return;
-  if (eventKey === "highlightMode" && ActivePage.get() === "test") {
+  if (
+    eventKey === "highlightMode" &&
+    (ActivePage.get() === "test" || ActivePage.get() === "loading")
+  ) {
     highlightMode(eventValue as SharedTypes.Config.HighlightMode);
-    updateActiveElement();
+    if (ActivePage.get() === "test") updateActiveElement();
   }
 
   if (typeof eventValue !== "boolean") return;

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -155,10 +155,7 @@ ConfigEvent.subscribe((eventKey, eventValue, nosave) => {
   if (eventKey === "theme") void applyBurstHeatmap();
 
   if (eventValue === undefined) return;
-  if (
-    eventKey === "highlightMode" &&
-    (ActivePage.get() === "test" || ActivePage.get() === "loading")
-  ) {
+  if (eventKey === "highlightMode") {
     highlightMode(eventValue as SharedTypes.Config.HighlightMode);
     if (ActivePage.get() === "test") updateActiveElement();
   }


### PR DESCRIPTION
### Description

Apply highlight mode in both `"test"` and `"loading"` pages.
On initial page load, the current page is set to `"loading"`, so no highlight mode is applied.
When in `"loading"` page, the active element is yet to be defined, so we should check if we are actually in `"test"` page before calling `updateActiveElement();`

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [ ] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

Closes #5507
