### PR TITLE
fix(test): funbox does not remember settings (@fehmer)

### DIFF
--- a/frontend/src/ts/pages/test.ts
+++ b/frontend/src/ts/pages/test.ts
@@ -33,7 +33,6 @@ export const page = new Page({
       noAnim: true,
     });
     void TestConfig.instantUpdate();
-    void Funbox.activate();
     void Keymap.refresh();
     ScrollToTop.hide();
   },


### PR DESCRIPTION
`funbox.applyConfig` was called twice when changing to test page. `funbox.rememberSettings` was saving the wrong setting, as it was called after the first `applyConfig`.

fixes #6700
