### PR TITLE
feat(settings): allow uploading local background images (@byseif21)

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -1126,9 +1126,9 @@
         <span>custom background</span>
       </div>
       <div class="text">
-        Set an image url to be a custom background image. Cover fits the image
-        to cover the screen. Contain fits the image to be fully visible. Max
-        fits the image corner to corner.
+        Set an image url or upload a local image to be a custom background.
+        Cover fits the image to cover the screen. Contain fits the image to be
+        fully visible. Max fits the image corner to corner.
       </div>
       <div class="inputs">
         <div class="inputAndButton">
@@ -1146,6 +1146,17 @@
             <button class="save no-auto-handle">
               <i class="fas fa-save fa-fw"></i>
             </button>
+            <div class="upload-container">
+              <label for="customBackgroundUpload" class="button">
+                <i class="fas fa-upload fa-fw"></i>
+              </label>
+              <input
+                type="file"
+                id="customBackgroundUpload"
+                accept="image/png,image/jpeg,image/jpg,image/gif"
+                style="display: none"
+              />
+            </div>
           </span>
         </div>
         <div class="buttons">

--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -1147,7 +1147,12 @@
               <i class="fas fa-save fa-fw"></i>
             </button>
             <div class="upload-container">
-              <label for="customBackgroundUpload" class="button">
+              <label
+                for="customBackgroundUpload"
+                class="button"
+                aria-label="Upload custom background image"
+                data-balloon-pos="left"
+              >
                 <i class="fas fa-upload fa-fw"></i>
               </label>
               <input

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -1059,6 +1059,15 @@ $(
     ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton input"
   ).val() as string;
 
