### PR TITLE
fix: remove the duplicate manifest tag (@malkiii)

### DIFF
--- a/frontend/src/html/head.html
+++ b/frontend/src/html/head.html
@@ -50,7 +50,6 @@
     content="/images/favicon/browserconfig.xml"
   />
   <meta id="metaThemeColor" name="theme-color" content="#e2b714" />
-  <link rel="manifest" href="/manifest.json" />
   <meta
     name="name"
     content="Monkeytype | A minimalistic, customizable typing test"


### PR DESCRIPTION
### Description

there are two manifest tags in the rendered head, it seems that the `/manifest.json` file already has been added by [vite.config.prod.js](https://github.com/monkeytypegame/monkeytype/blob/ca21b8dc3ae092af2b7140e1e0deeece8bc73130/frontend/vite.config.prod.js#L110)

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->
