### PR TITLE
fix: past leaderboard not fetching the users rank (@fehmer)

### DIFF
--- a/backend/src/api/controllers/leaderboard.ts
+++ b/backend/src/api/controllers/leaderboard.ts
@@ -15,9 +15,9 @@ import {
   GetLeaderboardRankResponse,
   GetLeaderboardResponse as GetLeaderboardResponse,
   GetWeeklyXpLeaderboardQuery,
+  GetWeeklyXpLeaderboardRankQuery,
   GetWeeklyXpLeaderboardRankResponse,
   GetWeeklyXpLeaderboardResponse,
-  WeeklyXpLeaderboardQuery,
 } from "@monkeytype/contracts/leaderboards";
 import { Configuration } from "@monkeytype/contracts/schemas/configuration";
 import {
@@ -189,7 +189,7 @@ export async function getWeeklyXpLeaderboardResults(
 }
 
 export async function getWeeklyXpLeaderboardRank(
-  req: MonkeyRequest<WeeklyXpLeaderboardQuery>
+  req: MonkeyRequest<GetWeeklyXpLeaderboardRankQuery>
 ): Promise<GetWeeklyXpLeaderboardRankResponse> {
   const { uid } = req.ctx.decodedToken;
 

--- a/backend/src/api/controllers/leaderboard.ts
+++ b/backend/src/api/controllers/leaderboard.ts
@@ -5,6 +5,7 @@ import MonkeyError from "../../utils/error";
 import * as DailyLeaderboards from "../../utils/daily-leaderboards";
 import * as WeeklyXpLeaderboard from "../../services/weekly-xp-leaderboard";
 import {
+  DailyLeaderboardQuery,
   GetDailyLeaderboardQuery,
   GetDailyLeaderboardRankQuery,
   GetDailyLeaderboardResponse,
@@ -16,6 +17,7 @@ import {
   GetWeeklyXpLeaderboardQuery,
   GetWeeklyXpLeaderboardRankResponse,
   GetWeeklyXpLeaderboardResponse,
+  WeeklyXpLeaderboardQuery,
 } from "@monkeytype/contracts/leaderboards";
 import { Configuration } from "@monkeytype/contracts/schemas/configuration";
 import {
@@ -73,7 +75,7 @@ export async function getRankFromLeaderboard(
 }
 
 function getDailyLeaderboardWithError(
-  { language, mode, mode2, daysBefore }: GetDailyLeaderboardRankQuery,
+  { language, mode, mode2, daysBefore }: DailyLeaderboardQuery,
   config: Configuration["dailyLeaderboards"]
 ): DailyLeaderboards.DailyLeaderboard {
   const customTimestamp =
@@ -187,12 +189,13 @@ export async function getWeeklyXpLeaderboardResults(
 }
 
 export async function getWeeklyXpLeaderboardRank(
-  req: MonkeyRequest
+  req: MonkeyRequest<WeeklyXpLeaderboardQuery>
 ): Promise<GetWeeklyXpLeaderboardRankResponse> {
   const { uid } = req.ctx.decodedToken;
 
   const weeklyXpLeaderboard = getWeeklyXpLeaderboardWithError(
-    req.ctx.configuration.leaderboards.weeklyXp
+    req.ctx.configuration.leaderboards.weeklyXp,
+    req.query.weeksBefore
   );
   const rankEntry = await weeklyXpLeaderboard.getRank(
     uid,

--- a/frontend/src/ts/pages/leaderboards.ts
+++ b/frontend/src/ts/pages/leaderboards.ts
@@ -658,8 +658,14 @@ function fillUser(): void {
   }
 
   if (isAuthenticated() && state.type === "daily" && state.userData === null) {
+    let str = `Not qualified`;
+
+    if (!state.yesterday) {
+      str += ` (min speed required: ${state.minWpm} wpm)`;
+    }
+
     $(".page.pageLeaderboards .bigUser").html(
-      `<div class="warning">Not qualified (min speed required: ${state.minWpm} wpm)</div>`
+      `<div class="warning">${str}</div>`
     );
     return;
   }
@@ -835,7 +841,7 @@ function fillUser(): void {
           <div class="sub">${formatted.time}</div>
         </div>
         <div class="stat wide">
-          <div class="title">date</div>
+          <div class="title">last activity</div>
           <div class="value">${format(
             userData.lastActivityTimestamp,
             "dd MMM yyyy HH:mm"

--- a/frontend/src/ts/pages/leaderboards.ts
+++ b/frontend/src/ts/pages/leaderboards.ts
@@ -246,6 +246,7 @@ async function requestData(update = false): Promise<void> {
         requests.rank = Ape.leaderboards.getDailyRank({
           query: {
             ...baseQuery,
+            daysBefore: state.yesterday ? 1 : undefined,
           },
         });
       }
@@ -324,7 +325,11 @@ async function requestData(update = false): Promise<void> {
     });
 
     if (isAuthenticated() && state.userData === null) {
-      requests.rank = Ape.leaderboards.getWeeklyXpRank();
+      requests.rank = Ape.leaderboards.getWeeklyXpRank({
+        query: {
+          weeksBefore: state.lastWeek ? 1 : undefined,
+        },
+      });
     }
 
     const [dataResponse, rankResponse] = await Promise.all([
@@ -667,15 +672,6 @@ function fillUser(): void {
   }
 
   if (state.data === null) {
-    return;
-  }
-
-  if (
-    (state.type === "weekly" && state.lastWeek) ||
-    (state.type === "daily" && state.yesterday)
-  ) {
-    $(".page.pageLeaderboards .bigUser").addClass("hidden");
-    $(".page.pageLeaderboards .tableAndUser > .divider").removeClass("hidden");
     return;
   }
 

--- a/packages/contracts/src/leaderboards.ts
+++ b/packages/contracts/src/leaderboards.ts
@@ -62,11 +62,14 @@ export type GetLeaderboardRankResponse = z.infer<
 
 //--------------------------------------------------------------------------
 
-export const GetDailyLeaderboardQuerySchema = LanguageAndModeQuerySchema.merge(
-  PaginationQuerySchema
-).extend({
+export const DailyLeaderboardQuerySchema = LanguageAndModeQuerySchema.extend({
   daysBefore: z.literal(1).optional(),
 });
+export type DailyLeaderboardQuery = z.infer<typeof DailyLeaderboardQuerySchema>;
+
+export const GetDailyLeaderboardQuerySchema = DailyLeaderboardQuerySchema.merge(
+  PaginationQuerySchema
+);
 export type GetDailyLeaderboardQuery = z.infer<
   typeof GetDailyLeaderboardQuerySchema
 >;
@@ -82,10 +85,8 @@ export type GetDailyLeaderboardResponse = z.infer<
 
 //--------------------------------------------------------------------------
 
-export const GetDailyLeaderboardRankQuerySchema =
-  LanguageAndModeQuerySchema.merge(PaginationQuerySchema).extend({
-    daysBefore: z.literal(1).optional(),
-  });
+export const GetDailyLeaderboardRankQuerySchema = DailyLeaderboardQuerySchema;
+
 export type GetDailyLeaderboardRankQuery = z.infer<
   typeof GetDailyLeaderboardRankQuerySchema
 >;
@@ -98,9 +99,16 @@ export type GetLeaderboardDailyRankResponse = z.infer<
 
 //--------------------------------------------------------------------------
 
-export const GetWeeklyXpLeaderboardQuerySchema = PaginationQuerySchema.extend({
+export const WeeklyXpLeaderboardQuerySchema = z.object({
   weeksBefore: z.literal(1).optional(),
 });
+export type WeeklyXpLeaderboardQuery = z.infer<
+  typeof WeeklyXpLeaderboardQuerySchema
+>;
+
+export const GetWeeklyXpLeaderboardQuerySchema =
+  WeeklyXpLeaderboardQuerySchema.merge(PaginationQuerySchema);
+
 export type GetWeeklyXpLeaderboardQuery = z.infer<
   typeof GetWeeklyXpLeaderboardQuerySchema
 >;
@@ -114,6 +122,12 @@ export type GetWeeklyXpLeaderboardResponse = z.infer<
 >;
 
 //--------------------------------------------------------------------------
+
+export const GetWeeklyXpLeaderboardRankQuerySchema =
+  WeeklyXpLeaderboardQuerySchema;
+export type GetWeeklyXpLeaderboardRankQuery = z.infer<
+  typeof GetWeeklyXpLeaderboardRankQuerySchema
+>;
 
 export const GetWeeklyXpLeaderboardRankResponseSchema =
   responseWithNullableData(XpLeaderboardEntrySchema);
@@ -210,6 +224,7 @@ export const leaderboardsContract = c.router(
         "Get the rank of the current user on the weekly xp leaderboard",
       method: "GET",
       path: "/xp/weekly/rank",
+      query: GetWeeklyXpLeaderboardRankQuerySchema.strict(),
       responses: {
         200: GetWeeklyXpLeaderboardRankResponseSchema,
       },

--- a/packages/contracts/src/leaderboards.ts
+++ b/packages/contracts/src/leaderboards.ts
@@ -99,12 +99,9 @@ export type GetLeaderboardDailyRankResponse = z.infer<
 
 //--------------------------------------------------------------------------
 
-export const WeeklyXpLeaderboardQuerySchema = z.object({
+const WeeklyXpLeaderboardQuerySchema = z.object({
   weeksBefore: z.literal(1).optional(),
 });
-export type WeeklyXpLeaderboardQuery = z.infer<
-  typeof WeeklyXpLeaderboardQuerySchema
->;
 
 export const GetWeeklyXpLeaderboardQuerySchema =
   WeeklyXpLeaderboardQuerySchema.merge(PaginationQuerySchema);


### PR DESCRIPTION
Show the users ranking for the last day on the daily and for the last week on the weekly leaderboard correctly.

- Fix request query schema for the [daily rank](https://api.monkeytype.com/docs/internal#tag/leaderboards/operation/leaderboards.getDailyRank) having pagination
- Fix request query schema for the [weekly rank](https://api.monkeytype.com/docs/internal#tag/leaderboards/operation/leaderboards.getWeeklyXpRank) missing the `weeksBefore` parameter
- Fix frontend to include the `daysBefore` or `weeksBefore` parameter on `rank` calls