### PR TITLE
impr: update filipino word list (@Killer8Hyper)

### DIFF
--- a/frontend/static/languages/filipino.json
+++ b/frontend/static/languages/filipino.json
@@ -107,7 +107,7 @@
     "panahon",
     "ayaw",
     "buong",
-    "bayan",
+    "pasok",
     "ulit",
     "tungkol",
     "tama",


### PR DESCRIPTION
Replaced less commonly appearing or less frequently typed word:

bayan → pasok (entry • entrance • admission • school day • work day • going to work)

My bad, I really missed this one out. It was on my list/notes, but I completely forgot about it.

It's been a year or two since I started planning to update some words in the list. So, yeah, this will be my final update on the most common 200 words in Filipino—unless someone requests an update. But I believe that's unlikely, as I've done my best to provide a useful list for everyone.