### PR TITLE
impr(serbian): add more attributes to Serbian files (@rammba)

### DIFF
--- a/frontend/static/languages/serbian.json
+++ b/frontend/static/languages/serbian.json
@@ -1,6 +1,9 @@
 {
   "name": "serbian",
   "noLazyMode": true,
+  "rightToLeft": false,
+  "ligatures": false,
+  "bcp47": "sr-Cyrl",
   "words": [
     "као",
     "ја",

--- a/frontend/static/languages/serbian_10k.json
+++ b/frontend/static/languages/serbian_10k.json
@@ -1,6 +1,9 @@
 {
   "name": "serbian_10k",
   "noLazyMode": true,
+  "rightToLeft": false,
+  "ligatures": false,
+  "bcp47": "sr-Cyrl",
   "words": [
     "је",
     "да",

--- a/frontend/static/languages/serbian_latin.json
+++ b/frontend/static/languages/serbian_latin.json
@@ -1,5 +1,8 @@
 {
   "name": "serbian_latin",
+  "rightToLeft": false,
+  "ligatures": false,
+  "bcp47": "sr-Latn",
   "additionalAccents": [["đ", "dj"]],
   "words": [
     "kao",

--- a/frontend/static/languages/serbian_latin_10k.json
+++ b/frontend/static/languages/serbian_latin_10k.json
@@ -1,5 +1,8 @@
 {
   "name": "serbian_latin_10k",
+  "rightToLeft": false,
+  "ligatures": false,
+  "bcp47": "sr-Latn",
   "additionalAccents": [["đ", "dj"]],
   "words": [
     "je",


### PR DESCRIPTION
I've specified `rightToLeft`, `ligatures` and `bcp47` attributes in all Serbian files just to make them more understandable.
I suppose that `rightToLeft` and `ligatures` are false by default. Please let me know if I'm wrong.