### PR TITLE
fix(leaderboards): content overflow on smaller screens (@byseif21, @miodec)

### DIFF
--- a/frontend/src/html/pages/leaderboards.html
+++ b/frontend/src/html/pages/leaderboards.html
@@ -23,7 +23,7 @@
         <div class="title timer">Updates in: -</div>
 
         <div class="jumpButtons">
-          <div class="updating hidden">
+          <div class="updating">
             <i class="fas fa-circle-notch fa-spin"></i>
           </div>
           <button data-action="firstPage"><i class="fas fa-crown"></i></button>

--- a/frontend/src/html/pages/leaderboards.html
+++ b/frontend/src/html/pages/leaderboards.html
@@ -55,7 +55,7 @@
               wpm
               <div class="sub">accuracy</div>
             </td>
-            <td class="stat narrow">
+            <td class="stat narrow rawAndConsistency">
               raw
               <div class="sub">consistency</div>
             </td>

--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -389,16 +389,18 @@ key {
   display: grid;
   grid-template-columns: max-content auto;
   align-items: baseline;
+  --spacing: 0.5em;
+  --horizontalScale: 1.25;
   .fas,
   .far {
-    margin-right: 0.3rem;
-    margin-left: 0.3rem;
-    margin-top: 0.3rem;
-    margin-bottom: 0.3rem;
+    margin-right: calc(var(--spacing) * var(--horizontalScale));
+    margin-left: calc(var(--spacing) * var(--horizontalScale));
+    margin-top: var(--spacing);
+    margin-bottom: var(--spacing);
     font-size: 0.9em;
   }
   .text {
-    margin-right: 0.3rem;
+    margin-right: calc(var(--spacing) * var(--horizontalScale));
   }
 }
 

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -121,6 +121,9 @@
           .sub {
             opacity: 0.5;
           }
+          &:last-child {
+            text-wrap-mode: nowrap;
+          }
         }
         .date {
           font-size: 0.75em;
@@ -178,7 +181,7 @@
               text-align: right;
             }
             &.date {
-              width: 20ch;
+              width: 1px;
               text-align: right;
             }
           }
@@ -234,6 +237,7 @@
           }
 
           td.date {
+            text-wrap-mode: nowrap;
             text-align: right;
             font-size: 0.75em;
           }

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -10,8 +10,8 @@
     height: 100%;
 
     .bigtitle {
-      font-size: 2rem;
-      margin-bottom: 1rem;
+      font-size: 2em;
+      margin-bottom: 1em;
       .text {
         grid-area: text;
       }

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -50,12 +50,12 @@
 
       .titleAndButtons {
         align-items: center;
-        font-size: 1rem;
+        font-size: 1em;
         display: grid;
         grid-template-columns: 1fr 1fr;
         justify-content: space-between;
         button {
-          width: 3rem;
+          width: 3em;
         }
         .title {
           font-size: 1rem;

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -87,8 +87,8 @@
       .bigUser {
         // color: var(--main-color);
         font-size: 1em;
-        margin-bottom: 2rem;
-        margin-top: 2rem;
+        margin-bottom: 2em;
+        margin-top: 2em;
         background: var(--sub-alt-color);
         padding: 1em 2em;
         border-radius: var(--roundness);

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -212,7 +212,7 @@
             grid-column: 1/2;
           }
           .badge {
-            font-size: 0.6em;
+            font-size: 0.75em;
           }
           .flagsAndBadge {
             display: flex;

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -70,7 +70,7 @@
           .updating {
             font-size: 1.5em;
             color: var(--sub-color);
-            margin-right: 0.5em;
+            margin-left: 0.5em;
           }
         }
       }

--- a/frontend/src/styles/leaderboards.scss
+++ b/frontend/src/styles/leaderboards.scss
@@ -143,15 +143,6 @@
           //   }
         }
       }
