### PR TITLE
feat(layout): colemak_wide keyboard layout (@papersacculos)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -32,6 +32,17 @@
       "row5": [" "]
     }
   },
+  "colemak_wide": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "=+", "7&", "8*", "9(", "0)", "-_"],
+      "row2": ["qQ", "wW", "fF", "pP", "gG", "[{", "jJ", "lL", "uU", "yY", ";:", "'\"", "\\|"],
+      "row3": ["aA", "rR", "sS", "tT", "dD", "]}", "hH", "nN", "eE", "iI", "oO"],
+      "row4": ["zZ", "xX", "cC", "vV", "bB", "/?", "kK", "mM", ",<", ".>"],
+      "row5": [" "]
+    }
+  },
   "colemak_dh": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
It seems to be a pretty popular mod for colemak without additional mods, which is easy to switch to from vanilla colemak, but for some reason nobody added it ;/

https://colemakmods.github.io/ergonomic-mods/wide.html