### PR TITLE
ci: skip cache download on prime-cache job (@fehmer)

### DIFF
--- a/.github/workflows/monkey-ci.yml
+++ b/.github/workflows/monkey-ci.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-build-${{ env.cache-name }}-${{ hashFiles('pnpm-lock.yaml') }}
+          lookup-only: true
 
       - if: ${{ steps.cache-pnpm.outputs.cache-hit != 'true' }}
         name: Full checkout


### PR DESCRIPTION
Don't download the cache on prime-cache. We only need the  `cache-hit` flag.

Reduces the runtime by six seconds.