### PR TITLE
feat(language): remove rustlang removed "box" keyword

### DIFF
--- a/frontend/static/languages/code_rust.json
+++ b/frontend/static/languages/code_rust.json
@@ -112,7 +112,6 @@
     "to_lowercase()",
     "to_uppercase()",
     "replace(\"a\", \"b\")",
-    "box",
     "lazy_static",
     "iter()",
     "into_iter()",


### PR DESCRIPTION
### Description

Removes Rust language "box" keyword, as it was removed a long time ago in https://github.com/rust-lang/rust/issues/49733