-      .avatarNameBadge {
-        display: grid;
-        grid-template-columns: min-content max-content auto;
-        gap: 0.5rem;
-        place-items: center left;
-        .avatarPlaceholder {
-          color: var(--sub-color);
-        }
-      }
       table {
         width: 100%;
         border-spacing: 0;
@@ -199,14 +190,11 @@
           gap: 0.5em;
           place-items: center left;
           .avatarPlaceholder {
-            width: 1.25em;
-            height: 1.25em;
-            font-size: 1.25em;
-            // background: var(--sub-color);
             color: var(--sub-color);
-            // display: grid;
-            // place-content: center center;
             border-radius: 100%;
+            i {
+              font-size: 1.29em;
+            }
           }
           .entryName {
             text-decoration: none;
@@ -215,6 +203,8 @@
           }
           .avatarPlaceholder,
           .avatar {
+            width: 1.25em;
+            height: 1.25em;
             grid-row: 1/2;
             grid-column: 1/2;
           }

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -60,16 +60,14 @@
   .pageLeaderboards {
     .content .tableAndUser {
       table {
-        tr[data-uid] {
-          .avatarNameBadge {
-            grid-template-columns: 1.25em 1fr;
-            grid-template-areas:
-              "avatar name"
-              "badges badges";
-            .flagsAndBadge {
-              grid-area: badges;
-              justify-self: center;
-            }
+        .avatarNameBadge {
+          grid-template-columns: 1.25em 1fr;
+          grid-template-areas:
+            "avatar name"
+            "badges badges";
+          .flagsAndBadge {
+            grid-area: badges;
+            // justify-self: center;
           }
         }
       }

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -72,6 +72,9 @@
         }
       }
       table {
+        .avatarNameBadge .flagsAndBadge .badge .text {
+          display: block;
+        }
         tbody td.date {
           font-size: 0.75em;
         }

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -57,4 +57,22 @@
   #testActivity {
     display: none;
   }
+  .pageLeaderboards {
+    .content .tableAndUser {
+      table {
+        tr[data-uid] {
+          .avatarNameBadge {
+            grid-template-columns: 1.25em 1fr;
+            grid-template-areas:
+              "avatar name"
+              "badges badges";
+            .flagsAndBadge {
+              grid-area: badges;
+              justify-self: center;
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -61,14 +61,24 @@
   .pageLeaderboards {
     .content .tableAndUser {
       font-size: 0.7rem;
-      .bigUser .stat.narrow:last-child {
-        font-size: 0.75em;
-      }
       .bigUser {
         gap: 0.5em;
         padding-left: 0.75em;
+        .stat.narrow:last-child {
+          font-size: 0.75em;
+        }
+        .userInfo {
+          font-size: 0.8em;
+        }
         .rank {
           margin-right: 0.5em;
+        }
+      }
+      .titleAndButtons {
+        // grid-template-columns: 1fr;
+        .title {
+          // text-align: center;
+          font-size: 1em;
         }
       }
       table {

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -57,9 +57,24 @@
   #testActivity {
     display: none;
   }
+
   .pageLeaderboards {
     .content .tableAndUser {
+      font-size: 0.7rem;
+      .bigUser .stat.narrow:last-child {
+        font-size: 0.75em;
+      }
+      .bigUser {
+        gap: 0.5em;
+        padding-left: 0.75em;
+        .rank {
+          margin-right: 0.5em;
+        }
+      }
       table {
+        tbody td.date {
+          font-size: 0.75em;
+        }
         .avatarNameBadge {
           grid-template-columns: 1.25em 1fr;
           grid-template-areas:

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -62,7 +62,7 @@
     .content .tableAndUser {
       //font-size: 0.7rem;
       .bigUser {
-        gap: 0.5em;
+        gap: 1em;
         padding-left: 0.75em;
         .stat.narrow:last-child {
           font-size: 0.75em;

--- a/frontend/src/styles/media-queries-brown.scss
+++ b/frontend/src/styles/media-queries-brown.scss
@@ -60,7 +60,7 @@
 
   .pageLeaderboards {
     .content .tableAndUser {
-      font-size: 0.7rem;
+      //font-size: 0.7rem;
       .bigUser {
         gap: 0.5em;
         padding-left: 0.75em;

--- a/frontend/src/styles/media-queries-gray.scss
+++ b/frontend/src/styles/media-queries-gray.scss
@@ -1,0 +1,26 @@
+//this is very overkill for the modern world so dont worry too much about this width
+@media only screen and (max-width: 330px) {
+  #mediaQueryDebug {
+    background: gray;
+    &::before {
+      content: "gray";
+    }
+  }
+  .pageLeaderboards .content .tableAndUser {
+    .titleAndButtons {
+      grid-template-columns: 1fr;
+      .title {
+        text-align: right;
+      }
+    }
+    .rawAndConsistency {
+      display: none;
+    }
+  }
+  header {
+    gap: 0.25rem;
+    nav .textButton {
+      padding: 0.5em 0.25em;
+    }
+  }
+}

--- a/frontend/src/styles/media-queries-gray.scss
+++ b/frontend/src/styles/media-queries-gray.scss
@@ -9,6 +9,7 @@
   .pageLeaderboards .content .tableAndUser {
     .titleAndButtons {
       grid-template-columns: 1fr;
+      gap: 0.5em;
       .title {
         text-align: right;
       }

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -349,70 +349,85 @@
 }
 
 @media only screen and (max-width: 350px) {
-  .pageLeaderboards table {
-    thead {
-      display: none;
-    }
-    tbody tr {
-      display: grid;
-      //grid-template-columns: 1fr;
-      gap: 0.7rem;
-      padding: 1rem;
+  .pageLeaderboards {
+    .content .tableAndUser .titleAndButtons {
+      grid-template-columns: 1fr;
+      gap: 1rem;
       margin-bottom: 1rem;
-      border: 1px solid var(--sub-alt-color);
-      border-radius: var(--roundness);
-      //background: var(--sub-alt-color);
-
-      &:nth-child(even) {
-        background: var(--bg-color);
-        border-color: var(--sub-color);
+      .jumpButtons {
+        justify-self: center;
+        gap: 0.25em;
+        button {
+          width: 2rem;
+          font-size: 0.8rem;
+        }
       }
+    }
+    table {
+      thead {
+        display: none;
+      }
+      tbody tr {
+        display: grid;
+        //grid-template-columns: 1fr;
+        gap: 0.7rem;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        border: 1px solid var(--sub-alt-color);
+        border-radius: var(--roundness);
+        //background: var(--sub-alt-color);
 
-      td {
-        display: block !important;
-        text-align: center !important;
-
-        &:nth-child(1) {
-          font-size: 1.5em;
+        &:nth-child(even) {
+          background: var(--bg-color);
+          border-color: var(--sub-color);
         }
 
-        .avatarNameBadge {
+        td {
+          display: block !important;
+          text-align: center !important;
+
+          &:nth-child(1) {
+            font-size: 1.5em;
+          }
+
+          .avatarNameBadge {
+            display: flex !important;
+            flex-direction: column !important;
+            align-items: center !important;
+            justify-content: center !important;
+            font-size: 1.5em;
+            gap: 0.5em;
+          }
+
+          &:nth-child(5)::before {
+            content: "wpm: ";
+            font-weight: bold;
+          }
+          &:nth-child(6)::before {
+            content: "accuracy: ";
+            font-weight: bold;
+          }
+          &:nth-child(7)::before {
+            content: "raw: ";
+            font-weight: bold;
+          }
+          &:nth-child(8)::before {
+            content: "consistency: ";
+            font-weight: bold;
+          }
+          &:nth-child(9)::before {
+            content: "date: ";
+            font-weight: bold;
+          }
+        }
+
+        .narrow {
+          display: none !important;
+        }
+
+        .wide .avatarNameBadge {
           display: flex !important;
-          flex-direction: column !important;
-          align-items: center !important;
-          justify-content: center !important;
-          font-size: 1.5em;
-          gap: 0.5em;
         }
-
-        &:nth-child(5)::before {
-          content: "wpm: ";
-          font-weight: bold;
-        }
-        &:nth-child(6)::before {
-          content: "accuracy: ";
-          font-weight: bold;
-        }
-        &:nth-child(7)::before {
-          content: "raw: ";
-          font-weight: bold;
-        }
-        &:nth-child(8)::before {
-          content: "consistency: ";
-          font-weight: bold;
-        }
-        &:nth-child(9)::before {
-          content: "date: ";
-          font-weight: bold;
-        }
-      }
-
-      .narrow {
-        display: none !important;
-      }
-
-      .wide .avatarNameBadge {
-        display: flex !important;
       }
     }
   }

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -328,6 +328,9 @@
         flex-direction: column;
         gap: 1em;
         //word-break: break-word;
+        .sub {
+          text-align: center;
+        }
       }
     }
   }

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -27,6 +27,9 @@
       left: 0.1rem;
       transform: none;
     }
+    .content .tableAndUser {
+      overflow-x: hidden;
+    }
   }
   header {
     nav {

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -347,3 +347,73 @@
     }
   }
 }
+
+@media only screen and (max-width: 350px) {
+  .pageLeaderboards table {
+    thead {
+      display: none;
+    }
+    tbody tr {
+      display: grid;
+      //grid-template-columns: 1fr;
+      gap: 0.7rem;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      border: 1px solid var(--sub-alt-color);
+      border-radius: var(--roundness);
+      //background: var(--sub-alt-color);
+
+      &:nth-child(even) {
+        background: var(--bg-color);
+        border-color: var(--sub-color);
+      }
+
+      td {
+        display: block !important;
+        text-align: center !important;
+
+        &:nth-child(1) {
+          font-size: 1.5em;
+        }
+
+        .avatarNameBadge {
+          display: flex !important;
+          flex-direction: column !important;
+          align-items: center !important;
+          justify-content: center !important;
+          font-size: 1.5em;
+          gap: 0.5em;
+        }
+
+        &:nth-child(5)::before {
+          content: "wpm: ";
+          font-weight: bold;
+        }
+        &:nth-child(6)::before {
+          content: "accuracy: ";
+          font-weight: bold;
+        }
+        &:nth-child(7)::before {
+          content: "raw: ";
+          font-weight: bold;
+        }
+        &:nth-child(8)::before {
+          content: "consistency: ";
+          font-weight: bold;
+        }
+        &:nth-child(9)::before {
+          content: "date: ";
+          font-weight: bold;
+        }
+      }
+
+      .narrow {
+        display: none !important;
+      }
+
+      .wide .avatarNameBadge {
+        display: flex !important;
+      }
+    }
+  }
+}

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -22,26 +22,30 @@
       }
     }
   }
+
   .pageLeaderboards {
     .content .bigtitle .text:after {
       left: 0.1rem;
       transform: none;
     }
     .content .tableAndUser {
-      overflow-x: hidden;
+      .bigUser {
+        gap: 1.5em;
+      }
       table {
-        tr[data-uid] {
-          .avatarNameBadge {
-            gap: 0.2em;
-          }
-          .stat {
-            padding: 0.1em 0.2em;
-          }
+        td {
+          padding: 0.5em;
         }
-        td,
-        th {
-          padding: 0.7em 0.9em;
+        .avatarNameBadge .flagsAndBadge .badge .text {
+          display: none;
         }
+        tbody td:nth-child(2) {
+          width: 100%;
+        }
+      }
+      .bigUser {
+        padding: 0.5em;
+        padding-left: 1em;
       }
     }
   }
@@ -316,119 +320,5 @@
   .popupWrapper .modal .inputs.withLabel,
   .modalWrapper .modal .inputs.withLabel {
     grid-template-columns: 1fr;
-  }
-}
-
-@media only screen and (max-width: 540px) {
-  .pageLeaderboards {
-    .content .tableAndUser {
-      .bigUser,
-      .needAuth {
-        text-align: center;
-        flex-direction: column;
-        gap: 1em;
-        //word-break: break-word;
-        .sub {
-          text-align: center;
-        }
-      }
-    }
-  }
-}
-
-@media only screen and (max-width: 520px) {
-  .pageLeaderboards {
-    .content .tableAndUser {
-      table {
-        tr[data-uid] {
-          font-size: 0.75em;
-        }
-      }
-    }
-  }
-}
-
-@media only screen and (max-width: 350px) {
-  .pageLeaderboards {
-    .content .tableAndUser .titleAndButtons {
-      grid-template-columns: 1fr;
-      gap: 1rem;
-      margin-bottom: 1rem;
-      .jumpButtons {
-        justify-self: center;
-        gap: 0.25em;
-        button {
-          width: 2rem;
-          font-size: 0.8rem;
-        }
-      }
-    }
-    table {
-      thead {
-        display: none;
-      }
-      tbody tr {
-        display: grid;
-        //grid-template-columns: 1fr;
-        gap: 0.7rem;
-        padding: 1rem;
-        margin-bottom: 1rem;
-        border: 1px solid var(--sub-alt-color);
-        border-radius: var(--roundness);
-        //background: var(--sub-alt-color);
-
-        &:nth-child(even) {
-          background: var(--bg-color);
-          border-color: var(--sub-color);
-        }
-
-        td {
-          display: block !important;
-          text-align: center !important;
-
-          &:nth-child(1) {
-            font-size: 1.5em;
-          }
-
-          .avatarNameBadge {
-            display: flex !important;
-            flex-direction: column !important;
-            align-items: center !important;
-            justify-content: center !important;
-            font-size: 1.5em;
-            gap: 0.5em;
-          }
-
-          &:nth-child(5)::before {
-            content: "wpm: ";
-            font-weight: bold;
-          }
-          &:nth-child(6)::before {
-            content: "accuracy: ";
-            font-weight: bold;
-          }
-          &:nth-child(7)::before {
-            content: "raw: ";
-            font-weight: bold;
-          }
-          &:nth-child(8)::before {
-            content: "consistency: ";
-            font-weight: bold;
-          }
-          &:nth-child(9)::before {
-            content: "date: ";
-            font-weight: bold;
-          }
-        }
-
-        .narrow {
-          display: none !important;
-        }
-
-        .wide .avatarNameBadge {
-          display: flex !important;
-        }
-      }
-    }
   }
 }

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -29,6 +29,20 @@
     }
     .content .tableAndUser {
       overflow-x: hidden;
+      table {
+        tr[data-uid] {
+          .avatarNameBadge {
+            gap: 0.2em;
+          }
+          .stat {
+            padding: 0.1em 0.2em;
+          }
+        }
+        td,
+        th {
+          padding: 0.7em 0.9em;
+        }
+      }
     }
   }
   header {

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -318,3 +318,29 @@
     grid-template-columns: 1fr;
   }
 }
+
+@media only screen and (max-width: 540px) {
+  .pageLeaderboards {
+    .content .tableAndUser {
+      .bigUser,
+      .needAuth {
+        text-align: center;
+        flex-direction: column;
+        gap: 1em;
+        //word-break: break-word;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 520px) {
+  .pageLeaderboards {
+    .content .tableAndUser {
+      table {
+        tr[data-uid] {
+          font-size: 0.75em;
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/styles/media-queries-purple.scss
+++ b/frontend/src/styles/media-queries-purple.scss
@@ -29,6 +29,7 @@
       transform: none;
     }
     .content .tableAndUser {
+      font-size: clamp(0.7rem, 2.8vw, 0.9rem);
       .bigUser {
         gap: 1.5em;
       }

--- a/frontend/src/styles/media-queries.scss
+++ b/frontend/src/styles/media-queries.scss
@@ -50,6 +50,7 @@ body {
 @import "media-queries-blue";
 @import "media-queries-purple";
 @import "media-queries-brown";
+@import "media-queries-gray";
 
 @media only screen and (max-width: 1875px) {
   .ad.ad-v {

--- a/frontend/src/styles/media-queries.scss
+++ b/frontend/src/styles/media-queries.scss
@@ -63,6 +63,32 @@ body {
   }
 }
 
+@media only screen and (max-width: 540px) {
+  .pageLeaderboards {
+    .content .tableAndUser {
+      .bigUser,
+      .needAuth {
+        text-align: center;
+        flex-direction: column;
+        gap: 1em;
+        //word-break: break-word;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 520px) {
+  .pageLeaderboards {
+    .content .tableAndUser {
+      table {
+        tr[data-uid] {
+          font-size: 0.75em;
+        }
+      }
+    }
+  }
+}
+
 // //1450px
 // @media only screen and (max-width: 90.625rem) {
 //   #leaderboardsWrapper #leaderboards {

--- a/frontend/src/styles/media-queries.scss
+++ b/frontend/src/styles/media-queries.scss
@@ -63,32 +63,6 @@ body {
   }
 }
 
-@media only screen and (max-width: 540px) {
-  .pageLeaderboards {
-    .content .tableAndUser {
-      .bigUser,
-      .needAuth {
-        text-align: center;
-        flex-direction: column;
-        gap: 1em;
-        //word-break: break-word;
-      }
-    }
-  }
-}
-
-@media only screen and (max-width: 520px) {
-  .pageLeaderboards {
-    .content .tableAndUser {
-      table {
-        tr[data-uid] {
-          font-size: 0.75em;
-        }
-      }
-    }
-  }
-}
-
 // //1450px
 // @media only screen and (max-width: 90.625rem) {
 //   #leaderboardsWrapper #leaderboards {

--- a/frontend/src/ts/pages/leaderboards.ts
+++ b/frontend/src/ts/pages/leaderboards.ts
@@ -858,7 +858,7 @@ function fillUser(): void {
 
 function updateContent(): void {
   $(".page.pageLeaderboards .loading").addClass("hidden");
-  $(".page.pageLeaderboards .updating").addClass("hidden");
+  $(".page.pageLeaderboards .updating").addClass("invisible");
   $(".page.pageLeaderboards .error").addClass("hidden");
 
   if (state.error !== undefined) {
@@ -870,7 +870,7 @@ function updateContent(): void {
 
   if (state.updating) {
     disableButtons();
-    $(".page.pageLeaderboards .updating").removeClass("hidden");
+    $(".page.pageLeaderboards .updating").removeClass("invisible");
     return;
   } else if (state.loading) {
     disableButtons();

--- a/frontend/src/ts/pages/leaderboards.ts
+++ b/frontend/src/ts/pages/leaderboards.ts
@@ -490,7 +490,7 @@ function buildTableRow(entry: LeaderboardEntry, me = false): string {
         <div class="sub">${formatted.acc}</div>
       </td>
       </td>
-      <td class="stat narrow">
+      <td class="stat narrow rawAndConsistency">
       ${formatted.raw}
         <div class="sub">${formatted.con}</div>
       </td>
@@ -756,7 +756,7 @@ function fillUser(): void {
           <div>${formatted.wpm}</div>
           <div class="sub">${formatted.acc}</div>
         </div>
-        <div class="stat narrow">
+        <div class="stat narrow rawAndConsistency">
           <div>${formatted.raw}</div>
           <div class="sub">${formatted.con}</div>
         </div>


### PR DESCRIPTION
### Description
* when the table got wider than the screen, it broke the layout and pushed other elements out of view.
fixed it by `overflow-x: hidden`
* making the table itself more responsive, so it adapts across screen sizes

* video ; 

https://github.com/user-attachments/assets/c84272d1-4c77-4e59-980e-aab09c18d6a1

Closes #6732