### PR TITLE
fix: mexican theme sub alt color (@fehmer)

### DIFF
--- a/frontend/static/themes/mexican.css
+++ b/frontend/static/themes/mexican.css
@@ -3,7 +3,7 @@
   --main-color: #b12189;
   --caret-color: #eee;
   --sub-color: #333;
-  --sub-alt-color: #0b9399;
+  --sub-alt-color: #f9b951;
   --text-color: #eee;
   --error-color: #da3333;
   --error-extra-color: #791717;


### PR DESCRIPTION
Yesterday I learned that the sub-alt color should be a slightly brighter or slightly darker color of the background.
