### PR TITLE
fix: stop broken background images from displaying (@mattlau1)

### DIFF
--- a/frontend/src/ts/controllers/theme-controller.ts
+++ b/frontend/src/ts/controllers/theme-controller.ts
@@ -357,7 +357,7 @@ function applyCustomBackground(): void {
     img.setAttribute("src", Config.customBackground);
     img.setAttribute(
       "onError",
-      "javascript:window.dispatchEvent(new Event('customBackgroundFailed'))"
+      "javascript:this.style.display='none'; window.dispatchEvent(new Event('customBackgroundFailed'))"
     );
     container?.replaceChildren(img);
 

--- a/frontend/src/ts/controllers/theme-controller.ts
+++ b/frontend/src/ts/controllers/theme-controller.ts
@@ -444,7 +444,7 @@ ConfigEvent.subscribe(async (eventKey, eventValue, nosave) => {
 
 window.addEventListener("customBackgroundFailed", () => {
   Notifications.add(
-    "Custom background link is either temporairly unavailable or expired. Please make sure the URL is correct or change it",
+    "Custom background link is either temporarily unavailable or expired. Please make sure the URL is correct or change it",
     0,
     { duration: 5 }
   );


### PR DESCRIPTION
### Description

If the specified background image is invalid, then we can hide it using `this.style.display='none'`, which will also hide the default white outline and broken image icon

Also fixed a typo in the notification for it (temporairly -> temporarily)

Tested fix by entering invalid custom background URL in settings (i.e. `https://tehtuhgsfdsfjsdg.com/test.jpg`)

Closes #6524 

<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->

Thanks!! :)
