### PR TITLE
fix: multi-line words causing issues in ui scrolling and tape mode (@NadAlaba)

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -263,6 +263,7 @@
 
   &.tape .word {
     margin: 0.25em 0.6em 0.75em 0;
+    white-space: nowrap;
   }
 
   /* a little hack for right-to-left languages */

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -530,8 +530,10 @@
 }
 
 #wordsInput {
-  font-size: 1rem;
-  opacity: 0;
+  width: 1ch;
+  font-size: 1em;
+  height: 1em;
+  // opacity: 0;
   padding: 0;
   margin: 0 auto;
   border: none;

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -533,7 +533,7 @@
   width: 1ch;
   font-size: 1em;
   height: 1em;
-  // opacity: 0;
+  opacity: 0;
   padding: 0;
   margin: 0 auto;
   border: none;

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1763,7 +1763,7 @@ export function setFontSize(
 
   config.fontSize = fontSize;
 
-  $("#caret, #paceCaret, #liveStatsMini, #typingTest").css(
+  $("#caret, #paceCaret, #liveStatsMini, #typingTest, #wordsInput").css(
     "fontSize",
     fontSize + "rem"
   );

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -463,10 +463,12 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
   const activeWordMargin = activeWordOuterHeight - activeWordOffsetHeight;
   // this is the same as activeWord.offsetHeight in single-line words
   let activeWordHeight;
-  if (letterHeight)
+  if (letterHeight) {
     activeWordHeight =
       activeWordOffsetHeight - activeWordContentHeight + letterHeight;
-  else activeWordHeight = activeWordOffsetHeight;
+  } else {
+    activeWordHeight = activeWordOffsetHeight;
+  }
 
   if (Config.tapeMode !== "off") {
     el.style.top =

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -455,7 +455,6 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
     parseInt(computed.marginTop) + parseInt(computed.marginBottom);
 
   const letterHeight = Numbers.convertRemToPixels(Config.fontSize);
-  const activeWordTopNoMargin = activeWord.offsetTop - activeWordMargin / 2;
   const targetTop =
     activeWord.offsetTop + letterHeight / 2 - el.offsetHeight / 2 + 1; //+1 for half of border
 

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -453,21 +453,29 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
     return;
   }
 
-  const computed = window.getComputedStyle(activeWord);
-  const activeWordMargin =
-    parseInt(computed.marginTop) + parseInt(computed.marginBottom);
+  let letter = activeWord.querySelector<HTMLElement>("letter");
+  let letterHeight = letter?.getBoundingClientRect().height;
+  if (!letterHeight) {
+    activeWord.insertAdjacentHTML(
+      "beforeend",
+      '<letter style="opacity: 0;">_</letter>'
+    );
+    letter = activeWord.querySelector("letter") as HTMLElement;
+    letterHeight = letter.getBoundingClientRect().height;
+    activeWord.replaceChildren();
+  }
 
-  // const wordsWrapperTop =
-  //   (document.querySelector("#wordsWrapper") as HTMLElement | null)
-  //     ?.offsetTop ?? 0;
+  const activeWordOuterHeight = $(activeWord).outerHeight(true) as number;
+  const activeWordOffsetHeight = $(activeWord).outerHeight() as number;
+  const activeWordContentHeight = $(activeWord).height() as number;
+  const activeWordMargin = activeWordOuterHeight - activeWordOffsetHeight;
+  // this is the same as activeWord.offsetHeight in single-line words
+  const activeWordHeight =
+    activeWordOffsetHeight - activeWordContentHeight + letterHeight;
 
   if (Config.tapeMode !== "off") {
     el.style.top =
-      // wordsWrapperTop +
-      activeWord.offsetHeight +
-      activeWordMargin * 0.25 +
-      -el.offsetHeight +
-      "px";
+      activeWordHeight + activeWordMargin * 0.25 + -el.offsetHeight + "px";
     el.style.left = activeWord.offsetLeft + "px";
     return;
   }
@@ -485,13 +493,13 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
   ) {
     el.style.top =
       activeWord.offsetTop +
-      activeWord.offsetHeight +
+      activeWordHeight +
       -el.offsetHeight +
-      (activeWord.offsetHeight + activeWordMargin) +
+      (activeWordHeight + activeWordMargin) +
       "px";
   } else {
     el.style.top =
-      activeWord.offsetTop + activeWord.offsetHeight + -el.offsetHeight + "px";
+      activeWord.offsetTop + activeWordHeight + -el.offsetHeight + "px";
   }
 }
 

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -453,25 +453,20 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
     return;
   }
 
