### PR TITLE
fix(notifications): remove old notifications when count is too high (@amandevelops)

### DIFF
--- a/frontend/src/ts/elements/notifications.ts
+++ b/frontend/src/ts/elements/notifications.ts
@@ -265,6 +265,14 @@ function updateClearAllButton(): void {
   }
 }
 
+function removeOldNotificaation(): void {
+  if (visibleStickyNotifications >= 4) {
+    const oldNotifications = id - visibleStickyNotifications;
+    $(`#notificationCenter .notif[id='${oldNotifications}']`).remove();
+    visibleStickyNotifications--;
+  }
+}
+
 export type AddNotificationOptions = {
   important?: boolean;
   duration?: number;
@@ -292,6 +300,8 @@ export function add(
     options.closeCallback,
     options.allowHTML
   ).show();
+
+  removeOldNotificaation();
 }
 
 export function addBanner(

--- a/frontend/src/ts/elements/notifications.ts
+++ b/frontend/src/ts/elements/notifications.ts
@@ -265,7 +265,8 @@ function updateClearAllButton(): void {
   }
 }
 
-function removeOldNotificaation(): void {
+function removeOldNotification(): void {
+  console.log(visibleStickyNotifications, id);
   if (visibleStickyNotifications >= 4) {
     const oldNotifications = id - visibleStickyNotifications;
     $(`#notificationCenter .notif[id='${oldNotifications}']`).remove();
@@ -301,7 +302,7 @@ export function add(
     options.allowHTML
   ).show();
 
-  removeOldNotificaation();
+  removeOldNotification();
 }
 
 export function addBanner(


### PR DESCRIPTION
### Description

This PR fixes the screen overflow caused by too many `visibleStickyNotifications`. If `visibleStickyNotifications` goes over 4, the oldest ones will be removed automatically.

### Checks

- [X] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [X] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.