### PR TITLE
Style: Add WhatsApp Dark Theme

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -1114,6 +1114,12 @@ export const themes: Record<ThemeName, Omit<Theme, "name">> = {
     subColor: "#5b578e",
     textColor: "#f4e0c9",
   },
+  whatsapp: {
+    bgColor: "#101D25",
+    mainColor: "#00B09C",
+    subColor: "#9FA2A7",
+    textColor: "#e7e8e9",
+  },
 };
 
 export const ThemesList: Theme[] = Object.keys(themes)

--- a/frontend/static/themes/whatsapp.css
+++ b/frontend/static/themes/whatsapp.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #101d25;
+  --main-color: #00b09c;
+  --caret-color: #0bd953;
+  --sub-color: #9fa2a7;
+  --sub-alt-color: #232d36;
+  --text-color: #e7e8e9;
+  --error-color: #0bd953;
+  --error-extra-color: #00b09c;
+  --colorful-error-color: #0bd953;
+  --colorful-error-extra-color: #00b09c;
+}

--- a/packages/contracts/src/schemas/themes.ts
+++ b/packages/contracts/src/schemas/themes.ts
@@ -187,6 +187,7 @@ export const ThemeNameSchema = z.enum(
     "watermelon",
     "wavez",
     "witch_girl",
+    "whatsapp",
   ],
   {
     errorMap: customEnumErrorHandler("Must be a known theme"),


### PR DESCRIPTION
## 🎨 Theme Overview
This PR introduces a new **WhatsApp Dark** theme that replicates the authentic WhatsApp dark mode color palette for a familiar and comfortable typing experience.

## 🌈 Color Palette
The theme uses WhatsApp's official dark mode colors:
- **Background**: `#101d25` (Dark blue-gray)
- **Primary Accent**: `#00b09c` (WhatsApp Teal)
- **Caret**: `#0bd953` (WhatsApp Green)
- **Text**: `#e7e8e9` (Light gray)
- **Secondary**: `#9fa2a7` (Medium gray)
- **Alt Background**: `#232d36` (Secondary dark)

## ✨ Features
- Authentic WhatsApp dark mode aesthetic
- High contrast for excellent readability
- Distinctive teal and green accent colors
- Optimized for extended typing sessions
- Unique color combination not found in existing themes

## 📸 Preview
![Screenshot 2025-05-27 at 10 43 30 AM](https://github.com/user-attachments/assets/b52648ec-3737-4c2c-b3be-b30b469e7c48)
![Screenshot 2025-05-27 at 10 43 19 AM](https://github.com/user-attachments/assets/9c73ffc8-8d69-4506-b83b-10490b541d46)
![Screenshot 2025-05-27 at 10 38 29 AM](https://github.com/user-attachments/assets/54c0af06-efdd-449a-9630-9502b8f8eedb)


## 🔍 Theme Uniqueness
After scanning all existing themes, this WhatsApp dark theme offers a unique combination that doesn't overlap with any current themes. The closest themes (Terminal, Matrix, Mint) use different color palettes and don't capture the authentic WhatsApp feel.

## 🧪 Testing
- ✅ Theme loads correctly
- ✅ All color variables properly defined
- ✅ Consistent with Monkeytype theme structure
- ✅ No conflicts with existing themes

## 📁 Files Changed
- `frontend/static/themes/whatsapp.css` - New theme file