### PR TITLE
fix: cleanup tmp while updating users inbox (@fehmer)

### DIFF
--- a/backend/__tests__/dal/user.spec.ts
+++ b/backend/__tests__/dal/user.spec.ts
@@ -936,7 +936,10 @@ describe("UserDal", () => {
       );
 
       //THEN
-      const { xp, inbox } = await UserDAL.getUser(user.uid, "");
+      const read = await UserDAL.getUser(user.uid, "");
+      expect(read).not.toHaveProperty("tmp");
+
+      const { xp, inbox } = read;
       expect(xp).toEqual(3100);
 
       //inbox is sorted by timestamp

--- a/backend/src/dal/user.ts
+++ b/backend/src/dal/user.ts
@@ -1046,6 +1046,7 @@ export async function updateInbox(
         inventory: "$tmp.inventory",
       },
     },
+    { $unset: "tmp" },
   ]);
 
   if (update.matchedCount !== 1)


### PR DESCRIPTION
fix mongo update pipeline leaving behind tmp data
