### PR TITLE
fix(strings): use grapheme-cluster splitting to prevent Thai diacritic overlap (@JNX03)

### DIFF
--- a/frontend/src/ts/utils/strings.ts
+++ b/frontend/src/ts/utils/strings.ts
@@ -159,11 +159,18 @@ export function cleanTypographySymbols(textToClean: string): string {
  * @param s string to be tokenized into characters
  * @returns array of characters
  */
-export function splitIntoCharacters(s: string): string[] {
-  const result: string[] = [];
-  for (const t of s) {
-    result.push(t);
+export function splitIntoCharacters(text: string): string[] {
+  if (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function") {
+    const segmenter = new Intl.Segmenter(undefined, {
+      granularity: "grapheme",
+    });
+    const parts: string[] = [];
+    for (const { segment } of segmenter.segment(text)) {
+      parts.push(segment);
+    }
+    return parts;
   }
 
-  return result;
+  const graphemes = text.match(/\P{Mark}\p{Mark}*/gu);
+  return graphemes ?? [];
 }


### PR DESCRIPTION
### Description

This PR replaces the existing naive `splitIntoCharacters` implementation with one that:

- Uses the built-in `Intl.Segmenter` API (when available) to split strings into true grapheme clusters.
- Falls back to a Unicode-aware regex (`/\P{Mark}\p{Mark}*/gu`) for environments without `Intl.Segmenter`.
- Ensures Thai vowels and tone marks stay attached to their base consonants, resolving the overlapping-diacritics issue reported in #6528.

### Checks

- [ ] Adding quotes?  
  - [ ] Make sure to include translations for the quotes in the description (or another comment).
- [ ] Adding a language?  
  - [ ] Follow the [languages documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LANGUAGES.md)  
  - [ ] Add language to `packages/contracts/src/schemas/languages.ts`  
  - [ ] Add language to exactly one group in `frontend/src/ts/constants/languages.ts`  
  - [ ] Add language json file to `frontend/static/languages`  
- [ ] Adding a theme?  
  - [ ] Follow the [themes documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/THEMES.md)  
  - [ ] Add theme to `packages/contracts/src/schemas/themes.ts`  
  - [ ] Add theme to `frontend/src/ts/constants/themes.ts`  
  - [ ] Add theme css file to `frontend/static/themes`  
- [ ] Adding a layout?  
  - [ ] Follow the [layouts documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/LAYOUTS.md)  
  - [ ] Add layout to `packages/contracts/src/schemas/layouts.ts`  
  - [ ] Add layout json file to `frontend/static/layouts`  

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.  
- [x] Make sure the PR title follows the Conventional Commits standard.  

Closes #6528

# Here some preview that i fix
![Screenshot 2025-05-07 232348](https://github.com/user-attachments/assets/b1e236a5-e6a4-4e52-a855-8c9c7130118a)
![Screenshot 2025-05-07 230558](https://github.com/user-attachments/assets/e77a030b-a783-4a9a-87e2-a582ce57445d)

And I have test with other language this change dosn't effect it 