### PR TITLE
impr(settings): prevent customLayoutFluid and customPolyglot to be empty (@fehmer)

### DIFF
--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -580,7 +580,7 @@ async function fillSettingsPage(): Promise<void> {
   customLayoutFluidSelect = new SlimSelect({
     select:
       ".pageSettings .section[data-config-name='customLayoutfluid'] select",
-    settings: { keepOrder: true },
+    settings: { keepOrder: true, minSelected: 1 },
     events: {
       afterChange: (newVal): void => {
         const customLayoutfluid = newVal.map(
@@ -598,6 +598,7 @@ async function fillSettingsPage(): Promise<void> {
 
   customPolyglotSelect = new SlimSelect({
     select: ".pageSettings .section[data-config-name='customPolyglot'] select",
+    settings: { minSelected: 1 },
     data: getLanguageDropdownData((language) =>
       Config.customPolyglot.includes(language)
     ),


### PR DESCRIPTION
Prevent user from deselecting all layouts/languages in customLayoutfluid and customPolyglot selects.

Fixes FRONTEND-MW and FRONTEND-MS
