### PR TITLE
fix(themes): clipped logo letters in some themes (@byseif21)

### DIFF
--- a/frontend/static/themes/incognito.css
+++ b/frontend/static/themes/incognito.css
@@ -27,5 +27,8 @@ header #logo .icon svg path {
 }
 
 header #logo .icon {
-  padding-bottom: 0.1em;
+  padding-bottom: 0.05em;
+}
+nav {
+  padding-bottom: 0.2em;
 }

--- a/frontend/static/themes/incognito.css
+++ b/frontend/static/themes/incognito.css
@@ -26,9 +26,14 @@ header #logo .icon svg path {
   fill: var(--text-color);
 }
 
+/* fix logo clipping */
 header #logo .icon {
   padding-bottom: 0.05em;
 }
 nav {
   padding-bottom: 0.2em;
 }
+header {
+  margin-bottom: -0.1em;
+}
+/*  */

--- a/frontend/static/themes/rainbow_trail.css
+++ b/frontend/static/themes/rainbow_trail.css
@@ -27,6 +27,7 @@ header #logo .text {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: rainbow-gradient 30s alternate ease-in-out infinite;
+  padding-bottom: 0.1em;
 }
 
 header #logo .top,

--- a/frontend/static/themes/rainbow_trail.css
+++ b/frontend/static/themes/rainbow_trail.css
@@ -29,6 +29,12 @@ header #logo .text {
   animation: rainbow-gradient 30s alternate ease-in-out infinite;
   padding-bottom: 0.1em;
 }
+header #logo .icon {
+  padding-bottom: 0.05em;
+}
+nav {
+  padding-bottom: 0.2em;
+}
 
 header #logo .top,
 .view-account .levelAndBar .level,

--- a/frontend/static/themes/rainbow_trail.css
+++ b/frontend/static/themes/rainbow_trail.css
@@ -29,12 +29,19 @@ header #logo .text {
   animation: rainbow-gradient 30s alternate ease-in-out infinite;
   padding-bottom: 0.1em;
 }
+
+/* fix logo clipping */
 header #logo .icon {
   padding-bottom: 0.05em;
 }
 nav {
   padding-bottom: 0.2em;
 }
+
+header {
+  margin-bottom: -0.1em;
+}
+/*  */
 
 header #logo .top,
 .view-account .levelAndBar .level,

--- a/frontend/static/themes/sewing_tin_light.css
+++ b/frontend/static/themes/sewing_tin_light.css
@@ -36,12 +36,19 @@ header #logo .text {
   -webkit-text-fill-color: transparent;
   padding-bottom: 0.1em;
 }
+
+/* fix logo clipping */
 header #logo .icon {
   padding-bottom: 0.05em;
 }
 nav {
   padding-bottom: 0.2em;
 }
+
+header {
+  margin-bottom: -0.1em;
+}
+/*  */
 
 header #logo .text .top {
   /* prevent it from being transparent */

--- a/frontend/static/themes/sewing_tin_light.css
+++ b/frontend/static/themes/sewing_tin_light.css
@@ -34,6 +34,7 @@ header #logo .text {
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  padding-bottom: 0.1em;
 }
 
 header #logo .text .top {

--- a/frontend/static/themes/sewing_tin_light.css
+++ b/frontend/static/themes/sewing_tin_light.css
@@ -36,6 +36,12 @@ header #logo .text {
   -webkit-text-fill-color: transparent;
   padding-bottom: 0.1em;
 }
+header #logo .icon {
+  padding-bottom: 0.05em;
+}
+nav {
+  padding-bottom: 0.2em;
+}
 
 header #logo .text .top {
   /* prevent it from being transparent */

--- a/frontend/static/themes/suisei.css
+++ b/frontend/static/themes/suisei.css
@@ -30,9 +30,16 @@ header #logo .text {
   color: transparent;
   padding-bottom: 0.1em;
 }
+
+/* fix logo clipping */
 header #logo .icon {
   padding-bottom: 0.05em;
 }
+header {
+  margin-bottom: -0.1em;
+}
+/*  */
+
 header #logo .text .top {
   color: var(--main-color);
 }

--- a/frontend/static/themes/suisei.css
+++ b/frontend/static/themes/suisei.css
@@ -30,6 +30,9 @@ header #logo .text {
   color: transparent;
   padding-bottom: 0.1em;
 }
+header #logo .icon {
+  padding-bottom: 0.05em;
+}
 header #logo .text .top {
   color: var(--main-color);
 }


### PR DESCRIPTION
### Description

all themes that use `background-clip: text` should have the `padding-bottom: 0.1em` to prevent the cut logo letters.
