### PR TITLE
chore: fix check annotations for dev routes (@fehmer)

### DIFF
--- a/backend/src/api/controllers/dev.ts
+++ b/backend/src/api/controllers/dev.ts
@@ -269,7 +269,7 @@ function randomValue<T>(values: T[]): T {
 }
 
 function createArray<T>(size: number, builder: () => T): T[] {
-  return new Array(size).fill(0).map((it) => builder());
+  return new Array(size).fill(0).map(() => builder());
 }
 
 async function updateTestActicity(uid: string): Promise<void> {

--- a/backend/src/api/routes/dev.ts
+++ b/backend/src/api/routes/dev.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { authenticateRequest } from "../../middlewares/auth";
 import {
   asyncHandler,
   validateConfiguration,


### PR DESCRIPTION
Fix lint warnings during ci-be build:

- `backend/src/api/controllers/dev.ts:272`: 'it' is defined but never used. 
- `backend/src/api/routes/dev.ts:2`: 'authenticateRequest' is defined but never used.
