### PR TITLE
fix: correct logo rotation issue in Chaos Theory theme (@byseif21)

### DIFF
--- a/frontend/static/themes/chaos_theory.css
+++ b/frontend/static/themes/chaos_theory.css
@@ -13,7 +13,7 @@
 }
 
 header #logo .text {
-  transform: rotateY(180deg);
+  transform: rotateY(360deg);
   unicode-bidi: bidi-override;
   transition: 0.5s;
 }
@@ -23,7 +23,7 @@ header #logo .top {
 }
 
 header #logo .icon {
-  transform: rotateX(180deg);
+  transform: rotateX(360deg);
   transition: 0.5s;
 }
 


### PR DESCRIPTION
### Description

<!-- Please describe the change(s) made in your PR -->

fix: correct logo rotation issue in Chaos Theory theme,

I’m not sure if this was intentional or not, but it really stood out and felt off while using the theme. Since *Chaos Theory* is my favorite theme, it was quite annoying to see the logo flipped, so I decided to fix it. If this was a design choice, feel free to disregard.

### Checks

- [ ] Adding quotes?  
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.  
- [ ] Adding a language or a theme?  
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?  
  - [ ] If is a theme, did you add the theme.css?  
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!  
- [ ] Check if any open issues are related to this PR; if so, be sure to tag them below.  
- [ ] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)  
- [ ] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.  

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you. -->

Closes #  

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->  
<!-- please also reference any issues and or PRs related to your pull request -->  
<!-- Also remove it if you are not following any issues. -->  

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->  

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->  
