### PR TITLE
feat: added catppuccin_latte theme (@neilsmahajan)

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -1114,6 +1114,12 @@ export const themes: Record<ThemeName, Omit<Theme, "name">> = {
     subColor: "#5b578e",
     textColor: "#f4e0c9",
   },
+  catppuccin_latte: {
+    bgColor: "#ejf1f5",
+    mainColor: "#8839ef",
+    subColor: "#8c8fa1",
+    textColor: "#4c4f69",
+  },
 };
 
 export const ThemesList: Theme[] = Object.keys(themes)

--- a/frontend/static/themes/catppuccin_latte.css
+++ b/frontend/static/themes/catppuccin_latte.css
@@ -1,0 +1,12 @@
+:root {
+  --bg-color: #ejf1f5;
+  --caret-color: #dc8a78;
+  --main-color: #8839ef;
+  --sub-color: #8c8fa1;
+  --sub-alt-color: #e6e9ef;
+  --text-color: #4c4f69;
+  --error-color: #d20f39;
+  --error-extra-color: #e64553;
+  --colorful-error-color: #d20f39;
+  --colorful-error-extra-color: #e64553;
+}

--- a/packages/schemas/src/themes.ts
+++ b/packages/schemas/src/themes.ts
@@ -27,6 +27,7 @@ export const ThemeNameSchema = z.enum(
     "camping",
     "carbon",
     "catppuccin",
+    "catppuccin_latte",
     "chaos_theory",
     "cheesecake",
     "cherry_blossom",


### PR DESCRIPTION
### Description

I added the `catpuccin latte` theme with the exact CSS from https://github.com/catppuccin/monkeytype for the preset theme. I want to be able to use `catpuccin latte` when my system is in light mode and `catpuccin` (mocha) when my system is in dark mode. I cannot do this with a custom theme. I tested with `pnpm run dev`.



### Checks

- [x] Adding a theme?
  - Make sure to follow the [themes documentation](https://github.com/monkeytypegame/monkeytype/blob/master/docs/THEMES.md)
  - [x] Add theme to `packages/schemas/src/themes.ts`
  - [x] Add theme to `frontend/src/ts/constants/themes.ts`
  - [x] Add theme css file to `frontend/static/themes`
  - [x] Add some screenshot of the theme, especially with different test settings (colorful, flip colors) to your pull request  

- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.
<img width="1898" height="915" alt="Screenshot 2025-08-07 at 5 46 35 PM" src="https://github.com/user-attachments/assets/448b3f07-f899-4a6e-9d0e-4ade2d33efa0" />
<img width="1894" height="909" alt="Screenshot 2025-08-07 at 5 47 25 PM" src="https://github.com/user-attachments/assets/8f377846-9ca4-420a-a411-a6dc68c62c0e" />


Closes #

**Note:** In the screenshots I provided, I wasn't able to see the `tab + enter` text or the `esc or cmd + shift + p` text. I am not sure what the issue is or how to fix it. Please tell me if there are some other CSS stylings I should change as this issue does not occur when I use the custom styling from https://github.com/catppuccin/monkeytype?tab=readme-ov-file. 


(@neilsmahajan)