### PR TITLE
style(dark note theme): fix roundness variable affecting account menu (@WarningImHack3r)

### DIFF
--- a/frontend/static/themes/dark_note.css
+++ b/frontend/static/themes/dark_note.css
@@ -20,7 +20,7 @@
   --current-color: var(--main-color);
 }
 
-.button,
+.button:not(.accountButtonAndMenu *),
 #testConfig .row {
   --roundness: 5em; /* overwriting default roundness to make it softer */
 }


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->

Fix the `--roundness` CSS variable override in the Dark Note theme, which incorrectly targets the account menu's first child.

Current look on hover:
<img src="https://github.com/user-attachments/assets/9108db43-f812-402b-8b3c-71155fa34203" alt="Current menu" width="300" />

The fix adds precision to the selector to avoid targetting `.button`s that are children of `.accountButtonAndMenu`, fixing that very issue.
There might be other places this variable incorrectly impacts, but I don't know the codebase so any insight is welcome. If there's none but still a better/different selector to use, let me know too!

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [ ] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [ ] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
