### PR TITLE
fix(tape mode): tape mode not centering properly on window resize (@laroccol)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -995,6 +995,8 @@ export function scrollTape(): void {
   } else {
     $("#words").css("margin-left", `${newMargin}px`);
   }
+
+  setTimeout(() => $("#wordsWrapper").scrollLeft(0));
 }
 
 export function updatePremid(): void {


### PR DESCRIPTION
### Description
When tape mode was enabled (letter or word) there was an issue when you went from a large screen size to a small screen size and restarted the test. The text/caret would not be centered on the screen and depending on how small the screen width you couldn't see it at all. The root of the issue seems to be that the focused element goes out of view so the browser tries to scroll it into view. This causes the words container to be offset by the scroll amount + the margin offset used for tape mode. 

![image](https://github.com/user-attachments/assets/8cab3b76-3c57-4aa7-9c7e-ff2c9b87a552)

To fix this I set the word box's scroll left to 0 whenever the tape is updated. I put it in a settimeout so it runs after the current execution flow because the focusing was happening after it. This is more of a band aid fix in order to not mess with things outside the tape mode scope. 

Closes #6093 
