### PR TITLE
Fix: When hiting æ key it prints 2 chars on screen a e

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -471,17 +471,17 @@ function handleChar(
     return;
   }
 
-  if (char === "œ" && TestWords.words.getCurrent()[charIndex] !== "œ") {
-    handleChar("o", charIndex);
-    handleChar("e", charIndex + 1);
-    return;
-  }
+  // if (char === "œ" && TestWords.words.getCurrent()[charIndex] !== "œ") {
+  //  handleChar("o", charIndex);
+  //  handleChar("e", charIndex + 1);
+  //  return;
+  // }
 
-  if (char === "æ" && TestWords.words.getCurrent()[charIndex] !== "æ") {
-    handleChar("a", charIndex);
-    handleChar("e", charIndex + 1);
-    return;
-  }
+  // if (char === "æ" && TestWords.words.getCurrent()[charIndex] !== "æ") {
+  //   handleChar("a", charIndex);
+  //   handleChar("e", charIndex + 1);
+  //   return;
+  // }
 
   console.debug("Handling char", char, charIndex, realInputValue);
 


### PR DESCRIPTION
### Description
Fix: When hiting æ key it prints 2 chars on screen a e
(Code is commented not remove why this code was there in the first place)

Closes #
issue: #6482 
