### PR TITLE
fix: don't use fetch timeout on very old browsers (@fehmer)

### DIFF
--- a/frontend/src/ts/ape/adapters/ts-rest-adapter.ts
+++ b/frontend/src/ts/ape/adapters/ts-rest-adapter.ts
@@ -28,7 +28,7 @@ function buildApi(timeout: number): (args: ApiFetcherArgs) => Promise<{
         headers["Authorization"] = `Bearer ${token}`;
       }
       const response = await fetch(request.path, {
-        signal: AbortSignal.timeout(timeout),
+        signal: AbortSignal?.timeout?.(timeout),
         method: request.method as Method,
         headers,
         body: request.body,


### PR DESCRIPTION
Fixes problem with old browsers (e.g. safari from 2022) not supporting `AbortSignal.timeout`.

On old browsers the configured client timeout (usually ten seconds) will be ignored.
