### PR TITLE
fix(commandline): prevent duplicate entries in Polyglot and Layoutfluid funbox modes (@byseif21)

### DIFF
--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1871,17 +1871,19 @@ export function setCustomLayoutfluid(
   value: ConfigSchemas.CustomLayoutFluid,
   nosave?: boolean
 ): boolean {
+  // Remove duplicates
+  const deduped = Array.from(new Set(value));
   if (
     !isConfigValueValid(
       "layoutfluid",
-      value,
+      deduped,
       ConfigSchemas.CustomLayoutFluidSchema
     )
   ) {
     return false;
   }
 
-  config.customLayoutfluid = value;
+  config.customLayoutfluid = deduped;
   saveToLocalStorage("customLayoutfluid", nosave);
   ConfigEvent.dispatch("customLayoutfluid", config.customLayoutfluid);
 
@@ -1892,16 +1894,18 @@ export function setCustomPolyglot(
   value: ConfigSchemas.CustomPolyglot,
   nosave?: boolean
 ): boolean {
+  // remove duplicates
+  const deduped = Array.from(new Set(value));
   if (
     !isConfigValueValid(
       "customPolyglot",
-      value,
+      deduped,
       ConfigSchemas.CustomPolyglotSchema
     )
   )
     return false;
 
-  config.customPolyglot = value;
+  config.customPolyglot = deduped;
   saveToLocalStorage("customPolyglot", nosave);
   ConfigEvent.dispatch("customPolyglot", config.customPolyglot);
 


### PR DESCRIPTION

### Description
 #### Issue:
* It was possible to add duplicate languages to Polyglot mode or duplicate layouts to Layoutfluid mode via the command line

#### fix:
* Prevent duplicate entries in Polyglot and Layoutfluid configs by deduplicating values before saving, ensuring unique values regardless of input source.