### PR TITLE
fix(test): immediately reposition caret and tape on tapeMargin change (@byseif21)

### DIFF
--- a/frontend/src/ts/config-metadata.ts
+++ b/frontend/src/ts/config-metadata.ts
@@ -512,6 +512,7 @@ export const configMetadata: ConfigMetadataObject = {
   tapeMargin: {
     icon: "fa-tape",
     displayString: "tape margin",
+    triggerResize: true,
     changeRequiresRestart: false,
   },
   smoothLineScroll: {


### PR DESCRIPTION
### Description

changing `tapeMargin` mid-test didn’t move the caret until typing resumed because no layout update was triggered for this config.