+  // check if it's a data:image URL
+  if (newVal.startsWith("data:image/")) {
+    Notifications.add(
+      "Data URLs are not allowed in the input field. Please use the import button for local images or use a proper URL link.",
+      0
+    );
+    return;
+  }
+
   const parsed = CustomBackgroundSchema.safeParse(newVal);
 
   if (!parsed.success) {
@@ -1085,6 +1094,15 @@ $(
     const newVal = $(
       ".pageSettings .section[data-config-name='customBackgroundSize'] .inputAndButton input"
     ).val() as string;
+
+    // check if it's a data:image URL
+    if (newVal.startsWith("data:image/")) {
+      Notifications.add(
+        "Data URLs are not allowed in the input field. Please use the import button for local images or use a proper URL link.",
+        0
+      );
+      return;
+    }
 
     const parsed = CustomBackgroundSchema.safeParse(newVal);
 

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -802,9 +802,7 @@ export async function update(): Promise<void> {
     Config.tapeMargin
   );
 
-  $(
-    ".pageSettings .section[data-config-name='customBackgroundSize'] input"
-  ).val(Config.customBackground);
+  $("#customBackgroundInput").val(Config.customBackground);
 
   if (isAuthenticated()) {
     showAccountSection();

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -1102,6 +1102,57 @@ $(
   }
 });
 
+$("#customBackgroundUpload").on("change", (e) => {
+  const fileInput = e.target as HTMLInputElement;
+  const file = fileInput.files?.[0];
+
+  if (!file) {
+    return;
+  }
+
+  // check file size (limit to 5MB)
+  if (file.size > 5 * 1024 * 1024) {
+    Notifications.add("Image file is too large (max 5MB)", 0);
+    fileInput.value = "";
+    return;
+  }
+
+  // check type
+  if (!file.type.match(/image\/(jpeg|jpg|png|gif)/)) {
+    Notifications.add("Unsupported image format", 0);
+    fileInput.value = "";
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    const dataUrl = event.target?.result as string;
+
+    // validate the data URL
+    const parsed = CustomBackgroundSchema.safeParse(dataUrl);
+    if (!parsed.success) {
+      Notifications.add(
+        `Invalid image format (${parsed.error.issues[0]?.message})`,
+        0
+      );
+      return;
+    }
+
+    // update the input field with the data URL
+    $("#customBackgroundInput").val(dataUrl);
+    // save the background
+    UpdateConfig.setCustomBackground(dataUrl);
+    // reset the file input
+    fileInput.value = "";
+  };
+
+  reader.onerror = () => {
+    Notifications.add("Error reading file", 0);
+    fileInput.value = "";
+  };
+  reader.readAsDataURL(file);
+});
+
 $(
   ".pageSettings .section[data-config-name='fontSize'] .inputAndButton button.save"
 ).on("click", () => {

--- a/packages/contracts/__test__/schema/config.spec.ts
+++ b/packages/contracts/__test__/schema/config.spec.ts
@@ -59,8 +59,11 @@ describe("config schema", () => {
       },
       {
         name: "data url",
-        input: `data:image/gif;base64,data`,
-        expectedError: "Unsupported protocol.",
+        input: `data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7`,
+      },
+      {
+        name: "invalid data url",
+        input: `data:image/gif;base64,invalid`,
       },
       {
         name: "long url",

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -366,9 +366,9 @@ export const CustomBackgroundSchema = z.string().refine(
     if (val === "") return { message: "" };
     if (val.startsWith("javascript:"))
       return { message: "Unsupported protocol." };
-    if (!/^[^`'"]*$/.test(val)) return { message: "May not contain quotes." };
     if (!/^(https|http):\/\/.*/.test(val))
       return { message: "Needs to be an URI." };
+    if (!/^[^`'"]*$/.test(val)) return { message: "May not contain quotes." };
     if (!/.+(\.png|\.gif|\.jpeg|\.jpg)/gi.test(val))
       return { message: "Unsupported image format." };
     if (val.length > 2048) return { message: "URL is too long." };

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -379,7 +379,8 @@ export const CustomBackgroundSchema = z.string().refine(
     if (val === "") return { message: "" };
     if (val.startsWith("javascript:"))
       return { message: "Unsupported protocol." };
-    if (val.length > 2048) return { message: "URL is too long." };
+    if (isHttpUrl(val) && val.length > 2048)
+      return { message: "URL is too long." };
     if (!isHttpUrl(val)) return { message: "Needs to be an URI." };
     if (containsQuotes(val)) return { message: "May not contain quotes." };
     if (!isImageExtension(val)) return { message: "Unsupported image format." };

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -333,14 +333,29 @@ export type FontSize = z.infer<typeof FontSizeSchema>;
 export const MaxLineWidthSchema = z.number().min(20).max(1000).or(z.literal(0));
 export type MaxLineWidth = z.infer<typeof MaxLineWidthSchema>;
 
-export const CustomBackgroundSchema = z
-  .string()
-  .url("Needs to be an URI.")
-  .regex(/^(https|http):\/\/.*/, "Unsupported protocol.")
-  .regex(/^[^`'"]*$/, "May not contain quotes.")
-  .regex(/.+(\.png|\.gif|\.jpeg|\.jpg)/gi, "Unsupported image format.")
-  .max(2048, "URL is too long.")
-  .or(z.literal(""));
+export const CustomBackgroundSchema = z.string().refine(
+  (val) => {
+    if (val === "") return true;
+    // check for http/https URL
+    if (
+      /^(https|http):\/\/.*/.test(val) &&
+      /^[^`'"]*$/.test(val) &&
+      /.+(\.png|\.gif|\.jpeg|\.jpg)/gi.test(val) &&
+      val.length <= 2048
+    ) {
+      return true;
+    }
+    // check for data URL
+    if (/^data:image\/(png|jpeg|gif);base64,[A-Za-z0-9+/]+=*$/.test(val)) {
+      return true;
+    }
+    return false;
+  },
+  {
+    message:
+      "Must be a valid http/https URL (png, gif, jpeg, jpg, max 2048 chars, no quotes) or a valid data URL (png, jpeg, gif).",
+  }
+);
 export type CustomBackground = z.infer<typeof CustomBackgroundSchema>;
 
 export const ConfigSchema = z

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -368,9 +368,7 @@ export const CustomBackgroundSchema = z.string().refine(
     if (val.startsWith("javascript:")) return false;
     if (containsQuotes(val)) return false;
     if (isHttpUrl(val)) {
-      if (!isImageExtension(val)) return false;
-      if (val.length > 2048) return false;
-      return true;
+      return isImageExtension(val) && val.length <= 2048;
     }
     if (isDataImageUrl(val)) {
       return isValidBase64Data(val);

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -351,9 +351,20 @@ export const CustomBackgroundSchema = z.string().refine(
     }
     return false;
   },
-  {
-    message:
-      "Must be a valid http/https URL (png, gif, jpeg, jpg, max 2048 chars, no quotes) or a valid data URL (png, jpeg, gif).",
+  (val) => {
+    if (val === "") return { message: "" };
+    if (!/^(https|http):\/\/.*/.test(val)) {
+      if (val.startsWith("javascript:"))
+        return { message: "Unsupported protocol." };
+      return { message: "Needs to be an URI." };
+    }
+    if (!/^[^`'"]*$/.test(val)) return { message: "May not contain quotes." };
+    if (!/.+(\.png|\.gif|\.jpeg|\.jpg)/gi.test(val))
+      return { message: "Unsupported image format." };
+    if (val.length > 2048) return { message: "URL is too long." };
+    if (!/^data:image\/(png|jpeg|gif);base64,[A-Za-z0-9+/]+=*$/.test(val))
+      return { message: "Invalid data URL format" };
+    return { message: "Invalid background value" };
   }
 );
 export type CustomBackground = z.infer<typeof CustomBackgroundSchema>;

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -336,10 +336,11 @@ export type MaxLineWidth = z.infer<typeof MaxLineWidthSchema>;
 export const CustomBackgroundSchema = z.string().refine(
   (val) => {
     if (val === "") return true;
+    // check for quotes first
+    if (!/^[^`'"]*$/.test(val)) return false;
     // check for http/https URL
     if (
       /^(https|http):\/\/.*/.test(val) &&
-      /^[^`'"]*$/.test(val) &&
       /.+(\.png|\.gif|\.jpeg|\.jpg)/gi.test(val) &&
       val.length <= 2048
     ) {
@@ -353,12 +354,12 @@ export const CustomBackgroundSchema = z.string().refine(
   },
   (val) => {
     if (val === "") return { message: "" };
+    if (!/^[^`'"]*$/.test(val)) return { message: "May not contain quotes." };
     if (!/^(https|http):\/\/.*/.test(val)) {
       if (val.startsWith("javascript:"))
         return { message: "Unsupported protocol." };
       return { message: "Needs to be an URI." };
     }
-    if (!/^[^`'"]*$/.test(val)) return { message: "May not contain quotes." };
     if (!/.+(\.png|\.gif|\.jpeg|\.jpg)/gi.test(val))
       return { message: "Unsupported image format." };
     if (val.length > 2048) return { message: "URL is too long." };

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -379,10 +379,10 @@ export const CustomBackgroundSchema = z.string().refine(
     if (val === "") return { message: "" };
     if (val.startsWith("javascript:"))
       return { message: "Unsupported protocol." };
+    if (val.length > 2048) return { message: "URL is too long." };
     if (!isHttpUrl(val)) return { message: "Needs to be an URI." };
     if (containsQuotes(val)) return { message: "May not contain quotes." };
     if (!isImageExtension(val)) return { message: "Unsupported image format." };
-    if (val.length > 2048) return { message: "URL is too long." };
     if (isDataImageUrl(val)) {
       const base64Data = val.split(",")[1];
       if (base64Data === null || base64Data === undefined || base64Data === "")


### PR DESCRIPTION
### Description

This PR adds support for uploading custom background images directly from local files, in addition to the existing URL-based method. users can now personalize their typing environment more easily without needing hosted images.

### Short Test & Preview:

https://github.com/user-attachments/assets/28c53651-c1fc-45a1-8a52-f50557f7f209



