### PR TITLE
fix(language): removed non-french from the french language files (@theiereman)

### DIFF
--- a/frontend/static/languages/french_10k.json
+++ b/frontend/static/languages/french_10k.json
@@ -1948,7 +1948,6 @@
     "israélienne",
     "capteurs",
     "monopole",
-    "music",
     "malfaçon",
     "épiler",
     "justifier",

--- a/frontend/static/languages/french_2k.json
+++ b/frontend/static/languages/french_2k.json
@@ -1948,7 +1948,6 @@
     "israélienne",
     "capteurs",
     "monopole",
-    "music",
     "malfaçon",
     "épiler",
     "justifier",


### PR DESCRIPTION
### Description

I was doing some typing tests and I noticed the "music" word in the french languages pack. I checked in a dictionnary and that word doesn't exist so I removed it from every package that had that word in it. The only correct existing word is "musique".