### PR TITLE
fix(wordsInput): prevent automatic scrolling when focusing #wordsInput (@NadAlaba)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -153,7 +153,9 @@ export function reset(): void {
 }
 
 export function focusWords(): void {
-  $("#wordsInput").trigger("focus");
+  const wordsInputEl = document.getElementById("wordsInput");
+  if (!wordsInputEl) return;
+  wordsInputEl.focus({ preventScroll: true });
 }
 
 export function blurWords(): void {


### PR DESCRIPTION
`#wordsInput.focus()` causes automatic scroll to the focused element by default, which caused a lot of issues #5857 #6093 #6610 #6723 that it now seems to be causing only trouble.

This will prevent scrolling in `focusWords()` to fix #6723 and avoid future issues.

p.s., this needs a lot of testing on all platforms and browsers before merging to make sure scrolling is not needed at all in `focusWords()`.