### PR TITLE
feat(layout): add Belgian AZERTY layout (@dozketen)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -429,6 +429,17 @@
       "row5": [" "]
   }
   },
+  "belgian_azerty": {
+    "keymapShowTopRow": true,
+    "type": "iso",
+    "keys": {
+      "row1": ["²³", "&1|", "é2@", "\"3#", "'4", "(5", "§6^", "è7", "!8", "ç9{", "à0}", ")°", "-_"],
+      "row2": ["aA", "zZ", "eE€", "rR", "tT", "yY", "uU", "iI", "oO", "pP", "^¨[", "$*]"],
+      "row3": ["qQ", "sS", "dD", "fF", "gG", "hH", "jJ", "kK", "lL", "mM", "ù%´", "µ£`"],
+      "row4": ["<>\\", "wW", "xX", "cC", "vV", "bB", "nN", ",?", ";." ".:", ":/", "=+~"],
+      "row5": [" "]
+  }
+  },
   "bepo": {
     "keymapShowTopRow": false,
     "type": "iso",


### PR DESCRIPTION
Added the Belgian AZERTY layout to the Monkeytype configuration. This includes the key mappings for rows 1 through 5, with special characters and symbols supported by the layout.

### Description

This PR adds support for the Belgian AZERTY keyboard layout to Monkeytype. The layout has been added under the `belgian_azerty` key, and it follows the ISO standard. The layout includes special characters and symbols commonly used in the Belgian AZERTY layout.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

