### PR TITLE
fix(commandline): improve caching to fix stale checkmark and UI state (@byseif21, @fehmer)

### DIFF
--- a/frontend/src/ts/commandline/commandline.ts
+++ b/frontend/src/ts/commandline/commandline.ts
@@ -202,7 +202,6 @@ async function goBackOrHide(): Promise<void> {
     await filterSubgroup();
     await showCommands();
     await updateActiveCommand();
-    //lastSingleListModeInputValue = "";
     return;
   }
 


### PR DESCRIPTION
### Description

Previously, when selecting a language via the text button on the test page, the checkmark (fa-check) in the commandline language list wouldn't update until a page refresh. This was due to the commandline's caching mechanism not detecting changes triggered outside its own control.

Although it first appeared to be a language-specific issue, it was later identified that the caching logic was generally insufficient — it didn’t account for updates to the active command state or configuration flags like usingSingleList.

## Solution
Fixed the caching logic in the commandline module by tracking a more complete internal state. The system now correctly detects changes in the command list, active state, and configuration, and rebuilds the list UI when necessary.

## Technical Details
- The commandline uses a caching mechanism (`lastList`) to avoid rebuilding the HTML if the list hasn't changed done in #6559
- Replaced the old lastList cache with a new lastState object that stores: the list of commands, each with its isActive flag, the usingSingleList configuration flag
- Improved the cache comparison logic, uses areSortedArraysEqual to compare command lists including active state ,compares the usingSingleList flag
- Previously, this cache wasn't being cleared when the language changed through the text button
- Now we clear the cache on changes, forcing a rebuild of the list with the correct checkmark

## Performance Impact
- Minimal performance impact
- The list is only rebuilt when:
  1. The language actually changes
  2. The list content changes
  3. The input value changes
- The caching mechanism still prevents unnecessary rebuilds in all other cases

## Testing
- [x] Language selection through text button updates checkmark immediately
- [x] Language selection through commandline works as before
- [x] No unnecessary rebuilds when language hasn't changed
- [x] Checkmark appears next to correct language in all cases
