### PR TITLE
fix: incorrect word highlight in shadow theme (@fehmer)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -229,8 +229,7 @@ export function updateActiveElement(
     if (
       ["word", "next_word", "next_two_words", "next_three_words"].includes(
         Config.highlightMode
-      ) &&
-      Config.theme !== "shadow"
+      )
     ) {
       active.querySelectorAll("letter").forEach((e) => {
         e.classList.remove("correct");

--- a/frontend/static/themes/shadow.css
+++ b/frontend/static/themes/shadow.css
@@ -48,6 +48,7 @@ a:hover {
 }
 
 #logo,
-#typingTest .word letter.correct {
+#words:not(.flipped) .word:has(~ .active) letter,
+#words.highlight-letter:not(.flipped) .word.active letter.correct {
   animation: shadow 5s linear 1 forwards;
 }


### PR DESCRIPTION
Fixes #5557

- **Revert "impr(shadow theme): dont dehighlight typed words in shadow theme"**
- **fix: incorrect word highlight in shadow theme**
