### PR TITLE
fix: upside down funbox tooltip not visible on settings page (@fehmer)

### DIFF
--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -594,7 +594,7 @@ async function fillSettingsPage(): Promise<void> {
           funbox.name
         }' aria-label="${
           funbox.info
-        }" data-balloon-pos="up" data-balloon-length="fit" style="transform:scaleX(-1) scaleY(-1);">${funbox.name.replace(
+        }" data-balloon-pos="up" data-balloon-length="fit" style="transform:scaleX(-1) scaleY(-1); z-index:1;">${funbox.name.replace(
           /_/g,
           " "
         )}</div>`;


### PR DESCRIPTION
Tooltip is behind the "zipf" funbox button:
![image](https://github.com/monkeytypegame/monkeytype/assets/3728838/f8c9a642-451c-4375-a89c-e04da4d00e92)
