### PR TITLE
fix(settings): fix highlight not visible with reduced-motion (@fehmer)

### DIFF
--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -493,7 +493,8 @@
     &.highlight {
       margin: -1em;
       padding: 1em;
-      animation: flashBorder 4s ease-in;
+      animation: flashBorder 4s ease-in forwards;
+      box-shadow: 0 0 0 0.2em var(--sub-color);
       border-radius: var(--roundness);
     }
 


### PR DESCRIPTION
Highlight was not visible if the user has prefers-reduced-motion enabled.
