### PR TITLE
feat(layout): add galite keyboard layout (@almk-dev)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1573,6 +1573,17 @@
       "row5": [" "]
     }
   },
+  "galite": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+"],
+      "row2": ["bB", "lL", "dD", "wW", "zZ", "jJ", "fF", "oO", "uU", ";:", "[{", "]}", "\\|"],
+      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", "'\""],
+      "row4": ["xX", "qQ", "mM", "cC", "vV", "kK", "pP", ",<", ".>", "/?"],
+      "row5": [" "]
+    }
+  },
   "gallium": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description
Adding `galite`, a hybrid tweak of GalliumV2, Graphite, and Colemak-DH, with more standard punctuation keys.
The [final version](https://www.reddit.com/r/KeyboardLayouts/comments/1iqo9ob/galite_galliumgraphite_hybrid_with_simplified/) is based on discussion and feedback from a [thread](https://www.reddit.com/r/KeyboardLayouts/comments/1ipdk2t/what_are_the_communitys_thoughts_on_a_gallium_row/) on the AKL community subreddit. 

Repo with details, notes, and stats:  [almk-dev/galite](https://github.com/almk-dev/galite)

![413474537-68b97426-dcc2-4d06-be35-5c23bcc959b0](https://github.com/user-attachments/assets/3d5312bc-3303-4d18-a98a-6f544530f2de)

