### PR TITLE
feat: show tape mode used on result screen (@fehmer)

### DIFF
--- a/frontend/src/ts/test/result.ts
+++ b/frontend/src/ts/test/result.ts
@@ -158,7 +158,7 @@ async function updateGraph(): Promise<void> {
         borderRadius: 3,
         position: "start",
         display: true,
-        content: `${content}`,
+        content: content,
       },
     });
   }
@@ -689,6 +689,9 @@ function updateTestType(randomQuote: Quote | null): void {
   }
   if (Config.funbox !== "none") {
     testType += "<br>" + Config.funbox.replace(/_/g, " ").replace(/#/g, ", ");
+  }
+  if (Config.tapeMode !== "off") {
+    testType += "<br> tape mode " + Config.tapeMode;
   }
   if (Config.difficulty === "expert") {
     testType += "<br>expert";


### PR DESCRIPTION
Show the tape mode used in the test type on the result screen.

This was requested on discord. I am not sure about this. On the one hand we do include the funboxes in the test mode. Funboxes like `plus three` or `crt` only change the appeareance and are shown. Tape mode could've been implemented as a funbox and would show up on the result screen.
On the other hand this is a regular setting and other settings like `highlight` work similar and are not shown on the result page.
