### PR TITLE
fix: fix mexican theme being unreadable (@fehmer)

### DIFF
--- a/frontend/static/themes/mexican.css
+++ b/frontend/static/themes/mexican.css
@@ -3,7 +3,7 @@
   --main-color: #b12189;
   --caret-color: #eee;
   --sub-color: #333;
-  --sub-alt-color: #b12189;
+  --sub-alt-color: #0b9399;
   --text-color: #eee;
   --error-color: #da3333;
   --error-extra-color: #791717;


### PR DESCRIPTION
There are some issues with the main and sub-alt color being the same. The PR is changing the sub-alt color to light blue. This changes the UI a lot (test settings, settings page, account page) but keeps the test colors the same, which I think is more important.

## Test config
- original 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/5073f3a3-95d1-494a-b26d-e57402a31a43)
- fixed 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/9e1bab2c-5ce9-42fa-9ccf-6a829d6c683e)

## Account page
- original 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/5fb874e9-4085-466b-bcdf-428efca8b017)
- fixed 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/b64549fe-a165-46a3-9b78-877c4999bfa4)

## Leaderboard
- original 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/62fbf683-1fd0-4a5b-9dd1-43dfd2fc9a0f)
- fixed 
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/438a72c7-8246-4cff-ad26-91a1af7f0a34)

