### PR TITLE
fix(account-history): highlight animation is not working on result selection (@byseif21)

### DIFF
--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -311,10 +311,6 @@
     border-collapse: collapse;
     color: var(--text-color);
 
-    tr {
-      background: var(--row-bg, var(--bg-color));
-    }
-
     td {
       padding: 0.5rem 0.5rem;
     }
@@ -325,7 +321,7 @@
     }
 
     tbody tr:nth-child(odd) {
-      --row-bg: var(--sub-alt-color);
+      background: var(--sub-alt-color);
     }
 
     tbody td:nth-child(1) {

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -309,6 +309,7 @@
     td {
       padding: 0.5rem 0.5rem;
       background: var(--row-bg, var(--bg-color));
+      background-clip: padding-box;
     }
 
     thead {

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -308,6 +308,7 @@
 
     td {
       padding: 0.5rem 0.5rem;
+      background: var(--row-bg, var(--bg-color));
     }
 
     thead {
@@ -316,7 +317,7 @@
     }
 
     tbody tr:nth-child(odd) td {
-      background: var(--sub-alt-color);
+      --row-bg: var(--sub-alt-color);
     }
 
     tbody td:nth-child(1) {

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -194,7 +194,7 @@
       table td {
         -webkit-appearance: unset;
       }
-      .active td {
+      .active {
         animation: flashHighlight 4s linear 0s 1;
       }
 
@@ -306,10 +306,12 @@
     border-collapse: collapse;
     color: var(--text-color);
 
+    tr {
+      background: var(--row-bg, var(--bg-color));
+    }
+
     td {
       padding: 0.5rem 0.5rem;
-      background: var(--row-bg, var(--bg-color));
-      background-clip: padding-box;
     }
 
     thead {
@@ -317,7 +319,7 @@
       font-size: 0.75rem;
     }
 
-    tbody tr:nth-child(odd) td {
+    tbody tr:nth-child(odd) {
       --row-bg: var(--sub-alt-color);
     }
 

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -194,7 +194,7 @@
       table td {
         -webkit-appearance: unset;
       }
-      .active {
+      .active td {
         animation: flashHighlight 4s linear 0s 1;
       }
 

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -194,8 +194,13 @@
       table td {
         -webkit-appearance: unset;
       }
+
+      table tr {
+        border-radius: var(--roundness);
+      }
+
       .active {
-        animation: flashHighlight 4s linear 0s 1;
+        animation: accountRowHighlight 4s linear 0s 1;
       }
 
       .loadMoreButton {

--- a/frontend/src/styles/animations.scss
+++ b/frontend/src/styles/animations.scss
@@ -64,18 +64,12 @@
   }
 }
 
-@keyframes flashHighlight {
+@keyframes accountRowHighlight {
   0% {
-    background-color: var(--row-bg) !important;
-  }
-  10% {
-    background-color: var(--main-color) !important;
-  }
-  40% {
-    background-color: var(--main-color) !important;
+    outline: 0.25em solid var(--main-color);
   }
   100% {
-    background-color: var(--row-bg) !important;
+    outline: 0.25em solid transparent;
   }
 }
 

--- a/frontend/src/styles/animations.scss
+++ b/frontend/src/styles/animations.scss
@@ -66,7 +66,7 @@
 
 @keyframes flashHighlight {
   0% {
-    background-color: var(--bg-color) !important;
+    background-color: var(--row-bg) !important;
   }
   10% {
     background-color: var(--main-color) !important;
@@ -75,7 +75,7 @@
     background-color: var(--main-color) !important;
   }
   100% {
-    background-color: var(--bg-color) !important;
+    background-color: var(--row-bg) !important;
   }
 }
 

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1156,17 +1156,19 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
   const windowHeight = $(window).height() ?? 0;
   const offset = $(`#result-${index}`).offset()?.top ?? 0;
   const scrollTo = offset - windowHeight / 2;
-  $([document.documentElement, document.body]).animate(
-    { scrollTop: scrollTo },
-    {
-      duration: Misc.applyReducedMotion(500),
-      done: () => {
-        const element = $(`#result-${index}`);
-        $(".resultRow").removeClass("active");
-        requestAnimationFrame(() => element.addClass("active"));
-      },
-    }
-  );
+  $([document.documentElement, document.body])
+    .stop(true)
+    .animate(
+      { scrollTop: scrollTo },
+      {
+        duration: Misc.applyReducedMotion(500),
+        done: () => {
+          const element = $(`#result-${index}`);
+          $(".resultRow").removeClass("active");
+          requestAnimationFrame(() => element.addClass("active"));
+        },
+      }
+    );
 });
 
 $(".pageAccount").on("click", ".miniResultChartButton", async (event) => {

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1163,7 +1163,9 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
     Misc.applyReducedMotion(500)
   );
   $(".resultRow").removeClass("active");
-  $(`#result-${index}`).addClass("active");
+  setTimeout(() => {
+    $(`#result-${index}`).addClass("active");
+  }, 0);
 });
 
 $(".pageAccount").on("click", ".miniResultChartButton", async (event) => {

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1159,14 +1159,13 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
   const element = $(`#result-${index}`);
   $([document.documentElement, document.body]).animate(
     { scrollTop: scrollTo },
-    {
-      duration: Misc.applyReducedMotion(500),
-      done: () => {
-        $(".resultRow").removeClass("active");
-        setTimeout(() => {
-          element.addClass("active");
-        }, 0);
-      },
+    Misc.applyReducedMotion(500),
+    () => {
+      $(".resultRow").removeClass("active");
+      requestAnimationFrame(() => {
+        element.addClass("active");
+        setTimeout(() => element.removeClass("active"), 4000);
+      });
     }
   );
 });

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1156,16 +1156,14 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
   const windowHeight = $(window).height() ?? 0;
   const offset = $(`#result-${index}`).offset()?.top ?? 0;
   const scrollTo = offset - windowHeight / 2;
-  const element = $(`#result-${index}`);
   $([document.documentElement, document.body]).animate(
     { scrollTop: scrollTo },
     Misc.applyReducedMotion(500),
     () => {
+      const element = $(`#result-${index}`);
       $(".resultRow").removeClass("active");
-      setTimeout(() => {
-        element.addClass("active");
-        setTimeout(() => element.removeClass("active"), 4000);
-      }, 0);
+      element.addClass("active");
+      setTimeout(() => element.removeClass("active"), 4000);
     }
   );
 });

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1156,16 +1156,19 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
   const windowHeight = $(window).height() ?? 0;
   const offset = $(`#result-${index}`).offset()?.top ?? 0;
   const scrollTo = offset - windowHeight / 2;
+  const element = $(`#result-${index}`);
   $([document.documentElement, document.body]).animate(
+    { scrollTop: scrollTo },
     {
-      scrollTop: scrollTo,
-    },
-    Misc.applyReducedMotion(500)
+      duration: Misc.applyReducedMotion(500),
+      done: () => {
+        $(".resultRow").removeClass("active");
+        setTimeout(() => {
+          element.addClass("active");
+        }, 0);
+      },
+    }
   );
-  $(".resultRow").removeClass("active");
-  setTimeout(() => {
-    $(`#result-${index}`).addClass("active");
-  }, 0);
 });
 
 $(".pageAccount").on("click", ".miniResultChartButton", async (event) => {

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1163,8 +1163,7 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
       done: () => {
         const element = $(`#result-${index}`);
         $(".resultRow").removeClass("active");
-        element.addClass("active");
-        setTimeout(() => element.removeClass("active"), 4000);
+        requestAnimationFrame(() => element.addClass("active"));
       },
     }
   );

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1162,10 +1162,10 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
     Misc.applyReducedMotion(500),
     () => {
       $(".resultRow").removeClass("active");
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         element.addClass("active");
         setTimeout(() => element.removeClass("active"), 4000);
-      });
+      }, 0);
     }
   );
 });

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1158,12 +1158,14 @@ $(".pageAccount #accountHistoryChart").on("click", () => {
   const scrollTo = offset - windowHeight / 2;
   $([document.documentElement, document.body]).animate(
     { scrollTop: scrollTo },
-    Misc.applyReducedMotion(500),
-    () => {
-      const element = $(`#result-${index}`);
-      $(".resultRow").removeClass("active");
-      element.addClass("active");
-      setTimeout(() => element.removeClass("active"), 4000);
+    {
+      duration: Misc.applyReducedMotion(500),
+      done: () => {
+        const element = $(`#result-${index}`);
+        $(".resultRow").removeClass("active");
+        element.addClass("active");
+        setTimeout(() => element.removeClass("active"), 4000);
+      },
     }
   );
 });


### PR DESCRIPTION
### Description

fix the highlight animation for the account history table (when clicking a chart dot) was not visible or only worked inconsistently. This was because the animation was applied to the <tr> element, but the background color for table rows is set on the <td> elements. As a result, the animation was hidden by the static background color of the table cells.

Closes #

