### PR TITLE
style: correct text in difficulty settings descriptions (@byseif21)

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -106,8 +106,8 @@
         <span>test difficulty</span>
       </div>
       <div class="text">
-        Normal is the classic type test experience. Expert fails the test if you
-        submit (press space) an incorrect word. Master fails if you press a
+        Normal is the classic typing test experience. Expert fails the test if
+        you submit (press space) an incorrect word. Master fails if you press a
         single incorrect key (meaning you have to achieve 100% accuracy).
       </div>
       <div class="buttons">


### PR DESCRIPTION
### Description

The is minor but I think it should be "typing test" not "type test"
