### PR TITLE
fix(connection): add jQuery selector for closing offline banner (@AmanWebDev2)

### DIFF
--- a/frontend/src/ts/states/connection.ts
+++ b/frontend/src/ts/states/connection.ts
@@ -38,6 +38,9 @@ const throttledHandleState = debounce(5000, () => {
       $(
         `#bannerCenter .banner[id="${noInternetBannerId}"] .closeButton`
       ).trigger("click");
+      $(
+        `#bannerCenter .psa.notice[id="${noInternetBannerId}"] .closeButton`
+      ).trigger("click");
     }
     bannerAlreadyClosed = false;
   } else if (!TestState.isActive) {

--- a/frontend/src/ts/states/connection.ts
+++ b/frontend/src/ts/states/connection.ts
@@ -31,10 +31,10 @@ export function showOfflineBanner(): void {
 
 const throttledHandleState = debounce(5000, () => {
   if (state) {
+    Notifications.add("You're back online", 1, {
+      customTitle: "Connection",
+    });
     if (noInternetBannerId !== undefined) {
-      Notifications.add("You're back online", 1, {
-        customTitle: "Connection",
-      });
       $(
         `#bannerCenter .banner[id="${noInternetBannerId}"] .closeButton`
       ).trigger("click");


### PR DESCRIPTION
### Description

This PR fixes issue #6389, which addresses the problem where the "No internet connection" banner would not disappear even after the user reconnects to the internet. The fix adds a proper jQuery selector that correctly targets the offline banner element with the appropriate classes (psa.notice), ensuring it gets closed when connection is restored.

Additionally, this PR also fixes an issue where, after going offline, if the user manually cancels the offline banner and then reconnects, the 'You're back online' toast message would not appear. The fix ensures the toast message is correctly triggered when the connection is restored.

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #6389


<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->

RESULT - 


https://github.com/user-attachments/assets/f69dbdc9-1f1b-4b71-9ebb-d2f8e95f28ea

https://github.com/user-attachments/assets/1c3986e3-382c-4055-b635-23c8dc19acdc


