### PR TITLE
fix: csp preventing new documentation unable to display logo (@fehmer)

### DIFF
--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -101,11 +101,6 @@ function prettyErrorMessage(issue: ZodIssue | undefined): string {
 
 function applyDevApiRoutes(app: Application): void {
   if (isDevEnvironment()) {
-    //disable csp to allow assets to load from unsecured http
-    app.use((req, res, next) => {
-      res.setHeader("Content-Security-Policy", "");
-      next();
-    });
     app.use("/configure", expressStatic(join(__dirname, "../../../private")));
 
     app.use(async (req, res, next) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,7 +15,11 @@ function buildApp(): express.Application {
   app.use(urlencoded({ extended: true }));
   app.use(json());
   app.use(cors());
-  app.use(helmet());
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+    })
+  );
 
   app.set("trust proxy", 1);
 


### PR DESCRIPTION
Don't send any scp headers from the api.

- for rest endpoints it is not needed.
- on /docs we want to access images from the main site

