### PR TITLE
feat(result page): open daily leaderboard when clicking the daily leaderboard rank (@theiereman)

### DIFF
--- a/frontend/src/html/pages/test.html
+++ b/frontend/src/html/pages/test.html
@@ -269,7 +269,14 @@
 
         <div class="group dailyLeaderboard hidden">
           <div class="top">daily leaderboard</div>
-          <div class="bottom">-</div>
+          <div
+            id="dailyLeaderboardRank"
+            aria-label="Show daily leaderboard"
+            data-balloon-pos="up"
+            class="bottom"
+          >
+            -
+          </div>
         </div>
 
         <div class="group source hidden">

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -831,7 +831,6 @@
 
         &.dailyLeaderboard {
           max-width: 13rem;
-          overflow: hidden;
           white-space: nowrap;
         }
 

--- a/frontend/src/ts/elements/leaderboards.ts
+++ b/frontend/src/ts/elements/leaderboards.ts
@@ -21,6 +21,7 @@ import {
   LeaderboardRank,
 } from "@monkeytype/contracts/schemas/leaderboards";
 import { Mode } from "@monkeytype/contracts/schemas/shared";
+import * as TestStats from "../test/test-stats";
 
 const wrapperId = "leaderboardsWrapper";
 
@@ -971,6 +972,17 @@ $("header nav").on("click", ".textButton", (e) => {
   if ($(e.currentTarget).hasClass("leaderboards")) {
     show();
   }
+});
+
+$(".pageTest").on("click", "#dailyLeaderboardRank", () => {
+  currentTimeRange = "daily";
+  updateYesterdayButton();
+  languageSelector?.enable();
+
+  currentLanguage = TestStats.lastResult.language;
+  languageSelector?.setSelected(currentLanguage);
+  void update();
+  show();
 });
 
 Skeleton.save(wrapperId);


### PR DESCRIPTION
### Description

Clicking on the rank (after getting a better rank in the daily leaderboard) will automatically open the leaderboard modal on the corresponding language screen

![gifgit](https://github.com/user-attachments/assets/92c974c5-acd1-4f2a-a7e7-bb61e30b692b)

Honestly, I mostly added this for me because I like to go to the daily leaderboard after I did a good run and it was annoying me to have to open it + change the language to french + change to daily.