### PR TITLE
fix: dark note theme dots being too big (@fehmer)

### DIFF
--- a/frontend/static/themes/dark_note.css
+++ b/frontend/static/themes/dark_note.css
@@ -101,11 +101,10 @@ body::before {
   --c-dot--error: var(--colorful-error-color);
 }
 
-#wordsWrapper .word:has(~ .active) letter {
-  animation: toDust 200ms ease-out 0ms 1 forwards;
+#words .word:has(~ .active) letter {
+  animation: toDust 200ms ease-out 0ms 1 forwards !important;
 }
-
-#wordsWrapper .word:has(~ .active) letter::after {
+#words .word:has(~ .active) letter::after {
   animation: fadeIn 100ms ease-in 100ms 1 forwards;
 }
 


### PR DESCRIPTION
Dots for correct letters are too big: 
![image](https://github.com/user-attachments/assets/35aca184-54c4-4fa6-a49c-2e5bfa0a53eb)
