### PR TITLE
fix(funbox): fix animations for choo_choo and earthquake funboxes in custom mode (@ShizukoV)

### DIFF
--- a/frontend/static/funbox/choo_choo.css
+++ b/frontend/static/funbox/choo_choo.css
@@ -2,17 +2,15 @@
   0% {
     transform: rotateZ(0deg);
   }
-
   50% {
     transform: rotateZ(180deg);
   }
-
   100% {
     transform: rotateZ(360deg);
   }
 }
 
-#words {
-  --correct-letter-animation: choochoo 2s infinite linear;
-  --untyped-letter-animation: choochoo 2s infinite linear;
+#words letter {
+  animation: choochoo 2s infinite linear !important;
+  display: inline-block !important;
 }

--- a/frontend/static/funbox/earthquake.css
+++ b/frontend/static/funbox/earthquake.css
@@ -34,9 +34,7 @@
   }
 }
 
-#words {
-  --correct-letter-animation: shake_dat_ass 0.25s infinite linear;
-  --untyped-letter-animation: shake_dat_ass 0.25s infinite linear;
-  --incorrect-letter-animation: shake_dat_ass 0.25s infinite linear;
-  --extra-letter-animation: shake_dat_ass 0.25s infinite linear;
+#words letter {
+  animation: shake_dat_ass 0.25s infinite linear !important;
+  display: inline-block !important;
 }


### PR DESCRIPTION
Fixed an issue where the `choo_choo` and `earthquake` funboxes did not "work" in custom mode.

Previously, these funboxes did not "work" in custom mode. When they were turned on, *no animations were played*. This change allows the animations to run regardless of the mode, so users can now experience the funboxes in custom mode as well. This change also makes sure they work on the other modes.

### Here is a video example of the bugs and the new changes in action:

[![funboxesFixedVideo](https://img.youtube.com/vi/oF1zuqWGYnQ/0.jpg)](https://www.youtube.com/watch?v=oF1zuqWGYnQ)
