### PR TITLE
impr(dockerfile): add support for Dockerfile language (@rammba)

### DIFF
--- a/frontend/static/languages/_groups.json
+++ b/frontend/static/languages/_groups.json
@@ -498,7 +498,8 @@
       "twitch_emotes",
       "git",
       "typing_of_the_dead",
-      "league_of_legends"
+      "league_of_legends",
+      "docker_file"
     ]
   },
   {

--- a/frontend/static/languages/_list.json
+++ b/frontend/static/languages/_list.json
@@ -353,4 +353,5 @@
   ,"xhosa"
   ,"code_cobol"
   ,"code_common_lisp"
+  ,"docker_file"
 ]

--- a/frontend/static/languages/docker_file.json
+++ b/frontend/static/languages/docker_file.json
@@ -1,0 +1,25 @@
+{
+  "name": "docker_file",
+  "noLazyMode": true,
+  "words": [
+    "ADD",
+    "ARG",
+    "AS",
+    "CMD",
+    "COPY",
+    "ENTRYPOINT",
+    "ENV",
+    "EXPOSE",
+    "FROM",
+    "HEALTHCHECK",
+    "LABEL",
+    "MAINTAINER",
+    "ONBUILD",
+    "RUN",
+    "SHELL",
+    "STOPSIGNAL",
+    "USER",
+    "VOLUME",
+    "WORKDIR"
+  ]
+}


### PR DESCRIPTION
I've added support for Dockerfile "language" even if it's not the language actually. All words added are listed in the [official docs](https://docs.docker.com/reference/dockerfile/#overview). I've put it to the other group of languages.

P.S. File name is `docker_file.json`, because when I name it `dockerfile.json`, my VS Code detects it as an actual dockerfile. Let me know if name should be changed.