### PR TITLE
fix: auto-refresh themes UI when navigating to settings page (@byseif21)

### DIFF
--- a/frontend/src/ts/elements/settings/theme-picker.ts
+++ b/frontend/src/ts/elements/settings/theme-picker.ts
@@ -39,6 +39,12 @@ function updateActiveButton(): void {
     ?.classList.add("active");
 }
 
+export async function refreshThemeUI(): Promise<void> {
+  await refreshPresetButtons();
+  updateActiveButton();
+  await refreshCustomButtons();
+}
+
 function updateColors(
   colorPicker: JQuery,
   color: string,

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -1364,6 +1364,7 @@ export const page = new Page({
     await UpdateConfig.loadPromise;
     await fillSettingsPage();
     await update();
+    await ThemePicker.refreshThemeUI();
   },
 });
 


### PR DESCRIPTION
### Description
When (changing / adding or removing themes from favorite ) via command line or from the current theme button "in page e.g test page" and then
navigating to Settings > Themes, the UI does not immediately reflect the current theme changes . The user has to manually refresh the page to see these changes. 

**Now**
 UI automatically refreshes
to reflect the current theme selection and favorites without requiring
a manual page refresh.

- Added refreshThemeUI function in theme-picker.ts that updates all
  theme-related UI components
- Called this refresh function in the settings page's beforeShow lifecycle hook to ensure the theme UI is always up-to-date when the page is displayed.


**FOR TESTING BEFORE & AFTER:**
keep changing themes then navigate to the settings and check and keep doing those things again to verify that the active theme and favorites update.