### PR TITLE
fix: bug in hexToRgb function (brenob6)

### DIFF
--- a/frontend/__tests__/utils/colors.spec.ts
+++ b/frontend/__tests__/utils/colors.spec.ts
@@ -1,0 +1,18 @@
+import { hexToRgb } from "../../src/ts/utils/colors";
+
+describe("colors.ts", () => {
+  describe("hexToRgb", () => {
+    it("Invalid hex values", () => {
+      expect(hexToRgb("ffff")).toEqual(undefined);
+      expect(hexToRgb("fff0000")).toEqual(undefined);
+      expect(hexToRgb("#ff")).toEqual(undefined);
+    });
+    it("Valid hex value", () => {
+      expect(hexToRgb("#ff0000")).toEqual({
+        r: 255,
+        g: 0,
+        b: 0,
+      });
+    });
+  });
+});

--- a/frontend/src/ts/utils/colors.ts
+++ b/frontend/src/ts/utils/colors.ts
@@ -44,27 +44,27 @@ export function blendTwoHexColors(
  * @param hex The hexadecimal color string (e.g., "#ff0000" or "#f00").
  * @returns An object with 'r', 'g', and 'b' properties representing the red, green, and blue components of the color, or undefined if the input is invalid.
  */
-function hexToRgb(hex: string):
+export function hexToRgb(hex: string):
   | {
       r: number;
       g: number;
       b: number;
     }
   | undefined {
-  if (hex.length !== 4 && hex.length !== 7 && !hex.startsWith("#")) {
+  if ((hex.length !== 4 && hex.length !== 7) || !hex.startsWith("#")) {
     return undefined;
   }
   let r: number;
   let g: number;
   let b: number;
   if (hex.length === 4) {
-    r = ("0x" + hex[1] + hex[1]) as unknown as number;
-    g = ("0x" + hex[2] + hex[2]) as unknown as number;
-    b = ("0x" + hex[3] + hex[3]) as unknown as number;
+    r = Number("0x" + hex[1] + hex[1]);
+    g = Number("0x" + hex[2] + hex[2]);
+    b = Number("0x" + hex[3] + hex[3]);
   } else if (hex.length === 7) {
-    r = ("0x" + hex[1] + hex[2]) as unknown as number;
-    g = ("0x" + hex[3] + hex[4]) as unknown as number;
-    b = ("0x" + hex[5] + hex[6]) as unknown as number;
+    r = Number("0x" + hex[1] + hex[2]);
+    g = Number("0x" + hex[3] + hex[4]);
+    b = Number("0x" + hex[5] + hex[6]);
   } else {
     return undefined;
   }


### PR DESCRIPTION
### Description

Added some test to the hexToRgb function. I found some issues and fixes it. 
To be able to test the hexToRgb function I exported it.

<!-- label(optional scope): pull request title (your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
