### PR TITLE
fix(release script): not updating root `package.json` version + not supporting some shells (@NadAlaba)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
       "eslint"
     ]
   },
-  "version": "24.32.0",
+  "version": "24.34.0",
   "packageManager": "pnpm@9.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dev": "turbo run dev --force",
     "dev-be": "turbo run dev --force --filter @monkeytype/backend",
     "dev-fe": "turbo run dev --force --filter @monkeytype/frontend",
-    "dev-pkg": "turbo run dev ---force -filter=\"./packages/*\"",
+    "dev-pkg": "turbo run dev --force --filter=\"./packages/*\"",
     "start": "turbo run start",
     "start-be": "turbo run start --filter @monkeytype/backend",
     "start-fe": "turbo run start --filter @monkeytype/frontend",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "nodemon --watch src --exec 'node ./src/index.js --dry'",
+    "dev": "nodemon --watch src --exec \"node ./src/index.js --dry\"",
     "dev-changelog": "nodemon ./src/buildChangelog.js",
     "lint": "eslint \"./**/*.js\"",
     "purge-cf-cache": "./bin/purgeCfCache.sh"

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -22,6 +22,5 @@
     "@octokit/rest": "20.1.1",
     "dotenv": "16.4.5",
     "readline-sync": "1.4.10"
-  },
-  "version": "24.34.0"
+  }
 }

