### PR TITLE
refactor(parsing): Replace JSON.parse with parseJsonWithSchema (@dev-…

### DIFF
--- a/frontend/src/ts/commandline/lists.ts
+++ b/frontend/src/ts/commandline/lists.ts
@@ -108,6 +108,7 @@ import * as FPSCounter from "../elements/fps-counter";
 import { migrateConfig } from "../utils/config";
 import { PartialConfigSchema } from "@monkeytype/contracts/schemas/configs";
 import { Command, CommandsSubgroup } from "./types";
+import { parseWithSchema as parseJsonWithSchema } from "@monkeytype/util/json";
 
 const layoutsPromise = JSONData.getLayoutsList();
 layoutsPromise
@@ -362,8 +363,9 @@ export const commands: CommandsSubgroup = {
       exec: async ({ input }): Promise<void> => {
         if (input === undefined || input === "") return;
         try {
-          const parsedConfig = PartialConfigSchema.strip().parse(
-            JSON.parse(input)
+          const parsedConfig = parseJsonWithSchema(
+            input,
+            PartialConfigSchema.strip()
           );
           await UpdateConfig.apply(migrateConfig(parsedConfig));
           UpdateConfig.saveFullConfigToLocalStorage();

--- a/frontend/src/ts/controllers/analytics-controller.ts
+++ b/frontend/src/ts/controllers/analytics-controller.ts
@@ -6,6 +6,8 @@ import {
 } from "firebase/analytics";
 import { app as firebaseApp } from "../firebase";
 import { createErrorMessage } from "../utils/misc";
+import { parseWithSchema as parseJsonWithSchema } from "@monkeytype/util/json";
+import { z } from "zod";
 
 let analytics: AnalyticsType;
 
@@ -13,6 +15,11 @@ type AcceptedCookies = {
   security: boolean;
   analytics: boolean;
 };
+
+const acceptedCookiesSchema = z.object({
+  security: z.boolean(),
+  analytics: z.boolean(),
+});
 
 export async function log(
   eventName: string,
@@ -28,7 +35,15 @@ export async function log(
 const lsString = localStorage.getItem("acceptedCookies");
 let acceptedCookies;
 if (lsString !== undefined && lsString !== null && lsString !== "") {
-  acceptedCookies = JSON.parse(lsString) as AcceptedCookies;
+  try {
+    acceptedCookies = parseJsonWithSchema(
+      lsString,
+      acceptedCookiesSchema
+    ) as AcceptedCookies;
+  } catch (e) {
+    console.error("Failed to parse accepted cookies:", e);
+    acceptedCookies = null;
+  }
 } else {
   acceptedCookies = null;
 }

--- a/frontend/src/ts/event-handlers/account.ts
+++ b/frontend/src/ts/event-handlers/account.ts
@@ -5,6 +5,8 @@ import { isAuthenticated } from "../firebase";
 import * as Notifications from "../elements/notifications";
 import * as EditResultTagsModal from "../modals/edit-result-tags";
 import * as AddFilterPresetModal from "../modals/new-filter-preset";
+import { parseWithSchema as parseJsonWithSchema } from "@monkeytype/util/json";
+import { z } from "zod";
 
 const accountPage = document.querySelector("#pageAccount") as HTMLElement;
 
@@ -39,9 +41,11 @@ $(accountPage).on("click", ".editProfileButton", () => {
 $(accountPage).on("click", ".group.history .resultEditTagsButton", (e) => {
   const resultid = $(e.target).attr("data-result-id");
   const tags = $(e.target).attr("data-tags");
+  const tagsArraySchema = z.array(z.string());
+
   EditResultTagsModal.show(
     resultid ?? "",
-    JSON.parse(tags ?? "[]") as string[],
+    parseJsonWithSchema(tags ?? "[]", tagsArraySchema),
     "accountPage"
   );
 });

--- a/frontend/src/ts/modals/import-export-settings.ts
+++ b/frontend/src/ts/modals/import-export-settings.ts
@@ -3,6 +3,7 @@ import * as UpdateConfig from "../config";
 import * as Notifications from "../elements/notifications";
 import AnimatedModal from "../utils/animated-modal";
 import { migrateConfig } from "../utils/config";
+import { parseWithSchema as parseJsonWithSchema } from "@monkeytype/util/json";
 
 type State = {
   mode: "import" | "export";
@@ -47,8 +48,9 @@ const modal = new AnimatedModal({
         return;
       }
       try {
-        const parsedConfig = PartialConfigSchema.strip().parse(
-          JSON.parse(state.value)
+        const parsedConfig = parseJsonWithSchema(
+          state.value,
+          PartialConfigSchema.strip()
         );
         await UpdateConfig.apply(migrateConfig(parsedConfig));
       } catch (e) {

--- a/frontend/src/ts/test/custom-text.ts
+++ b/frontend/src/ts/test/custom-text.ts
@@ -66,6 +66,13 @@ const customTextSettings = new LocalStorageWithSchema({
   },
 });
 
+export const customTextDataSchema = z.object({
+  text: z.array(z.string()),
+  mode: CustomTextModeSchema,
+  limit: z.object({ value: z.number(), mode: CustomTextLimitModeSchema }),
+  pipeDelimiter: z.boolean(),
+});
+
 export function getText(): string[] {
   return customTextSettings.get().text;
 }

--- a/frontend/src/ts/utils/local-storage-with-schema.ts
+++ b/frontend/src/ts/utils/local-storage-with-schema.ts
@@ -1,5 +1,6 @@
 import { ZodError, ZodIssue } from "zod";
 import { deepClone } from "./misc";
+import { parseWithSchema as parseJsonWithSchema } from "@monkeytype/util/json";
 
 export class LocalStorageWithSchema<T> {
   private key: string;
@@ -28,7 +29,7 @@ export class LocalStorageWithSchema<T> {
 
     let jsonParsed: unknown;
     try {
-      jsonParsed = JSON.parse(value);
+      jsonParsed = parseJsonWithSchema(value, this.schema);
     } catch (e) {
       console.log(
         `Value from localStorage ${this.key} was not a valid JSON, using fallback`,

--- a/frontend/src/ts/utils/url-handler.ts
+++ b/frontend/src/ts/utils/url-handler.ts
@@ -11,7 +11,13 @@ import * as Loader from "../elements/loader";
 import * as AccountButton from "../elements/account-button";
 import { restart as restartTest } from "../test/test-logic";
 import * as ChallengeController from "../controllers/challenge-controller";
-import { Mode, Mode2 } from "@monkeytype/contracts/schemas/shared";
+import {
+  DifficultySchema,
+  Mode,
+  Mode2,
+  Mode2Schema,
+  ModeSchema,
+} from "@monkeytype/contracts/schemas/shared";
 import {
   CustomBackgroundFilter,
   CustomBackgroundFilterSchema,
@@ -144,9 +150,31 @@ export function loadTestSettingsFromUrl(getOverride?: string): void {
   const getValue = Misc.findGetParameter("testSettings", getOverride);
   if (getValue === null) return;
 
-  const de = JSON.parse(
-    decompressFromURI(getValue) ?? ""
-  ) as SharedTestSettings;
+  const testSettingsSchema = z.tuple([
+    z.union([ModeSchema, z.null()]), // Mode | null
+    z.union([Mode2Schema, z.null()]), // Mode2<Mode> | null
+    z.union([CustomText.customTextDataSchema, z.null()]), // CustomTextData | null
+    z.union([z.boolean(), z.null()]), // boolean | null
+    z.union([z.boolean(), z.null()]), // boolean | null
+    z.union([z.string(), z.null()]), // string | null
+    z.union([DifficultySchema, z.null()]), // Difficulty | null
+    z.union([z.string(), z.null()]), // string | null
+  ]);
+
+  let de: SharedTestSettings;
+  try {
+    const decompressed = decompressFromURI(getValue) ?? "";
+    de = testSettingsSchema.parse(
+      JSON.parse(decompressed)
+    ) as SharedTestSettings;
+  } catch (e) {
+    console.error("Failed to parse test settings:", e);
+    Notifications.add(
+      "Failed to load test settings from URL: " + (e as Error).message,
+      0
+    );
+    return;
+  }
 
   const applied: Record<string, string> = {};
 


### PR DESCRIPTION
# refactor(parsing): Replace JSON.parse with parseJsonWithSchema (@dev-mohit06)

### Description
Replaces `JSON.parse` calls with `parseJsonWithSchema` to improve type safety and error handling across multiple frontend TypeScript files. This change enhances JSON parsing by adding schema validation and consistent error handling.

### Checks
- [ ] Adding quotes? (N/A)
- [ ] Adding a language or a theme? (N/A)
- [x] Check if any open issues are related to this PR
- [x] PR title follows Conventional Commits standard
- [x] Included GitHub username in PR title

### Changes
- Updated JSON parsing in files:
  - `frontend/src/ts/event-handlers/account.ts`
  - `frontend/src/ts/modals/import-export-settings.ts`
  - `frontend/src/ts/controllers/analytics-controller.ts`
  - `frontend/src/ts/utils/local-storage-with-schema.ts`
  - `frontend/src/ts/utils/url-handler.ts`
  - `frontend/src/ts/commandline/lists.ts`
  - `frontend/src/ts/test/wikipedia.ts`

- Added new schema in `frontend/src/ts/test/custom-text.ts`:
 ```typescript
 export const customTextDataSchema = z.object({
   text: z.array(z.string()),
   mode: CustomTextModeSchema,
   limit: z.object({ value: z.number(), mode: CustomTextLimitModeSchema }),
   pipeDelimiter: z.boolean(),
 });
```

### Motivation
- Improve runtime type safety
- Provide more robust error handling
- Create consistent JSON parsing approach across application