### PR TITLE
fix: font file type check for better browser compatibility (@byseif21)

### DIFF
--- a/frontend/src/ts/elements/settings/custom-font-picker.ts
+++ b/frontend/src/ts/elements/settings/custom-font-picker.ts
@@ -52,7 +52,10 @@ uploadContainerEl
     }
 
     // check type
-    if (!file.type.match(/font\/(woff|woff2|ttf|otf)/)) {
+    if (
+      !file.type.match(/font\/(woff|woff2|ttf|otf)/) &&
+      !file.name.match(/\.(woff|woff2|ttf|otf)$/i)
+    ) {
       Notifications.add(
         "Unsupported font format, must be woff, woff2, ttf or otf.",
         0


### PR DESCRIPTION
### Description

* browsers don't provide accurate MIME types for font files  , I couldn't even reuse the site fonts as local fonts. 
* Validation now checks both MIME type and file extension to ensure valid fonts aren't mistakenly rejected.