### PR TITLE
feat: add defensive DOM checks to result stats rendering (@rishabpremish)

### DIFF
--- a/frontend/src/ts/test/result.ts
+++ b/frontend/src/ts/test/result.ts
@@ -233,17 +233,29 @@ function updateWpmAndAcc(): void {
     inf = true;
   }
 
-  $("#result .stats .wpm .top .text").text(Config.typingSpeedUnit);
-
-  if (inf) {
-    $("#result .stats .wpm .bottom").text("Infinite");
-  } else {
-    $("#result .stats .wpm .bottom").text(Format.typingSpeed(result.wpm));
+  const $wpmTopText = $("#result .stats .wpm .top .text");
+  if ($wpmTopText.length) {
+    $wpmTopText.text(Config.typingSpeedUnit);
   }
-  $("#result .stats .raw .bottom").text(Format.typingSpeed(result.rawWpm));
-  $("#result .stats .acc .bottom").text(
-    result.acc === 100 ? "100%" : Format.accuracy(result.acc)
-  );
+
+  const $wpmBottom = $("#result .stats .wpm .bottom");
+  if ($wpmBottom.length) {
+    if (inf) {
+      $wpmBottom.text("Infinite");
+    } else {
+      $wpmBottom.text(Format.typingSpeed(result.wpm));
+    }
+  }
+
+  const $rawBottom = $("#result .stats .raw .bottom");
+  if ($rawBottom.length) {
+    $rawBottom.text(Format.typingSpeed(result.rawWpm));
+  }
+
+  const $accBottom = $("#result .stats .acc .bottom");
+  if ($accBottom.length) {
+    $accBottom.text(result.acc === 100 ? "100%" : Format.accuracy(result.acc));
+  }
 
   if (Config.alwaysShowDecimalPlaces) {
     if (Config.typingSpeedUnit !== "wpm") {

--- a/frontend/src/ts/test/result.ts
+++ b/frontend/src/ts/test/result.ts
@@ -233,56 +233,74 @@ function updateWpmAndAcc(): void {
     inf = true;
   }
 
-  const $wpmTopText = $("#result .stats .wpm .top .text");
-  if ($wpmTopText.length) {
-    $wpmTopText.text(Config.typingSpeedUnit);
+  const wpmTopText = document.querySelector("#result .stats .wpm .top .text");
+  if (wpmTopText) {
+    wpmTopText.textContent = Config.typingSpeedUnit;
   }
 
-  const $wpmBottom = $("#result .stats .wpm .bottom");
-  if ($wpmBottom.length) {
+  const wpmBottom = document.querySelector("#result .stats .wpm .bottom");
+  if (wpmBottom) {
     if (inf) {
-      $wpmBottom.text("Infinite");
+      wpmBottom.textContent = "Infinite";
     } else {
-      $wpmBottom.text(Format.typingSpeed(result.wpm));
+      wpmBottom.textContent = Format.typingSpeed(result.wpm);
     }
   }
 
-  const $rawBottom = $("#result .stats .raw .bottom");
-  if ($rawBottom.length) {
-    $rawBottom.text(Format.typingSpeed(result.rawWpm));
+  const rawBottom = document.querySelector("#result .stats .raw .bottom");
+  if (rawBottom) {
+    rawBottom.textContent = Format.typingSpeed(result.rawWpm);
   }
 
-  const $accBottom = $("#result .stats .acc .bottom");
-  if ($accBottom.length) {
-    $accBottom.text(result.acc === 100 ? "100%" : Format.accuracy(result.acc));
+  const accBottom = document.querySelector("#result .stats .acc .bottom");
+  if (accBottom) {
+    accBottom.textContent =
+      result.acc === 100 ? "100%" : Format.accuracy(result.acc);
   }
 
   if (Config.alwaysShowDecimalPlaces) {
     if (Config.typingSpeedUnit !== "wpm") {
-      $("#result .stats .wpm .bottom").attr(
-        "aria-label",
-        result.wpm.toFixed(2) + " wpm"
-      );
-      $("#result .stats .raw .bottom").attr(
-        "aria-label",
-        result.rawWpm.toFixed(2) + " wpm"
-      );
+      const wpmBottomEl = document.querySelector("#result .stats .wpm .bottom");
+      if (wpmBottomEl) {
+        wpmBottomEl.setAttribute("aria-label", result.wpm.toFixed(2) + " wpm");
+      }
+      const rawBottomEl = document.querySelector("#result .stats .raw .bottom");
+      if (rawBottomEl) {
+        rawBottomEl.setAttribute(
+          "aria-label",
+          result.rawWpm.toFixed(2) + " wpm"
+        );
+      }
     } else {
-      $("#result .stats .wpm .bottom").removeAttr("aria-label");
-      $("#result .stats .raw .bottom").removeAttr("aria-label");
+      const wpmBottomEl = document.querySelector("#result .stats .wpm .bottom");
+      if (wpmBottomEl) {
+        wpmBottomEl.removeAttribute("aria-label");
+      }
+      const rawBottomEl = document.querySelector("#result .stats .raw .bottom");
+      if (rawBottomEl) {
+        rawBottomEl.removeAttribute("aria-label");
+      }
     }
 
     let time = Numbers.roundTo2(result.testDuration).toFixed(2) + "s";
     if (result.testDuration > 61) {
       time = DateTime.secondsToString(Numbers.roundTo2(result.testDuration));
     }
-    $("#result .stats .time .bottom .text").text(time);
+    const timeBottomText = document.querySelector(
+      "#result .stats .time .bottom .text"
+    );
+    if (timeBottomText) {
+      timeBottomText.textContent = time;
+    }
     // $("#result .stats .acc .bottom").removeAttr("aria-label");
 
-    $("#result .stats .acc .bottom").attr(
-      "aria-label",
-      `${TestInput.accuracy.correct} correct\n${TestInput.accuracy.incorrect} incorrect`
-    );
+    const accBottomEl = document.querySelector("#result .stats .acc .bottom");
+    if (accBottomEl) {
+      accBottomEl.setAttribute(
+        "aria-label",
+        `${TestInput.accuracy.correct} correct\n${TestInput.accuracy.incorrect} incorrect`
+      );
+    }
   } else {
     //not showing decimal places
     const decimalsAndSuffix = {
@@ -297,11 +315,18 @@ function updateWpmAndAcc(): void {
       rawWpmHover += " (" + result.rawWpm.toFixed(2) + " wpm)";
     }
 
-    $("#result .stats .wpm .bottom").attr("aria-label", wpmHover);
-    $("#result .stats .raw .bottom").attr("aria-label", rawWpmHover);
+    const wpmBottomEl = document.querySelector("#result .stats .wpm .bottom");
+    if (wpmBottomEl) {
+      wpmBottomEl.setAttribute("aria-label", wpmHover);
+    }
+    const rawBottomEl = document.querySelector("#result .stats .raw .bottom");
+    if (rawBottomEl) {
+      rawBottomEl.setAttribute("aria-label", rawWpmHover);
+    }
 
-    $("#result .stats .acc .bottom")
-      .attr(
+    const accBottomEl = document.querySelector("#result .stats .acc .bottom");
+    if (accBottomEl) {
+      accBottomEl.setAttribute(
         "aria-label",
         `${
           result.acc === 100
@@ -310,8 +335,9 @@ function updateWpmAndAcc(): void {
         }\n${TestInput.accuracy.correct} correct\n${
           TestInput.accuracy.incorrect
         } incorrect`
-      )
-      .attr("data-balloon-break", "");
+      );
+      accBottomEl.setAttribute("data-balloon-break", "");
+    }
   }
 }
 


### PR DESCRIPTION
This pull request refactors the way result statistics are updated in the UI to improve robustness and prevent errors when elements are missing from the DOM. The main changes involve checking for the existence of DOM elements before updating their text content.

Improvements to DOM manipulation and error prevention:

* Updated the `updateWpmAndAcc` function in `frontend/src/ts/test/result.ts` to check for the existence of each relevant DOM element (`.wpm .top .text`, `.wpm .bottom`, `.raw .bottom`, `.acc .bottom`) before attempting to update its text, preventing potential runtime errors if elements are missing.### Description

<!-- Please describe the change(s) made in your PR -->

### Checks
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

<!-- label(optional scope): pull request title (@your_github_username) -->

<!-- I know I know they seem boring but please do them, they help us and you will find out it also helps you.-->

Closes #
(@rishabpremish)
<!-- the issue(s) your PR resolves if any (delete if that is not the case) -->
<!-- please also reference any issues and or PRs related to your pull request -->
<!-- Also remove it if you are not following any issues. -->

<!-- pro tip: you can mention an issue, PR, or discussion on GitHub by referencing its hash number e.g: [#1234](https://github.com/monkeytypegame/monkeytype/pull/1234) -->

<!-- pro tip: you can press . (dot or period) in the code tab of any GitHub repo to get access to GitHub's VS Code web editor Enjoy! :) -->
