### PR TITLE
fix(config): don't apply overrideConfig on nosave (@fehmer)

### DIFF
--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -188,7 +188,7 @@ export function genericSet<T extends keyof ConfigSchemas.Config>(
         continue; // no need to set if the value is already the same
       }
 
-      const set = genericSet(targetKey, targetValue, true);
+      const set = genericSet(targetKey, targetValue, nosave);
       if (!set) {
         throw new Error(
           `Failed to set config key "${targetKey}" with value "${targetValue}" for ${metadata.displayString} config override.`

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -173,7 +173,7 @@ export function genericSet<T extends keyof ConfigSchemas.Config>(
     return false;
   }
 
-  if (metadata.overrideConfig) {
+  if (!nosave && metadata.overrideConfig) {
     const targetConfig = metadata.overrideConfig({
       value,
       currentConfig: config,


### PR DESCRIPTION
workaround for the config loading problem
- do not apply overrideConfig on config.apply (nosave=true)
- do update overrideConfig on the server based on nosave

or to restore the old behaviour we might have to

- remove the configOverride from quoteLength, it was commented out before 
- change the order of config-metadata to this order https://github.com/monkeytypegame/monkeytype/blob/52548fe76fdef2182da15cad7daf295e861c6f6f/frontend/src/ts/config.ts#L1533