### PR TITLE
fix(quote search): search service not building in code_javascript quotes (@NadAlaba)

### DIFF
--- a/frontend/src/ts/utils/search-service.ts
+++ b/frontend/src/ts/utils/search-service.ts
@@ -84,12 +84,12 @@ export const buildSearchService = <T>(
     rawTokens.forEach((token) => {
       const stemmedToken = stemmer(token);
 
-      if (!(stemmedToken in normalizedTokenToOriginal)) {
+      if (!Object.hasOwn(normalizedTokenToOriginal, stemmedToken)) {
         normalizedTokenToOriginal[stemmedToken] = new Set<string>();
       }
       normalizedTokenToOriginal[stemmedToken]?.add(token);
 
-      if (!(stemmedToken in reverseIndex)) {
+      if (!Object.hasOwn(reverseIndex, stemmedToken)) {
         reverseIndex[stemmedToken] = new Set<InternalDocument>();
       }
       reverseIndex[stemmedToken]?.add(internalDocument);


### PR DESCRIPTION
### Description

`stemmedToken in normalizedTokenToOriginal` always returns `true` when `stemmedToken` is `"constructor"`.
This is not the case for `Object.hasOwn(normalizedTokenToOriginal, stemmedToken)`.