### PR TITLE
fix: blind mode not working in dark note theme (@fehmer)

### DIFF
--- a/frontend/static/themes/dark_note.css
+++ b/frontend/static/themes/dark_note.css
@@ -72,17 +72,17 @@ body::before {
   text-shadow: none;
 }
 
-#words.colorfulMode .word letter.incorrect:not(.extra),
-#words .word letter.incorrect:not(.extra) {
+#words:not(.blind).colorfulMode .word letter.incorrect:not(.extra),
+#words:not(.blind) .word letter.incorrect:not(.extra) {
   color: var(--current-color);
 }
 
-#words .word.error letter:not(.correct):not(.incorrect)::after {
+#words:not(.blind) .word.error letter:not(.correct):not(.incorrect)::after {
   background: var(--sub-color);
 }
 
-#words .word letter.incorrect,
-#words.colorfulMode .word letter.incorrect {
+#words:not(.blind) .word letter.incorrect,
+#words:not(.blind).colorfulMode .word letter.incorrect {
   text-decoration: line-through;
   text-decoration-color: var(--error-color);
   text-decoration-thickness: 2px;
@@ -128,7 +128,7 @@ body::before {
   background: var(--c-dot);
 }
 
-#wordsWrapper .word letter.incorrect::after {
+#wordsWrapper #words:not(.blind) .word letter.incorrect::after {
   background: var(--c-dot--error);
 }
 


### PR DESCRIPTION
Errors are still shown in blind mode when using the dark note theme.

Fixes #6185
