### PR TITLE
fix: local development using docker not working with pnpm (@fehmer)

### DIFF
--- a/backend/docker/compose.yml
+++ b/backend/docker/compose.yml
@@ -21,7 +21,11 @@ services:
 
   api-server:
     container_name: monkeytype-api-server
-    image: node:20.16.0
+    build:
+      dockerfile_inline: |
+        FROM node:20.16.0
+        RUN npm i -g pnpm@9.6.0
+        RUN mkdir /pnpm-store && chown -R 1000:1000 /pnpm-store
     user: "node"    ##this works as long as your local user has uid=1000
     restart: on-failure
     depends_on:
@@ -36,7 +40,7 @@ services:
       - ../../:/monkeytype
     entrypoint: 'bash -c "echo starting, this may take a while... \
       && cd /monkeytype \
-      && npm i -g pnpm \
+      && pnpm config set store-dir /pnpm-store
       && pnpm i \
       && npm run dev-be"'
 

--- a/frontend/docker/compose.dev.yml
+++ b/frontend/docker/compose.dev.yml
@@ -2,7 +2,11 @@ name: monkeytype
 services:
   frontend:
     container_name: monkeytype-frontend
-    image: node:20.16.0
+    build:
+      dockerfile_inline: |
+        FROM node:20.16.0
+        RUN npm i -g pnpm@9.6.0
+        RUN mkdir /pnpm-store && chown -R 1000:1000 /pnpm-store
     user: "node"    ##this works as long as your local user has uid=1000
     # restart: on-failure
     environment:
@@ -14,9 +18,7 @@ services:
       - ../../:/monkeytype
     entrypoint: 'bash -c "echo starting, this may take a while... \
       && cd /monkeytype \
-      && npm i -g pnpm \
+      && pnpm config set store-dir /pnpm-store
       && pnpm i \
       && export SERVER_OPEN=false \
       && npm run dev-fe"'
-
-


### PR DESCRIPTION
Global install of pnpm is not working as user  `node`. As a workaround we add `pnpm` during the build phase of the image and run the entrypoint as user  `node`