### PR TITLE
fix: ui not updating on favorite themes change via CLI in settings page (@byseif21)

### DIFF
--- a/frontend/src/ts/elements/settings/theme-picker.ts
+++ b/frontend/src/ts/elements/settings/theme-picker.ts
@@ -480,4 +480,7 @@ ConfigEvent.subscribe((eventKey) => {
   if (eventKey === "theme" && ActivePage.get() === "settings") {
     updateActiveButton();
   }
+  if (eventKey === "favThemes" && ActivePage.get() === "settings") {
+    void refreshPresetButtons();
+  }
 });


### PR DESCRIPTION

### Description
When using the command line to add or remove a theme from favorites while on the settings page, the favorites UI would not reflect the changes until the user manually refreshed the page or changed the theme. This caused confusion, despite the changes being correctly saved in the config.

**Solution**
Added a ConfigEvent subscription in theme-picker.ts to listen for "favThemes" updates. If the active page is "settings", the UI is now refreshed immediately by calling refreshPresetButtons().

