### PR TITLE
docs(SELF_HOSTING.md): add Firebase domain whitelisting instructions (@tobilobasalawu)

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -52,6 +52,10 @@ Stop the running docker containers using `docker compose down` before making any
   - open the [firebase console](https://console.firebase.google.com/) and open your project
   - go to `Authentication > Sign-in method`  
   - enable `Email/Password` and save
+- whitelist your domain
+  - In the Firebase console, go to `Authentication > Sign-in method`
+  - Scroll to `Authorized domains`
+  - Click `Add domain` and enter the domain where you’ll host the Monkeytype frontend (e.g. `localhost`)
 - generate service account
   - go to your project settings by clicking the `⚙` icon in the sidebar, then `Project settings`
   - navigate to the `Service accounts` tab


### PR DESCRIPTION
### Description

Improved the `SELF_HOSTING.md` documentation by adding clear instructions for whitelisting domains in Firebase Authentication.

#### Changes:
- Explained the purpose of Firebase's authorized domains
- Provided a step-by-step guide on how to whitelist your domain(s)

---

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

---

###  Issue Reference

Closes [#6809](https://github.com/monkeytypegame/monkeytype/issues/6809)