### PR TITLE
impr(language): auto-switch keyboard layout on language change (@dayanbattulga)

### DIFF
--- a/frontend/src/ts/commandline/lists/languages.ts
+++ b/frontend/src/ts/commandline/lists/languages.ts
@@ -28,7 +28,7 @@ const commands: Command[] = [
 ];
 
 /**
- * Intelligently maps a language to the most appropriate keyboard layout
+ * Maps a language to the most appropriate keyboard layout
  */
 function findLayoutForLanguage(language: string): string {
   // Strip word count suffix (e.g., "english_1k" -> "english")
@@ -73,7 +73,7 @@ function findLayoutForLanguage(language: string): string {
     return "qwerty";
   }
 
-  // Regional fall-backs based on common orthographic patterns
+  // Regional fall-backs based on common keyboard patterns
   if (
     baseLanguage.includes("cyrillic") ||
     baseLanguage.includes("bulgarian") ||

--- a/frontend/src/ts/commandline/lists/languages.ts
+++ b/frontend/src/ts/commandline/lists/languages.ts
@@ -4,6 +4,8 @@ import {
   getLanguageDisplayString,
 } from "../../utils/strings";
 import { Command, CommandsSubgroup } from "../types";
+import * as TestLogic from "../../test/test-logic";
+import { LayoutsList } from "../../constants/layouts";
 
 const subgroup: CommandsSubgroup = {
   title: "Language...",
@@ -25,6 +27,70 @@ const commands: Command[] = [
   },
 ];
 
+/**
+ * Intelligently maps a language to the most appropriate keyboard layout
+ */
+function findLayoutForLanguage(language: string): string {
+  // Strip word count suffix (e.g., "english_1k" -> "english")
+  const baseLanguage = language.replace(/_\d+k$/i, "");
+
+  // Direct matching - check if there's a layout with the exact language name
+  if (LayoutsList.includes(baseLanguage)) {
+    return baseLanguage;
+  }
+
+  // Check for language-specific layout patterns
+  const layoutMatches = LayoutsList.filter(
+    (layout) => layout.includes(baseLanguage) || baseLanguage.includes(layout)
+  );
+
+  if (layoutMatches.length > 0) {
+    // If we found layouts containing the language name, prefer the most specific one
+    return layoutMatches.sort((a, b) => b.length - a.length)[0] ?? "qwerty";
+  }
+
+  // Special case mappings for common languages
+  const specialMappings: Record<string, string> = {
+    english: "qwerty",
+    french: "azerty",
+    german: "qwertz",
+    spanish: "spanish_qwerty",
+    italian: "italian_qwerty",
+    portuguese: "portuguese_pt_qwerty_iso",
+    russian: "russian",
+    japanese: "japanese_hiragana",
+    korean: "korean",
+    turkish: "turkish_q",
+    arabic: "arabic_101",
+    persian: "persian_standard",
+    hebrew: "hebrew",
+    mongolian: "mongolian",
+    // Add more mappings as needed
+  };
+
+  const specialMapping = specialMappings[baseLanguage];
+  if (specialMapping === null) {
+    return "qwerty";
+  }
+
+  // Regional fall-backs based on common orthographic patterns
+  if (
+    baseLanguage.includes("cyrillic") ||
+    baseLanguage.includes("bulgarian") ||
+    baseLanguage.includes("ukrainian") ||
+    baseLanguage.includes("belarusian")
+  ) {
+    return "russian";
+  }
+
+  if (baseLanguage.includes("latin") || baseLanguage.includes("romance")) {
+    return "qwerty";
+  }
+
+  // Default to qwerty if no match is found
+  return "qwerty";
+}
+
 function update(languages: string[]): void {
   subgroup.list = [];
   languages.forEach((language) => {
@@ -34,6 +100,12 @@ function update(languages: string[]): void {
       configValue: language,
       exec: (): void => {
         UpdateConfig.setLanguage(language);
+        // Find appropriate layout for this language
+        const appropriateLayout = findLayoutForLanguage(language);
+
+        // Update the keymap layout
+        UpdateConfig.setKeymapLayout(appropriateLayout);
+        TestLogic.restart();
       },
     });
   });


### PR DESCRIPTION
### Description

This PR introduces automatic keyboard layout switching when a user changes languages. It improves the multilingual typing experience by providing the correct key layout based on the selected language.

### Implementation Details

- Added `findLayoutForLanguage()` to map languages to appropriate keyboard layouts
- Updated language selection logic to auto-switch keymaps
- Matching strategies include:
  - Direct layout name match
  - Pattern matching for language-specific layouts
  - Special-case mappings (e.g., Russian → JCUKEN)
  - Regional fallback based on orthographic hints

### Benefits

- Automatically assigns correct layout for supported languages
- Reduces setup friction for multilingual users
- Still allows users to manually override if desired

### Checks

- [ ] Adding quotes?  
  - [x] N/A
- [ ] Adding a language or a theme?  
  - [x] N/A
- [x] Check if any open issues are related to this PR  
  - None found at the time of writing
- [x] PR title follows Conventional Commits standard  
- [x] Includes GitHub username in the title

### Screenshots


https://github.com/user-attachments/assets/1c278e01-5ee6-48bd-9168-3e8d24552ceb

