### PR TITLE
fix: correct spelling in revoke all tokens modal (@Andotrium)

### DIFF
--- a/frontend/src/ts/modals/simple-modals.ts
+++ b/frontend/src/ts/modals/simple-modals.ts
@@ -983,7 +983,7 @@ list.revokeAllTokens = new SimpleModal({
       initVal: "",
     },
   ],
-  text: "Are you sure you want to this? This will log you out of all devices.",
+  text: "Are you sure you want to do this? This will log you out of all devices.",
   buttonText: "revoke all",
   onlineOnly: true,
   execFn: async (_thisPopup, password): Promise<ExecReturn> => {


### PR DESCRIPTION
Fixed the typo in modal that appeared when trying to revoke all tokens

### Description

fixed issue: #6011 
