### PR TITLE
build(contracts): fix output paths for windows (@NadAlaba)

### DIFF
--- a/packages/contracts/esbuild.config.js
+++ b/packages/contracts/esbuild.config.js
@@ -27,7 +27,7 @@ const entryPoints = getAllFiles("./src");
 
 // Function to generate output file names
 const getOutfile = (entryPoint, format) => {
-  const relativePath = entryPoint.replace("src/", "");
+  const relativePath = entryPoint.replace(/src[/\\]/, "");
   const fileBaseName = relativePath.replace(".ts", "");
   return `./dist/${fileBaseName}.${format === "esm" ? "mjs" : "cjs"}`;
 };


### PR DESCRIPTION
### Description

`esbuild` is outputting build files of packages/contracts in `./dist/src/*`, but other packages are expecting them to be in `./dist/*`, which is happening due to the different Windows path separator `\`.