### PR TITLE
feat(layout): add mirror nerps (Beethoven-n)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1463,6 +1463,17 @@
       "row5": [" "]
     }
   },
+  "mirror_nerps": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+"],
+      "row2": [";:", "uU", "oO", "kK", "zZ", "vV", "pP", "dD", "lL", "xX", "[{", "]}", "\\|"],
+      "row3": ["aA", "iI", "eE", "hH", "yY", "gG", "sS", "tT", "rR", "nN", "/?"],
+      "row4": [".>", ",<", "'\"", "fF", "bB", "wW", "cC", "mM", "jJ", "qQ"],
+      "row5": [" "]
+    }
+  },
   "sturdy_angle_ansi": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description

Added a mirrored nerps keyboard layout.
![image](https://github.com/monkeytypegame/monkeytype/assets/44652883/0ff3e080-6471-4a2b-9cbb-17854b4cde07)

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
technically related to #5573 but not by much
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username inside parentheses at the end of the PR title

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #

someone asked me try this and i found it was really easy to add in once i set up a dev environment lol

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