-  let letter = activeWord.querySelector<HTMLElement>("letter");
-  let letterHeight = letter?.getBoundingClientRect().height;
-  if (!letterHeight) {
-    activeWord.insertAdjacentHTML(
-      "beforeend",
-      '<letter style="opacity: 0;">_</letter>'
-    );
-    letter = activeWord.querySelector("letter") as HTMLElement;
-    letterHeight = letter.getBoundingClientRect().height;
-    activeWord.replaceChildren();
-  }
+  const letterHeight = activeWord
+    .querySelector("letter")
+    ?.getBoundingClientRect().height;
 
   const activeWordOuterHeight = $(activeWord).outerHeight(true) as number;
   const activeWordOffsetHeight = $(activeWord).outerHeight() as number;
   const activeWordContentHeight = $(activeWord).height() as number;
   const activeWordMargin = activeWordOuterHeight - activeWordOffsetHeight;
   // this is the same as activeWord.offsetHeight in single-line words
-  const activeWordHeight =
-    activeWordOffsetHeight - activeWordContentHeight + letterHeight;
+  let activeWordHeight;
+  if (letterHeight)
+    activeWordHeight =
+      activeWordOffsetHeight - activeWordContentHeight + letterHeight;
+  else activeWordHeight = activeWordOffsetHeight;
 
   if (Config.tapeMode !== "off") {
     el.style.top =

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -457,11 +457,7 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
   const letterHeight = Numbers.convertRemToPixels(Config.fontSize);
   const activeWordTopNoMargin = activeWord.offsetTop - activeWordMargin / 2;
   const targetTop =
-    activeWordTopNoMargin +
-    letterHeight / 2 -
-    el.offsetHeight / 2 +
-    activeWordMargin / 2 +
-    1; //+1 for half of border
+    activeWord.offsetTop + letterHeight / 2 - el.offsetHeight / 2 + 1; //+1 for half of border
 
   if (activeWord.offsetWidth < letterHeight) {
     el.style.width = letterHeight + "px";

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -438,6 +438,9 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
   if (ActivePage.get() !== "test") return;
   if (Config.tapeMode !== "off" && !initial) return;
 
+  const currentLanguage = await JSONData.getCurrentLanguage(Config.language);
+  const isLanguageRTL = currentLanguage.rightToLeft;
+
   const el = document.querySelector("#wordsInput") as HTMLElement;
   const activeWord =
     document.querySelectorAll<HTMLElement>("#words .word")[
@@ -476,7 +479,7 @@ export async function updateWordsInputPosition(initial = false): Promise<void> {
     el.style.top = targetTop + "px";
   }
 
-  if (activeWord.offsetWidth < letterHeight) {
+  if (activeWord.offsetWidth < letterHeight && isLanguageRTL) {
     el.style.left = activeWord.offsetLeft - letterHeight + "px";
   } else {
     el.style.left = activeWord.offsetLeft + "px";


### PR DESCRIPTION
### Description
1. When text is a single long multi-line word that takes up all of the screen, `#wordsInput` position will be below the visible screen which requires scrolling down.
    - This PR tweaks `#wordsInput` position calculation by considering a `word` height as the height of a single line of a word.
    - For visual illustration of this bug see this [video on discord server](https://discord.com/channels/713194177403420752/713195089303830548/1281633634650165278)
2. When a long multi-line word is used in tape mode, this word will wrap to multiple lines causing inability to type the letters which are below the first line.
    - The chosen solution was to use `white-space: nowrap` on `.tape .word` elements.
    - For visual illustration of this bug see [this](https://discord.com/channels/713194177403420752/713195115275091969/1281640882902401128), and [this](https://discord.com/channels/713194177403420752/713195089303830548/1281634954203369555) videos on discord server.