### PR TITLE
impr(commandline): skip input recall on up arrow when it's opened with specific list (@byseif21)

### DIFF
--- a/frontend/src/ts/commandline/commandline.ts
+++ b/frontend/src/ts/commandline/commandline.ts
@@ -711,6 +711,7 @@ const modal = new AnimatedModal({
       ) {
         if (
           Config.singleListCommandLine === "on" &&
+          subgroupOverride === null &&
           inputValue === "" &&
           lastSingleListModeInputValue !== ""
         ) {


### PR DESCRIPTION

### Description
fix this https://github.com/monkeytypegame/monkeytype/pull/6460#issuecomment-2816486698
also not only in the theme picker but you can find it happening in the language list through the language button.
