### PR TITLE
fix: result filters getting reset on page load (@fehmer)

### DIFF
--- a/frontend/src/ts/elements/account/result-filters.ts
+++ b/frontend/src/ts/elements/account/result-filters.ts
@@ -87,7 +87,7 @@ function save(): void {
 
 export async function load(): Promise<void> {
   try {
-    const filters = resultFiltersLS.get();
+    filters = resultFiltersLS.get();
 
     const newTags: Record<string, boolean> = { none: false };
     Object.keys(defaultResultFilters.tags).forEach((tag) => {


### PR DESCRIPTION
Result settings getting reset to defaults on page load

Steps to reproduce:
- go to account page
- set filter to last week
- reload the page

