### PR TITLE
chore: add test for recordClientVersion (@fehmer)

### DIFF
--- a/backend/__tests__/api/controllers/psa.spec.ts
+++ b/backend/__tests__/api/controllers/psa.spec.ts
@@ -1,15 +1,18 @@
 import request from "supertest";
 import app from "../../../src/app";
 import * as PsaDal from "../../../src/dal/psa";
+import * as Prometheus from "../../../src/utils/prometheus";
 import { ObjectId } from "mongodb";
 const mockApp = request(app);
 
 describe("Psa Controller", () => {
   describe("get psa", () => {
     const getPsaMock = vi.spyOn(PsaDal, "get");
+    const recordClientVersionMock = vi.spyOn(Prometheus, "recordClientVersion");
 
     afterEach(() => {
       getPsaMock.mockReset();
+      recordClientVersionMock.mockReset();
     });
 
     it("get psas without authorization", async () => {
@@ -53,12 +56,25 @@ describe("Psa Controller", () => {
           },
         ],
       });
+
+      expect(recordClientVersionMock).toHaveBeenCalledWith("unknown");
     });
     it("get psas with authorization", async () => {
       await mockApp
         .get("/psas")
         .set("authorization", `Uid 123456789`)
         .expect(200);
+    });
+
+    it("get psas records x-client-version", async () => {
+      await mockApp.get("/psas").set("x-client-version", "1.0").expect(200);
+
+      expect(recordClientVersionMock).toHaveBeenCalledWith("1.0");
+    });
+    it("get psas records client-version", async () => {
+      await mockApp.get("/psas").set("client-version", "2.0").expect(200);
+
+      expect(recordClientVersionMock).toHaveBeenCalledWith("2.0");
     });
   });
 });

--- a/packages/contracts/src/presets.ts
+++ b/packages/contracts/src/presets.ts
@@ -34,7 +34,7 @@ export const presetsContract = c.router(
       summary: "get presets",
       description: "Get presets of the current user.",
       method: "GET",
-      path: "/",
+      path: "",
       responses: {
         200: GetPresetResponseSchema,
       },
@@ -43,7 +43,7 @@ export const presetsContract = c.router(
       summary: "add preset",
       description: "Add a new preset for the current user.",
       method: "POST",
-      path: "/",
+      path: "",
       body: AddPresetRequestSchema.strict(),
       responses: {
         200: AddPresetResponseSchemna,
@@ -53,7 +53,7 @@ export const presetsContract = c.router(
       summary: "update preset",
       description: "Update an existing preset for the current user.",
       method: "PATCH",
-      path: "/",
+      path: "",
       body: PresetSchema.strict(),
       responses: {
         200: MonkeyResponseSchema,


### PR DESCRIPTION
- add tests to verify recordClientVersion is called
- remove tailing slash for `/presets` endpoints
