### PR TITLE
style: added vscode default dark theme (@Fr0styGDEV)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1251,5 +1251,12 @@
     "mainColor": "#bef0ff",
     "subColor": "#fe9841",
     "textColor": "#dbdeeb"
+  },
+  {
+    "name": "vscode",
+    "bgColor": "#1e1e1e",
+    "mainColor": "#007acc",
+    "subColor": "#d4d4d4",
+    "textColor": "#a6a6a6"
   }
 ]

--- a/frontend/static/themes/vscode.css
+++ b/frontend/static/themes/vscode.css
@@ -1,12 +1,12 @@
 :root {
   --bg-color: #1e1e1e;
   --main-color: #007acc;
-  --caret-color: #569cd6;
-  --sub-color: #4d4d4d;
-  --sub-alt-color: #191919;
-  --text-color: #d4d4d4;
-  --error-color: #f44747;
-  --error-extra-color: #f44747;
-  --colorful-error-color: #f44747;
-  --colorful-error-extra-color: #f44747;
+  --caret-color: #e2c08d;
+  --sub-color: #d4d4d4;
+  --sub-alt-color: #383a49;
+  --text-color: #a6a6a6;
+  --error-color: #f14c4c;
+  --error-extra-color: #f14c4c;
+  --colorful-error-color: #f14c4c;
+  --colorful-error-extra-color: #f14c4c;
 }


### PR DESCRIPTION
### Description

Copies exact colors of default VS Code dark theme

### Checks

- [x] Adding a language or a theme?
  - [x] If is a theme, did you add the theme.css?

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

### Screenshots
![image_2024-12-26_211844246](https://github.com/user-attachments/assets/e6deb04c-6661-4d7a-9062-90921d4f2d01)
![image](https://github.com/user-attachments/assets/35bebd25-473a-4117-aaf8-52bd9314a42e)
![image](https://github.com/user-attachments/assets/4253bfee-c991-443d-9f1d-fcfa412fe678)




