### PR TITLE
impr: use rainbow effect on rgb badges for reduced-motion (@fehmer)

### DIFF
--- a/frontend/src/ts/controllers/badge-controller.ts
+++ b/frontend/src/ts/controllers/badge-controller.ts
@@ -16,7 +16,7 @@ const badges: Record<number, UserBadge> = {
     icon: "fa-laptop",
     color: "white",
     customStyle:
-      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg in hsl longer hue, hsl(330, 90%, 30%) 0%, hsl(250, 90%, 30%) 100%);",
   },
   2: {
     id: 2,
@@ -25,7 +25,7 @@ const badges: Record<number, UserBadge> = {
     icon: "fa-code",
     color: "white",
     customStyle:
-      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg in hsl longer hue, hsl(330, 90%, 30%) 0%, hsl(250, 90%, 30%) 100%);",
   },
   3: {
     id: 3,
@@ -34,7 +34,7 @@ const badges: Record<number, UserBadge> = {
     icon: "fa-hammer",
     color: "white",
     customStyle:
-      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg in hsl longer hue, hsl(330, 90%, 30%) 0%, hsl(250, 90%, 30%) 100%);",
   },
   4: {
     id: 4,
@@ -115,7 +115,7 @@ const badges: Record<number, UserBadge> = {
     icon: "fa-rocket",
     color: "white",
     customStyle:
-      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg in hsl longer hue, hsl(330, 90%, 30%) 0%, hsl(250, 90%, 30%) 100%);",
   },
   14: {
     id: 14,

--- a/frontend/src/ts/controllers/badge-controller.ts
+++ b/frontend/src/ts/controllers/badge-controller.ts
@@ -114,7 +114,7 @@ const badges: Record<number, UserBadge> = {
     description: "Yes, I'm actually this fast",
     icon: "fa-rocket",
     color: "white",
-    customStyle: "animation: rgb-bg 10s linear infinite;",
+    customStyle: "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
   },
   14: {
     id: 14,

--- a/frontend/src/ts/controllers/badge-controller.ts
+++ b/frontend/src/ts/controllers/badge-controller.ts
@@ -114,7 +114,8 @@ const badges: Record<number, UserBadge> = {
     description: "Yes, I'm actually this fast",
     icon: "fa-rocket",
     color: "white",
-    customStyle: "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
+    customStyle:
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
   },
   14: {
     id: 14,

--- a/frontend/src/ts/controllers/badge-controller.ts
+++ b/frontend/src/ts/controllers/badge-controller.ts
@@ -15,7 +15,8 @@ const badges: Record<number, UserBadge> = {
     description: "I made this",
     icon: "fa-laptop",
     color: "white",
-    customStyle: "animation: rgb-bg 10s linear infinite;",
+    customStyle:
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
   },
   2: {
     id: 2,
@@ -23,7 +24,8 @@ const badges: Record<number, UserBadge> = {
     description: "I helped make this",
     icon: "fa-code",
     color: "white",
-    customStyle: "animation: rgb-bg 10s linear infinite;",
+    customStyle:
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
   },
   3: {
     id: 3,
@@ -31,7 +33,8 @@ const badges: Record<number, UserBadge> = {
     description: "Discord server moderator",
     icon: "fa-hammer",
     color: "white",
-    customStyle: "animation: rgb-bg 10s linear infinite;",
+    customStyle:
+      "animation: rgb-bg 10s linear infinite; background: linear-gradient(45deg, hsl(120, 39%, 49%) 0%, hsl(192, 48%, 48%) 20%, hsl(264, 90%, 58%) 40%, hsl(357, 89%, 50%) 60%, hsl(46, 100%, 51%) 80%, hsl(120, 39%, 49%) 100%);",
   },
   4: {
     id: 4,


### PR DESCRIPTION
RGB rainbow effect is disabled if user prefers reduced motion. Currently the badge is then only shown in the default color. This PR adds a background with the rgb effect.

Before:
![image](https://github.com/user-attachments/assets/89ddbbe3-4834-42ef-ab7c-b068da1d7f7b)
![image](https://github.com/user-attachments/assets/e15c59a6-95b0-4560-bd1c-fbe381051b83)

After:
![image](https://github.com/user-attachments/assets/e6cadc66-049f-4405-a6a5-ca0c93359145)
![image](https://github.com/user-attachments/assets/39388893-dee4-4dde-87c7-ffd4597471e8)

