### PR TITLE
fix(caret): getting last letter top in long multiline words (@NadAlaba)

### DIFF
--- a/frontend/src/ts/test/caret.ts
+++ b/frontend/src/ts/test/caret.ts
@@ -159,7 +159,8 @@ export async function updatePosition(noAnim = false): Promise<void> {
   const isLanguageRightToLeft = currentLanguage.rightToLeft;
 
   // in blind mode, and hide extra letters, extra letters have zero offsets
-  // offsetTop and offsetHeight is the same for all visible letters
+  // offsetHeight is the same for all visible letters
+  // so is offsetTop (for same line letters)
   const letterHeight =
     currentLetter?.offsetHeight ||
     lastWordLetter?.offsetHeight ||

--- a/frontend/src/ts/test/caret.ts
+++ b/frontend/src/ts/test/caret.ts
@@ -165,8 +165,9 @@ export async function updatePosition(noAnim = false): Promise<void> {
     lastWordLetter?.offsetHeight ||
     Config.fontSize * Numbers.convertRemToPixels(1);
 
-  const letterPosTop =
-    currentLetter?.offsetTop || lastWordLetter?.offsetTop || 0;
+  let letterPosTop = currentLetter?.offsetTop ?? lastWordLetter?.offsetTop ?? 0;
+  if ((Config.blindMode || Config.hideExtraLetters) && inputLen > wordLen)
+    letterPosTop = lastWordLetter?.offsetTop ?? 0;
   const diff = letterHeight - caret.offsetHeight;
   let newTop = activeWordEl.offsetTop + letterPosTop + diff / 2;
   if (Config.caretStyle === "underline") {

--- a/frontend/src/ts/test/caret.ts
+++ b/frontend/src/ts/test/caret.ts
@@ -165,9 +165,8 @@ export async function updatePosition(noAnim = false): Promise<void> {
     lastWordLetter?.offsetHeight ||
     Config.fontSize * Numbers.convertRemToPixels(1);
 
-  let letterPosTop = currentLetter?.offsetTop ?? lastWordLetter?.offsetTop ?? 0;
-  if ((Config.blindMode || Config.hideExtraLetters) && inputLen > wordLen)
-    letterPosTop = lastWordLetter?.offsetTop ?? 0;
+  const letterPosTop =
+    currentLetter?.offsetTop ?? lastWordLetter?.offsetTop ?? 0;
   const diff = letterHeight - caret.offsetHeight;
   let newTop = activeWordEl.offsetTop + letterPosTop + diff / 2;
   if (Config.caretStyle === "underline") {


### PR DESCRIPTION
### Description

- When getting to a long multi-line word, the caret jumps to the last line of that word instead of the line of the first letter.
![long-word-caret](https://github.com/user-attachments/assets/a8dbdf5b-404a-45f7-a7a7-580cf4650520)
