### PR TITLE
feat(theme): add kanagawa theme (@ZeLongZhuang)

### DIFF
--- a/frontend/static/themes/_list.json
+++ b/frontend/static/themes/_list.json
@@ -1272,5 +1272,12 @@
     "mainColor": "#41ce5c",
     "subColor": "#788386",
     "textColor": "#ccdae6"
+  },
+  {
+    "name": "kanagawa",
+    "bgColor": "#1f1f28",
+    "mainColor": "#e6c384",
+    "subColor": "#727169",
+    "textColor": "#dcd7ba"
   }
 ]

--- a/frontend/static/themes/kanagawa.css
+++ b/frontend/static/themes/kanagawa.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #1f1f28;
+  --caret-color: #c8c093;
+  --main-color: #e6c384;
+  --sub-color: #727169;
+  --sub-alt-color: #2a2a37;
+  --text-color: #dcd7ba;
+  --error-color: #c34043;
+  --error-extra-color: #e82424;
+  --colorful-error-color: #c34043;
+  --colorful-error-extra-color: #e82424;
+}


### PR DESCRIPTION
Adds `kanagawa` theme. Based on Kanagawa Wave variant from [kanagawa.nvim](https://github.com/rebelot/kanagawa.nvim)

![屏幕截图 2025-04-12 172853](https://github.com/user-attachments/assets/65878dbc-d3b0-4dbb-a49f-a2b992c67b7c)
![屏幕截图 2025-04-12 172953](https://github.com/user-attachments/assets/58d76925-d524-4217-9b51-cdf74022164a)
![屏幕截图 2025-04-12 173046](https://github.com/user-attachments/assets/31cb65c3-81b1-4383-ae45-cf0ab0c445dc)
![屏幕截图 2025-04-12 173145](https://github.com/user-attachments/assets/93848de5-9643-4f33-9a83-8c0e7cc3df45)