### PR TITLE
fix: smooth transition for theme palette icon in chaos_theory theme (@byseif21)

### DIFF
--- a/frontend/static/themes/chaos_theory.css
+++ b/frontend/static/themes/chaos_theory.css
@@ -94,6 +94,11 @@ header.focus #logo:after {
   direction: ltr;
 }
 
+footer .leftright .right .current-theme .fas.fa-fw.fa-palette {
+  transform: rotateY(0deg);
+  transition: 0.5s;
+}
+
 footer .leftright .right .current-theme:hover .fas.fa-fw.fa-palette {
   transform: rotateY(180deg);
   transition: 0.5s;


### PR DESCRIPTION

### Description

fix the transition animation for the theme palette icon in the chaos_theory theme.

hovering over the current theme button would trigger a smooth 180° flip of the palette icon. However, when quickly moving the cursor away, the icon would abruptly snap back to its original position instead of transitioning smoothly.
### Before: 

https://github.com/user-attachments/assets/55b6683a-c83b-4f93-806b-bf289bf30c5f

-------------


### Now:


https://github.com/user-attachments/assets/59d08d45-ba2d-4921-9cc4-ee84455a0571

