### PR TITLE
fix(settings): play sound on error on hover in pop up menu (@Bretis2019)

### DIFF
--- a/frontend/src/ts/commandline/lists/sound-on-error.ts
+++ b/frontend/src/ts/commandline/lists/sound-on-error.ts
@@ -17,6 +17,9 @@ const subgroup: MonkeyTypes.CommandsSubgroup = {
       id: "setPlaySoundOnError1",
       display: "damage",
       configValue: "1",
+      hover: (): void => {
+        void SoundController.previewError("1");
+      },
       exec: (): void => {
         UpdateConfig.setPlaySoundOnError("1");
         void SoundController.playError();
@@ -26,6 +29,9 @@ const subgroup: MonkeyTypes.CommandsSubgroup = {
       id: "setPlaySoundOnError2",
       display: "triangle",
       configValue: "2",
+      hover: (): void => {
+        void SoundController.previewError("2");
+      },
       exec: (): void => {
         UpdateConfig.setPlaySoundOnError("2");
         void SoundController.playError();
@@ -35,6 +41,9 @@ const subgroup: MonkeyTypes.CommandsSubgroup = {
       id: "setPlaySoundOnError3",
       display: "square",
       configValue: "3",
+      hover: (): void => {
+        void SoundController.previewError("3");
+      },
       exec: (): void => {
         UpdateConfig.setPlaySoundOnError("3");
         void SoundController.playError();
@@ -44,6 +53,9 @@ const subgroup: MonkeyTypes.CommandsSubgroup = {
       id: "setPlaySoundOnError3",
       display: "punch miss",
       configValue: "4",
+      hover: (): void => {
+        void SoundController.previewError("4");
+      },
       exec: (): void => {
         UpdateConfig.setPlaySoundOnError("4");
         void SoundController.playError();

--- a/frontend/src/ts/controllers/sound-controller.ts
+++ b/frontend/src/ts/controllers/sound-controller.ts
@@ -404,6 +404,20 @@ export async function previewClick(val: string): Promise<void> {
   safeClickSounds[val][0].sounds[0].play();
 }
 
+export async function previewError(val: string): Promise<void> {
+  if (errorSounds === null) await initErrorSound();
+
+  const errorClickSounds = errorSounds as ErrorSounds;
+
+  const clickSoundIds = Object.keys(errorClickSounds);
+  if (!clickSoundIds.includes(val)) return;
+
+  //@ts-expect-error
+  errorClickSounds[val][0].sounds[0].seek(0);
+  //@ts-expect-error
+  errorClickSounds[val][0].sounds[0].play();
+}
+
 let currentCode = "KeyA";
 
 $(document).on("keydown", (event) => {


### PR DESCRIPTION
### Description

- Added `previewError` function to `sound-controller.ts`.
- Used that function to preview error sounds on hover using: 
```ts
hover: (): void => {
   void SoundController.previewError("1");
},
```

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.
