### PR TITLE
fix: test history tags button flashing on load (@fehmer)

### DIFF
--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -388,6 +388,10 @@
       opacity: 1;
     }
   }
+  //remove flashHighlight from .group.History .active
+  .group.history .resultEditTagsButton {
+    animation: none;
+  }
 }
 
 .pageAccount {


### PR DESCRIPTION
Tags button is flashing on load if the current active tags are matching the tags from the result:
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/f386b6cb-f20f-439d-99fa-4847d3c6502e)

Introduced with e29d280.