### PR TITLE
fix: compatability check header shown if client is using cached responses (@fehmer)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "cron": "2.3.0",
     "date-fns": "3.6.0",
     "dotenv": "16.4.5",
+    "etag": "1.8.1",
     "express": "4.21.1",
     "express-rate-limit": "7.4.0",
     "firebase-admin": "12.0.0",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,11 +9,8 @@ import {
   rootRateLimiter,
 } from "./middlewares/rate-limit";
 import { compatibilityCheckMiddleware } from "./middlewares/compatibilityCheck";
-import {
-  COMPATIBILITY_CHECK,
-  COMPATIBILITY_CHECK_HEADER,
-} from "@monkeytype/contracts";
-import { default as etag } from "etag";
+import { COMPATIBILITY_CHECK_HEADER } from "@monkeytype/contracts";
+import { createETagGenerator } from "./utils/etag";
 
 const etagFn = createETagGenerator({ weak: true });
 
@@ -40,27 +37,6 @@ function buildApp(): express.Application {
   app.use(errorHandlingMiddleware);
 
   return app;
-}
-
-/**
- * create etag generator, based on the express implementation https://github.com/expressjs/express/blob/9f4dbe3a1332cd883069ba9b73a9eed99234cfc7/lib/utils.js#L247
- * Adds the api COMPATIBILITY_CHECK version in front of the etag.
- * @param options
- * @returns
- */
-function createETagGenerator(options: {
-  weak: boolean;
-}): (body: Buffer | string, encoding: BufferEncoding | undefined) => string {
-  return function generateETag(body, encoding) {
-    const buf = !Buffer.isBuffer(body) ? Buffer.from(body, encoding) : body;
-
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-    const generatedTag: string = etag(buf, options);
-    if (generatedTag.startsWith("W/")) {
-      return `W/"V${COMPATIBILITY_CHECK}-${generatedTag.slice(3)}`;
-    }
-    return `"V${COMPATIBILITY_CHECK}-${generatedTag.slice(1)}`;
-  };
 }
 
 export default buildApp();

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,7 +9,13 @@ import {
   rootRateLimiter,
 } from "./middlewares/rate-limit";
 import { compatibilityCheckMiddleware } from "./middlewares/compatibilityCheck";
-import { COMPATIBILITY_CHECK_HEADER } from "@monkeytype/contracts";
+import {
+  COMPATIBILITY_CHECK,
+  COMPATIBILITY_CHECK_HEADER,
+} from "@monkeytype/contracts";
+import { default as etag } from "etag";
+
+const etagFn = createETagGenerator({ weak: true });
 
 function buildApp(): express.Application {
   const app = express();
@@ -27,11 +33,34 @@ function buildApp(): express.Application {
   app.use(badAuthRateLimiterHandler);
   app.use(rootRateLimiter);
 
+  app.set("etag", etagFn);
+
   addApiRoutes(app);
 
   app.use(errorHandlingMiddleware);
 
   return app;
+}
+
+/**
+ * create etag generator, based on the express implementation https://github.com/expressjs/express/blob/9f4dbe3a1332cd883069ba9b73a9eed99234cfc7/lib/utils.js#L247
+ * Adds the api COMPATIBILITY_CHECK version in front of the etag.
+ * @param options
+ * @returns
+ */
+function createETagGenerator(options: {
+  weak: boolean;
+}): (body: Buffer | string, encoding: BufferEncoding | undefined) => string {
+  return function generateETag(body, encoding) {
+    const buf = !Buffer.isBuffer(body) ? Buffer.from(body, encoding) : body;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const generatedTag: string = etag(buf, options);
+    if (generatedTag.startsWith("W/")) {
+      return `W/"V${COMPATIBILITY_CHECK}-${generatedTag.slice(3)}`;
+    }
+    return `"V${COMPATIBILITY_CHECK}-${generatedTag.slice(1)}`;
+  };
 }
 
 export default buildApp();

--- a/backend/src/utils/etag.ts
+++ b/backend/src/utils/etag.ts
@@ -1,0 +1,25 @@
+import { COMPATIBILITY_CHECK } from "@monkeytype/contracts";
+import { default as etag } from "etag";
+
+/**
+ * create etag generator, based on the express implementation https://github.com/expressjs/express/blob/9f4dbe3a1332cd883069ba9b73a9eed99234cfc7/lib/utils.js#L247
+ * Adds the api COMPATIBILITY_CHECK version in front of the etag.
+ * @param options
+ * @returns
+ */
+export function createETagGenerator(options: {
+  weak: boolean;
+}): (body: Buffer | string, encoding: BufferEncoding | undefined) => string {
+  return function generateETag(body, encoding) {
+    const buf = !Buffer.isBuffer(body) ? Buffer.from(body, encoding) : body;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    const generatedTag: string = etag(buf, options);
+
+    //custom code to add the version number
+    if (generatedTag.startsWith("W/")) {
+      return `W/"V${COMPATIBILITY_CHECK}-${generatedTag.slice(3)}`;
+    }
+    return `"V${COMPATIBILITY_CHECK}-${generatedTag.slice(1)}`;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
+      etag:
+        specifier: 1.8.1
+        version: 1.8.1
       express:
         specifier: 4.21.1
         version: 4.21.1


### PR DESCRIPTION
If frontend and backend are deployed with a new COMPATABILITY_CHECK header frontend might show the backend version is lower because of the http header of a cached response.

Adding the COMPATABILITY_CHECK version as part of the etag fixes this.
