### PR TITLE
fix: rounding issues causing daily leaderboard to be out of order sometimes (@fehmer)

### DIFF
--- a/backend/__tests__/utils/misc.spec.ts
+++ b/backend/__tests__/utils/misc.spec.ts
@@ -62,6 +62,12 @@ describe("Misc Utils", () => {
         timestamp: 1653591901000,
         expectedScore: 1196200960717699,
       },
+      {
+        wpm: 196.205,
+        acc: 96.075,
+        timestamp: 1653591901000,
+        expectedScore: 1196210960817699,
+      },
     ];
 
     _.each(testCases, ({ wpm, acc, timestamp, expectedScore }) => {

--- a/backend/__tests__/utils/misc.spec.ts
+++ b/backend/__tests__/utils/misc.spec.ts
@@ -68,6 +68,14 @@ describe("Misc Utils", () => {
         timestamp: 1653591901000,
         expectedScore: 1196210960817699,
       },
+      {
+        // this one is particularly important - in JS 154.39 * 100 is equal to 15438.999999999998
+        // thanks floating point errors!
+        wpm: 154.39,
+        acc: 96.14,
+        timestamp: 1740333827000,
+        expectedScore: 1154390961421373,
+      },
     ];
 
     _.each(testCases, ({ wpm, acc, timestamp, expectedScore }) => {

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -67,8 +67,8 @@ export function matchesAPattern(text: string, pattern: string): boolean {
 }
 
 export function kogascore(wpm: number, acc: number, timestamp: number): number {
-  const normalizedWpm = Math.floor(wpm * 100);
-  const normalizedAcc = Math.floor(acc * 100);
+  const normalizedWpm = Math.round(wpm * 100);
+  const normalizedAcc = Math.round(acc * 100);
 
   const padAmount = 100000;
   const firstPart = (padAmount + normalizedWpm) * padAmount;

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -67,6 +67,8 @@ export function matchesAPattern(text: string, pattern: string): boolean {
 }
 
 export function kogascore(wpm: number, acc: number, timestamp: number): number {
+  // its safe to round after multiplying by 100 (99.99 * 100 rounded will be 9999 not 100)
+  // rounding is necessary to protect against floating point errors
   const normalizedWpm = Math.round(wpm * 100);
   const normalizedAcc = Math.round(acc * 100);
 


### PR DESCRIPTION
Backend was using `Math.floor` on wpm and accuracy while frontend is using `Math.round`. `

Frontend:
[leaderboard.ts:buildTableRow](https://github.com/monkeytypegame/monkeytype/blob/master/frontend/src/ts/pages/leaderboards.ts#L481) -> [format.ts:typingSpeed](https://github.com/monkeytypegame/monkeytype/blob/master/frontend/src/ts/utils/format.ts#L26)

Backend: 
[daily-leaderboard.ts:addResult](https://github.com/monkeytypegame/monkeytype/blob/master/backend/src/utils/daily-leaderboards.ts#L73) -> [misc.ts:kogascore](https://github.com/monkeytypegame/monkeytype/blob/master/backend/src/utils/misc.ts#L69) which is then used in redis for the sorted set.

This was leading to wrong sorting in the daily leaderboard : 
![image](https://github.com/user-attachments/assets/d4e7a4ed-6684-4acb-adca-fe1afd283a16)

