### PR TITLE
Add neon theme with vibrant colors

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1244,5 +1244,12 @@
     "mainColor": "#e0794e",
     "subColor": "#688e8f",
     "textColor": "#023e3b"
+  },
+  {
+    "name": "neon",
+    "bgColor": "#2b213a",
+    "mainColor": "#ff71ce",
+    "subColor": "#01cdfe",
+    "textColor": "#fffb96"
   }
 ]

--- a/frontend/static/themes/neon.css
+++ b/frontend/static/themes/neon.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #2b213a;
+  --main-color: #ff71ce;
+  --caret-color: #b967ff;
+  --sub-color: #01cdfe;
+  --sub-alt-color: #664e8c;
+  --text-color: #fffb96;
+  --error-color: #ff3864;
+  --error-extra-color: #ff5e5e;
+  --colorful-error-color: #ff00ff;
+  --colorful-error-extra-color: #00ffff;
+}


### PR DESCRIPTION
### **feat: Add neon theme with vibrant colors**

**Description:**  
Added a new neon theme with a dark background and vibrant, eye-catching colors. The theme includes bright accents and error colors for an engaging typing experience.

**Theme Overview:**
- **Background Color:** `#2b213a`
- **Main Color:** `#ff71ce`
- **Caret Color:** `#b967ff`
- **Sub Color:** `#01cdfe`
- **Sub Alt Color:** `#664e8c`
- **Text Color:** `#fffb96`
- **Error Color:** `#ff3864`
- **Error Extra Color:** `#ff5e5e`
- **Colorful Error Color:** `#ff00ff`
- **Colorful Error Extra Color:** `#00ffff`

### **Test Cases:**

1. **Theme Overview:**
   - Verified that the theme colors render correctly when applied.
   ![Theme Overview](https://github.com/user-attachments/assets/7fe5ab39-bbb2-48cd-90ab-1f9325dc26d9)

2. **Theme with Typing:**
   - Tested typing experience with the neon theme enabled to ensure readability and visual comfort.
   ![Theme with typing](https://github.com/user-attachments/assets/0322f5ae-e880-4563-a860-86c38c08a438)

3. **Navigation Menu Example:**
   - Confirmed that the navigation menu is visually consistent with the theme.
   ![Navigation Menu Example](https://github.com/user-attachments/assets/f2d56fbb-d5a6-494c-81a6-f3aa3f3340bb)

4. **Color Full Mode:**
   - Tested color full mode to ensure colors are vibrant and enhance the typing experience.
   ![Color Full Mode](https://github.com/user-attachments/assets/f8d883f2-d320-4222-a159-3c4e6acd316f)

5. **Color Flip Mode:**
   - Checked color flip mode to ensure colors transition smoothly and remain readable.
   ![Color Flip Mode](https://github.com/user-attachments/assets/3a938bf0-99ee-4db1-a2ea-d12ded0b5d7c)

**Additional Notes:**
- All changes have been tested and confirmed to meet the theme guidelines.
- If further adjustments are needed, please let me know.

**Author:** Mohit Paddhariya