### PR TITLE
fix: remove deprecated galite layout (@almk-dev)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -1573,17 +1573,6 @@
       "row5": [" "]
     }
   },
-  "galite": {
-    "keymapShowTopRow": false,
-    "type": "ansi",
-    "keys": {
-      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+"],
-      "row2": ["bB", "lL", "dD", "wW", "zZ", "jJ", "fF", "oO", "uU", ";:", "[{", "]}", "\\|"],
-      "row3": ["nN", "rR", "tT", "sS", "gG", "yY", "hH", "aA", "eE", "iI", "'\""],
-      "row4": ["xX", "qQ", "mM", "cC", "vV", "kK", "pP", ",<", ".>", "/?"],
-      "row5": [" "]
-    }
-  },
   "gallium": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description
After feedback from the AKL community, I have reverted many of the changes made in Galite to the point where it is not meaningfully different from Gallium. As such, Galite is deprecated and no longer supported/recommended. Apologies for the inconvenience.