### PR TITLE
impr(server): trim consecutive newlines when updating user profile (theiereman)

### DIFF
--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -847,7 +847,7 @@ export async function updateProfile(
 
   await UserDAL.updateProfile(uid, profileDetailsUpdates, user.inventory);
 
-  return new MonkeyResponse("Profile updated");
+  return new MonkeyResponse("Profile updated", profileDetailsUpdates);
 }
 
 export async function getInbox(

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -160,6 +160,7 @@ export function sanitizeString(str: string | undefined): string | undefined {
   return str
     .replace(/[\u0300-\u036F]/g, "")
     .trim()
+    .replace(/\n{3,}/g, "\n\n")
     .replace(/\s{3,}/g, "  ");
 }
 

--- a/frontend/src/ts/ape/endpoints/users.ts
+++ b/frontend/src/ts/ape/endpoints/users.ts
@@ -221,7 +221,7 @@ export default class Users {
   async updateProfile(
     profileUpdates: Partial<SharedTypes.UserProfileDetails>,
     selectedBadgeId?: number
-  ): Ape.EndpointResponse<null> {
+  ): Ape.EndpointResponse<SharedTypes.UserProfileDetails> {
     return await this.httpClient.patch(`${BASE_PATH}/profile`, {
       payload: {
         ...profileUpdates,

--- a/frontend/src/ts/modals/edit-profile.ts
+++ b/frontend/src/ts/modals/edit-profile.ts
@@ -158,7 +158,7 @@ async function updateProfile(): Promise<void> {
     return;
   }
 
-  snapshot.details = updates;
+  snapshot.details = response.data ?? updates;
   snapshot.inventory?.badges.forEach((badge) => {
     if (badge.id === currentSelectedBadgeId) {
       badge.selected = true;


### PR DESCRIPTION
### Description

Removes unnecessary consecutive newlines when updating user bio or user keyboard on user profile modal to limit extreme layout stretch. 

Currently only trims server-side then updates the frontend with trimmed values the server returned. 
Blocking multiple newlines on the input felt weird so I decided not to implement it.

### Checks
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

Closes #5526
