### PR TITLE
impr(settings): clarified 'reset settings' wording (@SamLonneman)

### DIFF
--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -1808,7 +1808,8 @@
         </button>
       </div>
       <div class="text">
-        Resets settings to the default (but doesn't touch your tags).
+        Resets settings to the default (but doesn't touch your tags and
+        presets).
         <br />
         <span class="red">You can't undo this action!</span>
       </div>

--- a/packages/contracts/src/schemas/presets.ts
+++ b/packages/contracts/src/schemas/presets.ts
@@ -8,7 +8,7 @@ import {
 
 export const PresetNameSchema = z
   .string()
-  .regex(/^[0-9a-zA-Z_-]+$/)
+  .regex(/^[ -~]+$/)
   .max(16);
 export type PresetName = z.infer<typeof PresetNameSchema>;
 

--- a/packages/contracts/src/schemas/presets.ts
+++ b/packages/contracts/src/schemas/presets.ts
@@ -10,7 +10,7 @@ export const PresetNameSchema = z
   .string()
   .regex(/^[0-9a-zA-Z_-]+$/)
   .max(16);
-export type PresentName = z.infer<typeof PresetNameSchema>;
+export type PresetName = z.infer<typeof PresetNameSchema>;
 
 export const PresetTypeSchema = z.enum(["full", "partial"]);
 export type PresetType = z.infer<typeof PresetTypeSchema>;

--- a/packages/contracts/src/schemas/presets.ts
+++ b/packages/contracts/src/schemas/presets.ts
@@ -8,7 +8,7 @@ import {
 
 export const PresetNameSchema = z
   .string()
-  .regex(/^[ -~]+$/)
+  .regex(/^[0-9a-zA-Z_-]+$/)
   .max(16);
 export type PresetName = z.infer<typeof PresetNameSchema>;
 


### PR DESCRIPTION
### Description

**`impr`** - Clarified description for "Reset Settings" feature, emphasizing that in addition to tags, settings presets are also preserved.

**`refactor`** - the unused type `PresetName` was misspelled as `PresentName`.