### PR TITLE
feat(layout): Adds Hands Down Promethium layout (@andre-krueger)

### DIFF
--- a/frontend/static/layouts/_list.json
+++ b/frontend/static/layouts/_list.json
@@ -517,6 +517,17 @@
       "row5": [" "]
   }
   },
+  "handsdown_promethium": {
+    "keymapShowTopRow": false,
+    "type": "ansi",
+    "keys": {
+      "row1": ["`~", "1!", "2@", "3#", "4$", "5%", "6^", "7&", "8*", "9(", "0)", "-_", "=+"],
+      "row2": ["fF", "pP", "dD", "lL", "xX", ";:", "uU", "oO", "yY", "bB", "zZ", "]}", "\\|"],
+      "row3": ["sS", "nN", "tT", "hH", "kK", ",<", "aA", "eE", "iI", "cC", "qQ"],
+      "row4": ["vV", "wW", "gG", "mM", "jJ", "-_", ".>", "'\"", "=+", "/?"],
+      "row5": ["rR", " "]
+    }
+  },
   "typehack": {
     "keymapShowTopRow": false,
     "type": "ansi",


### PR DESCRIPTION
### Description

This PR adds the [Hands Down Promethium layout](https://www.reddit.com/r/KeyboardLayouts/comments/1g66ivi/hands_down_promethium_snth_meets_hd_silverengram/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button).

### Checks

- [ ] Adding quotes?
  - [ ] Make sure to include translations for the quotes in the description (or another comment) so we can verify their content.
- [ ] Adding a language or a theme?
  - [ ] If is a language, did you edit `_list.json`, `_groups.json` and add `languages.json`?
  - [ ] If is a theme, did you add the theme.css?
    - Also please add a screenshot of the theme, it would be extra awesome if you do so!
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->
