### PR TITLE
chore(workflows): update deprecated action and remove duplicate workflow message (@NadAlaba)

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Read the pr_num file
         id: pr_num_reader
-        uses: juliangruber/read-file-action@v1.0.0
+        uses: juliangruber/read-file-action@v1
         with:
           path: ./pr_num/pr_num.txt
 
@@ -31,3 +31,10 @@ jobs:
           issue-number: ${{ steps.pr_num_reader.outputs.content }}
           body: |
             Continuous integration check(s) failed. Please review the [failing check\'s logs](${{ github.event.workflow_run.html_url }}) and make the necessary changes.
+
+      - name: Apply label changes
+        uses: PauMAVA/add-remove-label-action@v1
+        with:
+          issue_number:  ${{ steps.pr_num_reader.outputs.content }}
+          add: "waiting for update"
+          remove: "waiting for review"

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: Download workflow artifact
-        uses: dawidd6/action-download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: peek_icons.yml

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: peek_icons.yml
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Read the pr_num file

--- a/.github/workflows/monkey-ci.yml
+++ b/.github/workflows/monkey-ci.yml
@@ -353,7 +353,7 @@ jobs:
         run: echo $PR_NUM > pr_num.txt
 
       - name: Upload the PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr_num
           path: ./pr_num.txt

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -42,12 +42,7 @@ jobs:
             Title "{title}"
             didn't match the configured pattern. Please ensure that the title
             contains your name so that you can be credited in our changelog.
-            A correct version would look something like: 
-            
-            feat: add new feature (@github-username)
-            impr(quotes): add english quotes (@github-username)
-            fix: resolve bug (@github-username)
-            
+
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
@@ -66,9 +61,9 @@ jobs:
             ```
             A correct version would look something like: 
 
-            feat: add new feature (@github-username)
-            impr(quotes): add english quotes (@github-username)
-            fix: resolve bug (@github-username)
+            feat: add new feature (@github_username)
+            impr(quotes): add english quotes (@username)
+            fix(leaderboard): show user rank correctly (@user1, @user2, @user3)
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}

--- a/.github/workflows/write-labels.yml
+++ b/.github/workflows/write-labels.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Read json file
         id: json_reader
-        uses: juliangruber/read-file-action@v1.1.7
+        uses: juliangruber/read-file-action@v1
         with:
           path: ./labels/write-labels.json
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Apply label changes
         if: env.ADD_LABELS || env.REMOVE_LABELS
-        uses: PauMAVA/add-remove-label-action@v1.0.3
+        uses: PauMAVA/add-remove-label-action@v1
         with:
           issue_number: ${{ fromJSON(steps.json_reader.outputs.content).pr_num }}
           add: ${{ env.ADD_LABELS }}

--- a/packages/release/src/buildChangelog.js
+++ b/packages/release/src/buildChangelog.js
@@ -352,7 +352,7 @@ async function main() {
     log.push({
       hashes: quoteAddCommits.map((item) => item.hashes).flat(),
       type: "impr",
-      scope: "quote",
+      scope: "quotes",
       message: "add quotes in various languages",
       usernames: quoteAddCommits.map((item) => item.usernames).flat(),
       prs: quoteAddCommits.map((item) => item.prs).flat(),
@@ -364,7 +364,7 @@ async function main() {
     log.push({
       hashes: quoteReportCommits.map((item) => item.hashes).flat(),
       type: "fix",
-      scope: "quote",
+      scope: "quotes",
       message: "update or remove quotes reported by users",
       usernames: quoteReportCommits.map((item) => item.usernames).flat(),
       prs: quoteReportCommits.map((item) => item.prs).flat(),


### PR DESCRIPTION
### Description

1. remove duplicate correct examples in semantic-pr-title error message, and make the examples more diverse (show how to credit multiple contributors).
![patternMessage](https://github.com/user-attachments/assets/cb6afe48-ed67-4894-ab4a-76894dd50e3b)

2. make the scope (quotes, languages, ...) consistently plural across the repo docs (A subjective change I know, but in the changelog, the scope looks better when it is plural i.e. **quotes:** add various quotes).
3. update deprecated action `upload-artifact` from v3 to v4, because it was making the `ci-failure-comment` workflow fail.
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
4. use the same official action to download and upload artifacts across the repo's workflows.
5. add 'waiting for update' and remove 'waiting for review' labels when the Monkey CI workflow fails.
6. fix actions' major version only, to allow minor updates and patches.