### PR TITLE
chore(workflows): use specific version of add-remove-label-action (@NadAlaba)

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -32,7 +32,7 @@ jobs:
             Continuous integration check(s) failed. Please review the [failing check\'s logs](${{ github.event.workflow_run.html_url }}) and make the necessary changes.
 
       - name: Apply label changes
-        uses: PauMAVA/add-remove-label-action@v1
+        uses: PauMAVA/add-remove-label-action@v1.0.3
         with:
           issue_number:  ${{ steps.pr_num_reader.outputs.content }}
           add: "waiting for update"

--- a/.github/workflows/write-labels.yml
+++ b/.github/workflows/write-labels.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Apply label changes
         if: env.ADD_LABELS || env.REMOVE_LABELS
-        uses: PauMAVA/add-remove-label-action@v1
+        uses: PauMAVA/add-remove-label-action@v1.0.3
         with:
           issue_number: ${{ fromJSON(steps.json_reader.outputs.content).pr_num }}
           add: ${{ env.ADD_LABELS }}


### PR DESCRIPTION
revert fixing major version only of the `PauMAVA/add-remove-label-action` action from #6344 because this action does not have a `v1` tag