### PR TITLE
feat(profile): add Open Graph meta tags for social sharing (@TryOmar)

### DIFF
--- a/frontend/src/ts/controllers/page-controller.ts
+++ b/frontend/src/ts/controllers/page-controller.ts
@@ -23,6 +23,23 @@ type ChangeOptions = {
   data?: unknown;
 };
 
+// New function to update or create the og:url meta tag
+function updateOpenGraphUrl(): void {
+  const ogUrlTag = document.querySelector('meta[property="og:url"]');
+  const currentUrl = window.location.href;
+
+  if (ogUrlTag) {
+    // Update existing tag
+    ogUrlTag.setAttribute("content", currentUrl);
+  } else {
+    // Create and append new tag if it doesn't exist
+    const newOgUrlTag = document.createElement("meta");
+    newOgUrlTag.setAttribute("property", "og:url");
+    newOgUrlTag.content = currentUrl;
+    document.head.appendChild(newOgUrlTag);
+  }
+}
+
 export async function change(
   pageName: PageName,
   options = {} as ChangeOptions
@@ -92,6 +109,10 @@ export async function change(
           }
           Focus.set(false);
           ActivePage.set(nextPage.id);
+
+          // Call the new function to update the og:url after the page is set
+          updateOpenGraphUrl();
+
           await previousPage?.afterHide();
           await nextPage?.beforeShow({
             params: options.params,

--- a/frontend/src/ts/controllers/page-controller.ts
+++ b/frontend/src/ts/controllers/page-controller.ts
@@ -23,7 +23,6 @@ type ChangeOptions = {
   data?: unknown;
 };
 
-// New function to update or create the og:url meta tag
 function updateOpenGraphUrl(): void {
   const ogUrlTag = document.querySelector('meta[property="og:url"]');
   const currentUrl = window.location.href;
@@ -110,15 +109,14 @@ export async function change(
           Focus.set(false);
           ActivePage.set(nextPage.id);
 
-          // Call the new function to update the og:url after the page is set
-          updateOpenGraphUrl();
-
           await previousPage?.afterHide();
           await nextPage?.beforeShow({
             params: options.params,
             // @ts-expect-error for the future (i think)
             data: options.data,
           });
+
+          updateOpenGraphUrl();
         }
       );
     });

--- a/frontend/src/ts/pages/profile.ts
+++ b/frontend/src/ts/pages/profile.ts
@@ -161,30 +161,6 @@ type UpdateOptions = {
   data?: undefined | UserProfile;
 };
 
-function updateOpenGraphTags(username: string): void {
-  const baseUrl = "https://monkeytype.com";
-  const profileUrl = `${baseUrl}/profile/${username}`;
-
-  // Remove existing Open Graph tags to prevent duplicates
-  document.querySelectorAll('meta[property^="og:"]').forEach(meta => meta.remove());
-
-  // Add new Open Graph tags
-  const ogTitle = document.createElement("meta");
-  ogTitle.setAttribute("property", "og:title");
-  ogTitle.content = `${username}'s Monkeytype Profile`;
-  document.head.appendChild(ogTitle);
-
-  const ogDescription = document.createElement("meta");
-  ogDescription.setAttribute("property", "og:description");
-  ogDescription.content = "Check out my typing stats on Monkeytype!";
-  document.head.appendChild(ogDescription);
-
-  const ogUrl = document.createElement("meta");
-  ogUrl.setAttribute("property", "og:url");
-  ogUrl.content = profileUrl;
-  document.head.appendChild(ogUrl);
-}
-
 async function update(options: UpdateOptions): Promise<void> {
   const getParamExists = checkIfGetParameterExists("isUid");
   if (options.data) {
@@ -222,7 +198,6 @@ async function update(options: UpdateOptions): Promise<void> {
         response.body.data.personalBests as unknown as PersonalBests,
         true
       );
-      updateOpenGraphTags(response.body.data.name);
     } else {
       // $(".page.pageProfile .failedToLoad").removeClass("hidden");
       Notifications.add("Failed to load profile: " + response.body.message, -1);

--- a/frontend/src/ts/pages/profile.ts
+++ b/frontend/src/ts/pages/profile.ts
@@ -161,6 +161,30 @@ type UpdateOptions = {
   data?: undefined | UserProfile;
 };
 
+function updateOpenGraphTags(username: string): void {
+  const baseUrl = "https://monkeytype.com";
+  const profileUrl = `${baseUrl}/profile/${username}`;
+
+  // Remove existing Open Graph tags to prevent duplicates
+  document.querySelectorAll('meta[property^="og:"]').forEach(meta => meta.remove());
+
+  // Add new Open Graph tags
+  const ogTitle = document.createElement("meta");
+  ogTitle.setAttribute("property", "og:title");
+  ogTitle.content = `${username}'s Monkeytype Profile`;
+  document.head.appendChild(ogTitle);
+
+  const ogDescription = document.createElement("meta");
+  ogDescription.setAttribute("property", "og:description");
+  ogDescription.content = "Check out my typing stats on Monkeytype!";
+  document.head.appendChild(ogDescription);
+
+  const ogUrl = document.createElement("meta");
+  ogUrl.setAttribute("property", "og:url");
+  ogUrl.content = profileUrl;
+  document.head.appendChild(ogUrl);
+}
+
 async function update(options: UpdateOptions): Promise<void> {
   const getParamExists = checkIfGetParameterExists("isUid");
   if (options.data) {
@@ -198,6 +222,7 @@ async function update(options: UpdateOptions): Promise<void> {
         response.body.data.personalBests as unknown as PersonalBests,
         true
       );
+      updateOpenGraphTags(response.body.data.name);
     } else {
       // $(".page.pageProfile .failedToLoad").removeClass("hidden");
       Notifications.add("Failed to load profile: " + response.body.message, -1);


### PR DESCRIPTION
Add Open Graph meta tags to user profile pages to improve how they appear when shared on social media platforms. This includes title, description and URL meta tags.

Closes #6597

### Description

This PR adds Open Graph Protocol (OGP) meta tags to user profile pages to fix the issue with LinkedIn and other social media platforms incorrectly redirecting profile links to the homepage. The implementation:

- Adds dynamic Open Graph meta tags for title, description and URL
- Updates tags whenever a profile page is loaded
- Uses the user's name in the title tag for better personalization

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard.
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

Closes #6597

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->