--- a/packages/release/src/buildChangelog.js
+++ b/packages/release/src/buildChangelog.js
@@ -251,19 +251,11 @@ function convertStringToLog(logString) {
 
     //split message using regex based on fix(language): spelling mistakes in Nepali wordlist and quotes (sapradhan) (#4528)
     //scope is optional, username is optional, pr number is optional
-    const [_, type, scope, message, message2, message3] = title.split(
-      /^(\w+)(?:\(([^)]+)\))?:\s+(.+?)\s*(?:\(([^)]+)\))?(?:\s+\(([^)]+)\))?(?:\s+\(([^)]+)\))?$/
+    const [_, type, scope, message, username, pr] = title.split(
+      /^(\w+)(?:\(([^)]+)\))?:\s+(.+?)(?:\s*\((@[^)]+)\))?(?:\s+\((#[^)]+)\))?$/
     );
 
-    const usernames = message2 && message3 ? message2.split(", ") : [];
-
-    let pr;
-    if (message2 && message3) {
-      pr = message3;
-    } else if (message2 && !message3) {
-      pr = message2;
-    }
-
+    const usernames = username ? username.split(", ") : [];
     const prs = pr ? pr.split(", ") : [];
 
     if (type && message) {
@@ -278,7 +270,7 @@ function convertStringToLog(logString) {
         scope,
         message,
         usernames: usernames || [],
-        prs,
+        prs: prs || [],
         body: body || "",
       });
     } else {

--- a/packages/release/src/buildChangelog.js
+++ b/packages/release/src/buildChangelog.js
@@ -86,7 +86,7 @@ const titles = {
 
 function getPrLink(pr) {
   const prNum = pr.replace("#", "");
-  return `[#${prNum}](https://github.com/monkeytypegame/monkeytype/issues/${prNum})`;
+  return `[#${prNum}](https://github.com/monkeytypegame/monkeytype/pull/${prNum})`;
 }
 
 function getCommitLink(hash, longHash) {

--- a/packages/release/src/buildChangelog.js
+++ b/packages/release/src/buildChangelog.js
@@ -37,18 +37,20 @@ const logDelimiter =
   "thisismylogdelimiterthatwilldefinitelynotappearintheactualcommitmessage";
 
 async function getLog() {
-  return new Promise((resolve, reject) => {
-    exec(
-      `git log --oneline $(git describe --tags --abbrev=0 @^)..@ --pretty="format:${lineDelimiter}%H${logDelimiter}%h${logDelimiter}%s${logDelimiter}%b"`,
-      (err, stdout, _stderr) => {
-        if (err) {
-          reject(err);
-        }
-
+  function execPromise(command) {
+    return new Promise((resolve, reject) => {
+      exec(command, (err, stdout, _stderr) => {
+        if (err) reject(err);
         resolve(stdout);
-      }
-    );
-  });
+      });
+    });
+  }
+
+  return execPromise(`git describe --tags --abbrev=0 HEAD^`).then((lastTag) =>
+    execPromise(
+      `git log --oneline ${lastTag.trim()}..HEAD --pretty="format:${lineDelimiter}%H${logDelimiter}%h${logDelimiter}%s${logDelimiter}%b"`
+    )
+  );
 }
 
 function itemIsAddingQuotes(item) {

--- a/packages/release/src/index.js
+++ b/packages/release/src/index.js
@@ -120,20 +120,24 @@ const updatePackage = (newVersion) => {
     console.log(`[Dry Run] Updated package.json to version ${newVersion}`);
     return;
   }
-  const packagePath = path.resolve(__dirname, "../package.json");
+  const packageDirs = [path.resolve(__dirname, "../"), PROJECT_ROOT];
 
-  // Read the package.json file
-  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  for (const packageDir of packageDirs) {
+    const packagePath = `${packageDir}/package.json`;
 
-  // Update the version field
-  packageJson.version = newVersion.replace("v", "");
+    // Read the package.json file
+    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
 
-  // Write the updated JSON back to package.json
-  fs.writeFileSync(
-    packagePath,
-    JSON.stringify(packageJson, null, 2) + "\n",
-    "utf8"
-  );
+    // Update the version field
+    packageJson.version = newVersion.replace("v", "");
+
+    // Write the updated JSON back to package.json
+    fs.writeFileSync(
+      packagePath,
+      JSON.stringify(packageJson, null, 2) + "\n",
+      "utf8"
+    );
+  }
 
   console.log(`Updated package.json to version ${newVersion}`);
 };

--- a/packages/release/src/index.js
+++ b/packages/release/src/index.js
@@ -120,24 +120,20 @@ const updatePackage = (newVersion) => {
     console.log(`[Dry Run] Updated package.json to version ${newVersion}`);
     return;
   }
-  const packageDirs = [path.resolve(__dirname, "../"), PROJECT_ROOT];
+  const packagePath = `${PROJECT_ROOT}/package.json`;
 
-  for (const packageDir of packageDirs) {
-    const packagePath = `${packageDir}/package.json`;
+  // Read the package.json file
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
 
-    // Read the package.json file
-    const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  // Update the version field
+  packageJson.version = newVersion.replace("v", "");
 
-    // Update the version field
-    packageJson.version = newVersion.replace("v", "");
-
-    // Write the updated JSON back to package.json
-    fs.writeFileSync(
-      packagePath,
-      JSON.stringify(packageJson, null, 2) + "\n",
-      "utf8"
-    );
-  }
+  // Write the updated JSON back to package.json
+  fs.writeFileSync(
+    packagePath,
+    JSON.stringify(packageJson, null, 2) + "\n",
+    "utf8"
+  );
 
   console.log(`Updated package.json to version ${newVersion}`);
 };


### PR DESCRIPTION
### Description

1. When updating the version, the script is getting current version from root `package.json`, but updating `release/package.json`, so root `package.json` never gets updated and minor will always be zero.
Chosen solution was to get version from root, but update both.
Other possible solution is to not use version in `release/package.json` at all (i.e, get and set version in root only).
**[EDIT]**
Solution changed to removing version from all `package.json` other than root one, and only get and update it in root.

2. Change single quotes in `nodemon --exec '...'` to double quotes.
![releaseScript](https://github.com/user-attachments/assets/531444c2-be21-41d6-b0fd-b0c195fe8c2a)

3. Changes in `buildChangelog.getLog()` are because some shells don't support evaluating subexpressions in `$(...)`.

4. Change root `package.json` version to current version.

5. In commit titles, trailing parenthesis that are not usernames or PR numbers are being considered PRs. So now usernames get matched when they start with `@` and PRs when they start with `#`.
![log](https://github.com/user-attachments/assets/4bc5d3b0-dc17-4164-b232-22da5dbeb2bd)