### PR TITLE
ci: skip full checkout on pre-ci on pull requests (@fehmer)

### DIFF
--- a/.github/workflows/monkey-ci.yml
+++ b/.github/workflows/monkey-ci.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Full checkout
         uses: actions/checkout@v4
-        # For pull requests it's not necessary to checkout the code
+        # paths filter doesn't need checkout on pr
         if: github.event_name != 'pull_request'
 
       - name: Detect changes

--- a/.github/workflows/monkey-ci.yml
+++ b/.github/workflows/monkey-ci.yml
@@ -33,8 +33,13 @@ jobs:
       assets-json: ${{ steps.export-changes.outputs.assets-json }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - name: Full checkout
+        uses: actions/checkout@v4
+        # For pull requests it's not necessary to checkout the code
+        if: github.event_name != 'pull_request'
+
+      - name: Detect changes
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Skip the checkout before running paths-filter action on pull requests.

Reduces runtime of `pre-ci` from 13s down to 2s