### PR TITLE
docs(self-hosting): improve grammar and structure of setup guide (@nitin-is-me)

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -112,7 +112,7 @@ Stop the running docker containers using `docker compose down` before making any
 ### Setup Recaptcha
 
 - [create](https://www.google.com/recaptcha/admin/create) a new recaptcha token
-    - label: monkeytype
+    - label: `monkeytype`
     - type: v2
     - domain: the domain of the frontend 
 - update the `.env` file with the site key from the previous step

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -25,7 +25,7 @@
 
 
 ## Prerequisites
-- you need `docker` and `docker-compose-plugin` installed. Follow the [docker documentation](https://docs.docker.com/compose/install/) on how to do this.
+- you need to have `docker` and `docker-compose-plugin` installed. Follow the [docker documentation](https://docs.docker.com/compose/install/) on how to do this.
 
 ## Quickstart
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -30,7 +30,7 @@
 ## Quickstart
 
 - create a new directory (e.g.  `monkeytype`) and navigate into it.
-- download the [docker-compose.yml](https://github.com/monkeytypegame/monkeytype/tree/master/docker/docker-compose.yml)
+- download the [docker-compose.yml](https://github.com/monkeytypegame/monkeytype/tree/master/docker/docker-compose.yml) file.
 - create an `.env` file, you can copy the content from the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env).
 - download the [backend-configuration.json](https://github.com/monkeytypegame/monkeytype/tree/master/docker/backend-configuration.json)
 - run `docker compose up -d`

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -185,5 +185,4 @@ Contains your firebase config, only needed if you want to allow users to signup.
 Configuration of the backend. Check the [default configuration](https://github.com/monkeytypegame/monkeytype/blob/master/backend/src/constants/base-configuration.ts#L8) for possible values.
 
 > [!NOTE]
-> The configuration is applied on container startup only. You have to restart the container for your changes to become active.
-
+> Configuration changes are applied only on container startup. You must restart the container for your updates to take effect. 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -39,7 +39,7 @@
 
 ## Account System
 
-User signup/login is disabled by default. To allow users to signup you'll need to setup a Firebase project. 
+By default, user sign-up and login are disabled. To enable this, you'll need to set up a Firebase project. 
 Stop the running docker containers using `docker compose down` before making any changes.
 
 ### Setup Firebase

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -29,7 +29,7 @@
 
 ## Quickstart
 
-- create a new directory, e.g.  `monkeytype` and open it.
+- create a new directory (e.g.  `monkeytype`) and navigate into it.
 - download the [docker-compose.yml](https://github.com/monkeytypegame/monkeytype/tree/master/docker/docker-compose.yml)
 - create an `.env` file, you can copy the content from the [example.env](https://github.com/monkeytypegame/monkeytype/tree/master/docker/example.env).
 - download the [backend-configuration.json](https://github.com/monkeytypegame/monkeytype/tree/master/docker/backend-configuration.json)

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -53,11 +53,11 @@ Stop the running docker containers using `docker compose down` before making any
   - go to `Authentication > Sign-in method`  
   - enable `Email/Password` and save
 - generate service account
-  - open the project settings by clicking the `⚙` icon on the sidebar and `Project settings`
-  - go to `Service accounts`
-  - click `Generate new private key`. This will download a `.json` file.
-  - store the `.json` file as `serviceAccountKey.json`
-  - update the `docker-compose.yml` file and uncomment the first volume from the `monkeytype-backend` container
+  - go to your project settings by clicking the `⚙` icon in the sidebar, then `Project settings`
+  - navigate to the `Service accounts` tab
+  - click `Generate new private key` to download the `.json` file.
+  - save it as `serviceAccountKey.json`
+  - update `docker-compose.yml` and uncomment the volume block in the `monkeytype-backend` container to mount the Firebase service account:
     ```yaml
       #uncomment to enable the account system, check the SELF_HOSTING.md file
       - type: bind
@@ -69,12 +69,12 @@ Stop the running docker containers using `docker compose down` before making any
 - update the `.env` file
   - open the [firebase console](https://console.firebase.google.com/) and open your project
   - open the project settings by clicking the `⚙` icon on the sidebar and `Project settings`
-  - if there is no app in your project create a new web-app `</>`
+  - if your project has no apps yet, create a new Web app (`</>` icon)
     - nickname `monkeytype`
     - uncheck `set up firebase hosting`
     - click `Register app` 
    - select your app and select `Config` for `SDK setup and configuration`
-   - it will display sth like this:
+   - it will display something like this:
         ```
         const firebaseConfig = {
         apiKey: "AAAAAAAA",

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -137,7 +137,7 @@ To enable emails for password reset and email verification update the following 
 EMAIL_HOST=mail.myserver   # your mailserver domain
 EMAIL_USER=mailuser        # username to authenticate with your mailserver
 EMAIL_PASS=mailpass        # password for the user
-EMAIL_PORT=465             # port, likely 465 or 578
+EMAIL_PORT=465             # port, likely 465 or 587
 EMAIL_FROM="Support <noreply@myserver>"
 ``` 
 


### PR DESCRIPTION
### Description

Improved grammar, structure, and tone of the `docs/self_hosting.md` file for better clarity and consistency. Changes include fixing typos, rewording vague instructions, improving formatting, and aligning with the overall documentation tone.

### Checks

- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

### Other notes

This PR does not add any quotes, languages, themes, or layouts.

---

Closes # (none)
