### PR TITLE
Fix Quick restart key tip

### DIFF
--- a/frontend/src/ts/ui.ts
+++ b/frontend/src/ts/ui.ts
@@ -47,7 +47,7 @@ function updateKeytips(): void {
 
   const commandKey = Config.quickRestart === "esc" ? "tab" : "esc";
   $("footer .keyTips").html(`
-    <key>${Config.quickRestart}</key> - restart test<br>
+    <key>${Config.quickRestart=="off"?"(No key binded)":Config.quickRestart}</key> - restart test<br>
     <key>${commandKey}</key> or <key>${modifierKey}</key>+<key>shift</key>+<key>p</key> - command line`);
 }
 


### PR DESCRIPTION
### Description
People will get confused if they see "off" as the quick restart key bind, so if the quick restart keybind is not bound, instead it will show `(No key binded)` instead.