### PR TITLE
fix(theme-picker): ensure color input is updated correctly in updateColors function

### DIFF
--- a/frontend/src/ts/elements/settings/theme-picker.ts
+++ b/frontend/src/ts/elements/settings/theme-picker.ts
@@ -59,6 +59,7 @@ function updateColors(
     }
     colorPicker.find("input.input").val(color);
     colorPicker.find("input.color").attr("value", color);
+    colorPicker.find("input.color").val(color);
     return;
   }
   const colorREGEX = [
@@ -114,6 +115,7 @@ function updateColors(
   }
   colorPicker.find("input.input").val(color);
   colorPicker.find("input.color").attr("value", color);
+  colorPicker.find("input.color").val(color);
 }
 
 export async function refreshPresetButtons(): Promise<void> {


### PR DESCRIPTION
### Description

The input of type color doesn't properly get updated when the text input for setting a custom color is modified with a value.

Video: https://github.com/user-attachments/assets/87bcc3fd-a71c-460f-adb6-94945efb8b1f
