### PR TITLE
fix: remove user from XP leaderboard if opt-out, reset or deleted (@fehmer)

### DIFF
--- a/backend/__tests__/api/controllers/user.spec.ts
+++ b/backend/__tests__/api/controllers/user.spec.ts
@@ -29,6 +29,7 @@ import _ from "lodash";
 import { MonkeyMail, UserStreak } from "@monkeytype/contracts/schemas/users";
 import { isFirebaseError } from "../../../src/utils/error";
 import { LeaderboardEntry } from "@monkeytype/contracts/schemas/leaderboards";
+import * as WeeklyXpLeaderboard from "../../../src/services/weekly-xp-leaderboard";
 
 const mockApp = request(app);
 const configuration = Configuration.getCachedConfiguration();
@@ -600,6 +601,10 @@ describe("user controller test", () => {
       DailyLeaderboards,
       "purgeUserFromDailyLeaderboards"
     );
+    const purgeUserFromXpLeaderboardsMock = vi.spyOn(
+      WeeklyXpLeaderboard,
+      "purgeUserFromXpLeaderboards"
+    );
     const blocklistAddMock = vi.spyOn(BlocklistDal, "add");
 
     beforeEach(() => {
@@ -611,6 +616,7 @@ describe("user controller test", () => {
         deleteAllPresetsMock,
         deleteConfigMock,
         purgeUserFromDailyLeaderboardsMock,
+        purgeUserFromXpLeaderboardsMock,
       ].forEach((it) => it.mockResolvedValue(undefined));
 
       deleteAllResultMock.mockResolvedValue({} as any);
@@ -627,6 +633,7 @@ describe("user controller test", () => {
         deleteAllApeKeysMock,
         deleteAllPresetsMock,
         purgeUserFromDailyLeaderboardsMock,
+        purgeUserFromXpLeaderboardsMock,
       ].forEach((it) => it.mockReset());
     });
 
@@ -661,6 +668,10 @@ describe("user controller test", () => {
         uid,
         (await configuration).dailyLeaderboards
       );
+      expect(purgeUserFromXpLeaderboardsMock).toHaveBeenCalledWith(
+        uid,
+        (await configuration).leaderboards.weeklyXp
+      );
     });
     it("should delete user without adding to blocklist if not banned", async () => {
       //GIVEN
@@ -692,6 +703,10 @@ describe("user controller test", () => {
         uid,
         (await configuration).dailyLeaderboards
       );
+      expect(purgeUserFromXpLeaderboardsMock).toHaveBeenCalledWith(
+        uid,
+        (await configuration).leaderboards.weeklyXp
+      );
     });
   });
   describe("resetUser", () => {
@@ -704,6 +719,10 @@ describe("user controller test", () => {
     const purgeUserFromDailyLeaderboardsMock = vi.spyOn(
       DailyLeaderboards,
       "purgeUserFromDailyLeaderboards"
+    );
+    const purgeUserFromXpLeaderboardsMock = vi.spyOn(
+      WeeklyXpLeaderboard,
+      "purgeUserFromXpLeaderboards"
     );
 
     const unlinkDiscordMock = vi.spyOn(GeorgeQueue, "unlinkDiscord");
@@ -723,6 +742,7 @@ describe("user controller test", () => {
         deleteAllResultsMock,
         deleteConfigMock,
         purgeUserFromDailyLeaderboardsMock,
+        purgeUserFromXpLeaderboardsMock,
         unlinkDiscordMock,
         addImportantLogMock,
       ].forEach((it) => it.mockReset());
@@ -753,6 +773,10 @@ describe("user controller test", () => {
       expect(purgeUserFromDailyLeaderboardsMock).toHaveBeenCalledWith(
         uid,
         (await Configuration.getLiveConfiguration()).dailyLeaderboards
+      );
+      expect(purgeUserFromXpLeaderboardsMock).toHaveBeenCalledWith(
+        uid,
+        (await configuration).leaderboards.weeklyXp
       );
       expect(unlinkDiscordMock).not.toHaveBeenCalled();
       expect(addImportantLogMock).toHaveBeenCalledWith(

--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -21,6 +21,7 @@ import { deleteConfig } from "../../dal/config";
 import { verify } from "../../utils/captcha";
 import * as LeaderboardsDAL from "../../dal/leaderboards";
 import { purgeUserFromDailyLeaderboards } from "../../utils/daily-leaderboards";
+import { purgeUserFromXpLeaderboards } from "../../services/weekly-xp-leaderboard";
 import { v4 as uuidv4 } from "uuid";
 import { ObjectId } from "mongodb";
 import * as ReportDAL from "../../dal/report";
@@ -273,6 +274,10 @@ export async function deleteUser(req: MonkeyRequest): Promise<MonkeyResponse> {
       uid,
       req.ctx.configuration.dailyLeaderboards
     ),
+    purgeUserFromXpLeaderboards(
+      uid,
+      req.ctx.configuration.leaderboards.weeklyXp
+    ),
   ]);
 
   //delete user from
@@ -309,6 +314,10 @@ export async function resetUser(req: MonkeyRequest): Promise<MonkeyResponse> {
     purgeUserFromDailyLeaderboards(
       uid,
       req.ctx.configuration.dailyLeaderboards
+    ),
+    purgeUserFromXpLeaderboards(
+      uid,
+      req.ctx.configuration.leaderboards.weeklyXp
     ),
   ];
 
@@ -382,6 +391,10 @@ export async function optOutOfLeaderboards(
   await purgeUserFromDailyLeaderboards(
     uid,
     req.ctx.configuration.dailyLeaderboards
+  );
+  await purgeUserFromXpLeaderboards(
+    uid,
+    req.ctx.configuration.leaderboards.weeklyXp
   );
   void addImportantLog("user_opted_out_of_leaderboards", "", uid);
 

--- a/backend/src/services/weekly-xp-leaderboard.ts
+++ b/backend/src/services/weekly-xp-leaderboard.ts
@@ -252,3 +252,21 @@ export function get(
 
   return new WeeklyXpLeaderboard(customTimestamp);
 }
+
+export async function purgeUserFromXpLeaderboards(
+  uid: string,
+  weeklyXpLeaderboardConfig: Configuration["leaderboards"]["weeklyXp"]
+): Promise<void> {
+  const connection = RedisClient.getConnection();
+  if (!connection || !weeklyXpLeaderboardConfig.enabled) {
+    return;
+  }
+
+  // @ts-expect-error we are doing some weird file to function mapping, thats why its any
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  await connection.purgeResults(
+    0,
+    uid,
+    weeklyXpLeaderboardLeaderboardNamespace
+  );
+}


### PR DESCRIPTION
Ensure user is removed from the weekly XP leaderboards if they either `opt-out`, `reset` their account or `delete` their account.