### PR TITLE
fix: changing the font size would display incorrect number of lines (@byseif21)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -64,7 +64,9 @@ ConfigEvent.subscribe((eventKey, eventValue, nosave) => {
   }
   if (eventKey === "fontSize" && !nosave) {
     OutOfFocus.hide();
-    updateWordWrapperClasses();
+    requestAnimationFrame(() => {
+      updateWordWrapperClasses();
+    });
   }
   if (
     ["fontSize", "fontFamily", "blindMode", "hideExtraLetters"].includes(


### PR DESCRIPTION
### Description

after the recent font refactor, changing the font size  now would cause the UI to display wrong number of lines till the test restarted.

The `updateWordsWrapperHeight()` function was being called synchronously immediately after the font size CSS was applied, but before the browser could recalculate element dimensions with the new font metrics ,this fix it.

