### PR TITLE
fix: highlight mode not getting applied (@fehmer)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -155,9 +155,9 @@ ConfigEvent.subscribe((eventKey, eventValue, nosave) => {
   if (eventKey === "theme") void applyBurstHeatmap();
 
   if (eventValue === undefined) return;
-  if (eventKey === "highlightMode" && ActivePage.get() === "test") {
+  if (eventKey === "highlightMode") {
     highlightMode(eventValue as SharedTypes.Config.HighlightMode);
-    updateActiveElement();
+    if (ActivePage.get() === "test") updateActiveElement();
   }
 
   if (typeof eventValue !== "boolean") return;


### PR DESCRIPTION
Reported by user nova on discord:

> there's a bug where if you choose the highlight mode from the settings page instead of the command line, it won't apply

Fixes #5507 

