### PR TITLE
fix: remove space at beginning of custom text lines

### DIFF
--- a/frontend/src/ts/modals/custom-text.ts
+++ b/frontend/src/ts/modals/custom-text.ts
@@ -221,9 +221,9 @@ async function afterAnimation(): Promise<void> {
 }
 
 export function show(showOptions?: ShowOptions): void {
-  state.textarea = CustomText.getText().join(
-    CustomText.getPipeDelimiter() ? "|" : " "
-  );
+  state.textarea = CustomText.getText()
+    .join(CustomText.getPipeDelimiter() ? "|" : " ")
+    .replace(/^ +/gm, "");
   void modal.show({
     ...(showOptions as ShowOptions<IncomingData>),
     beforeAnimation,


### PR DESCRIPTION
when creating a multi line text in the custom text editor and then reopening the editor all lines after the first will have a space at the start, this is because .join adds a space regardless of whether there is a newline character