### PR TITLE
fix(input-controller): update keymap UI on backspace in layout emulator (@47th)

### DIFF
--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -1335,6 +1335,7 @@ $("#wordsInput").on("input", (event) => {
     inputValue.length >= currTestInput.length
   ) {
     setWordsInput(" " + currTestInput);
+    updateUI();
     return;
   }
 


### PR DESCRIPTION
### Description

Fixes the keymap UI not highlighting the current letter to be typed when backspaced to a previous word in layout emulator.


https://github.com/user-attachments/assets/12ba72d8-567b-4097-bbf6-407814140545

