### PR TITLE
Fix: Caps Lock indicator doesn't update until typing (#5987)

### DIFF
--- a/frontend/src/ts/test/caps-warning.ts
+++ b/frontend/src/ts/test/caps-warning.ts
@@ -39,5 +39,5 @@ function update(event: JQuery.KeyDownEvent | JQuery.KeyUpEvent): void {
 $(document).on("keyup", update);
 
 $(document).on("keydown", (event) => {
-  if (isMacOs) update(event);
+  if (event.code === "CapsLock") update(event);
 });


### PR DESCRIPTION
### Description

Fixes an issue where the Caps Lock warning indicator does not update immediately when the key is toggled (e.g., when turning it off) until the user types something.

This PR:

* Adds a `keydown` listener that detects when the Caps Lock key is pressed.
* Calls the existing `update()` function to reflect the state change immediately.
* Resolves [#5987](https://github.com/monkeytypegame/monkeytype/issues/5987).

---

### Checks

Leave most of these **unchecked** unless you're doing those specific changes (like adding a language, theme, etc). But **check these:**

* [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
* [x] Make sure the PR title follows the Conventional Commits standard. (Use format like `fix:`, `feat:`, `chore:` etc.)

---

### PR Title Format

Use this as your **PR title**:

```
fix: update Caps Lock indicator immediately on toggle (#5987) (@sujal-cs)
```

---

### Closes

```md
Closes #5987
```

---

