### PR TITLE
feat(themes): added witchthorne theme (NotMageLock)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1,4 +1,11 @@
 [
+    {
+    "name": "witchthorne",
+    "bgColor": "#36093e",
+    "mainColor": "#7be000",
+    "subColor": "#95b295",
+    "textColor": "#61ff7e"
+  },
   {
     "name": "dark_note",
     "bgColor": "#1f1f1f",

--- a/frontend/static/themes/witchthorne.css
+++ b/frontend/static/themes/witchthorne.css
@@ -1,0 +1,12 @@
+:root {
+    --bg-color: #36093e;
+    --main-color: #7be000;
+    --caret-color: #ffffff;
+    --sub-color: #95b295;
+    --sub-alt-color: #4a1961;
+    --text-color: #61ff7e;
+    --error-color: #ff0000;
+    --error-extra-color: #85002c;
+    --colorful-error-color: #ff0000;
+    --colorful-error-extra-color: #85002c;
+  }


### PR DESCRIPTION
added new theme, witchthorne
![IMG_5666](https://github.com/user-attachments/assets/0e234987-f993-4c92-b30c-d1877ddf404f)
![IMG_5664](https://github.com/user-attachments/assets/501c154f-3db3-45c9-97d0-a0f678726ddd)
