### PR TITLE
build: fix openapi spec path for docs & stats endpoints on dev (@NadAlaba)

### DIFF
--- a/backend/__tests__/tsconfig.json
+++ b/backend/__tests__/tsconfig.json
@@ -4,9 +4,6 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "ts-node": {
-    "files": true
-  },
   "files": ["vitest.d.ts"],
   "include": ["./**/*.ts", "./**/*.spec.ts", "./setup-tests.ts"]
 }

--- a/backend/scripts/tsconfig.json
+++ b/backend/scripts/tsconfig.json
@@ -3,9 +3,5 @@
   "compilerOptions": {
     "target": "ES6"
   },
-  "ts-node": {
-    "files": true
-  },
-  "files": ["../src/types/types.d.ts"],
   "include": ["./**/*"]
 }

--- a/backend/src/api/routes/docs.ts
+++ b/backend/src/api/routes/docs.ts
@@ -2,7 +2,7 @@ import { Response, Router } from "express";
 
 const router = Router();
 
-const root = __dirname + "../../../static";
+const root = __dirname + "/../../../dist/static";
 
 router.use("/internal", (req, res) => {
   setCsp(res);

--- a/backend/src/api/routes/swagger.ts
+++ b/backend/src/api/routes/swagger.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "fs";
 import Logger from "../../utils/logger";
 
 function addSwaggerMiddlewares(app: Application): void {
-  const openApiSpec = __dirname + "/../../static/api/openapi.json";
+  const openApiSpec = __dirname + "/../../../dist/static/api/openapi.json";
   let spec = {};
   try {
     spec = JSON.parse(readFileSync(openApiSpec, "utf8")) as string;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,9 +8,6 @@
     "useUnknownInCatchVariables": false,
     "strictPropertyInitialization": false
   },
-  "ts-node": {
-    "files": true
-  },
   "include": ["src"],
   "exclude": [
     "node_modules",

--- a/frontend/__tests__/tsconfig.json
+++ b/frontend/__tests__/tsconfig.json
@@ -6,9 +6,6 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "ts-node": {
-    "files": true
-  },
   "files": ["vitest.d.ts"],
   "include": ["./**/*.spec.ts", "./setup-tests.ts"]
 }

--- a/packages/contracts/__test__/tsconfig.json
+++ b/packages/contracts/__test__/tsconfig.json
@@ -4,9 +4,5 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "ts-node": {
-    "files": true
-  },
-  "files": ["../src/types/types.d.ts"],
   "include": ["./**/*.ts", "./**/*.spec.ts", "./setup-tests.ts"]
 }

--- a/packages/funbox/__test__/tsconfig.json
+++ b/packages/funbox/__test__/tsconfig.json
@@ -4,9 +4,5 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "ts-node": {
-    "files": true
-  },
-  // "files": ["../src/types/types.d.ts"],
   "include": ["./**/*.ts", "./**/*.spec.ts", "./setup-tests.ts"]
 }

--- a/packages/funbox/package.json
+++ b/packages/funbox/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "tsup-node --watch",
     "build": "npm run madge && tsup-node",
+    "test": "vitest run",
     "madge": " madge --circular --extensions ts ./src",
     "ts-check": "tsc --noEmit",
     "lint": "eslint \"./**/*.ts\""

--- a/packages/util/__test__/tsconfig.json
+++ b/packages/util/__test__/tsconfig.json
@@ -4,9 +4,5 @@
     "noEmit": true,
     "types": ["vitest/globals"]
   },
-  "ts-node": {
-    "files": true
-  },
-  // "files": ["../src/types/types.d.ts"],
   "include": ["./**/*.ts", "./**/*.spec.ts", "./setup-tests.ts"]
 }


### PR DESCRIPTION
### Description

1. fix openapi specification path so that /docs endpoint would work on dev.

> Error: ENOENT: no such file or directory, stat 'backend/src/static/api/public.html' Stack: Error: ENOENT: no such file or directory

2. fix openapi specification path so that API Operation would work on /stats endpoint on dev.

> Cannot read openApi specification from backend/src/api/routes/../../static/api/openapi.json. Swagger stats will not fully work.
![stats](https://github.com/user-attachments/assets/82f3e8b4-814c-4ede-ba67-8da53dacad87)

3. remove unneeded `files` & `ts-node` options from `tsconfig.json` in various places.

> File 'backend/src/types/types.d.ts' not found.
  The file is in the program because:
    Part of 'files' list in tsconfig.json

4. add the missing `pnpm test` script to the funbox package.
