### PR TITLE
chore(workflows): use correct name of action input (@NadAlaba)

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Download workflow artifact
         uses: actions/download-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Read the pr_num file
         id: pr_num_reader


### PR DESCRIPTION
change the name of the input action that should've been changed in #6344 when the action was changed.
Sorry!