### PR TITLE
fix(zen-mode): restore input history and watch replay (@byseif21)

### DIFF
--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -904,6 +904,12 @@ export async function finish(difficultyFailed = false): Promise<void> {
     Replay.replayGetWordsList(TestInput.input.getHistory());
   }
 
+  // in zen mode, ensure the replay words list reflects the typed input history
+  // even if the current input was empty at finish (e.g., after submitting a word).
+  if (Config.mode === "zen") {
+    Replay.replayGetWordsList(TestInput.input.getHistory());
+  }
+
   TestInput.forceKeyup(now); //this ensures that the last keypress(es) are registered
 
   const endAfkSeconds = (now - TestInput.keypressTimings.spacing.last) / 1000;

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1297,7 +1297,7 @@ async function loadWordsHistory(): Promise<boolean> {
       }
 
       const inputCharacters = Strings.splitIntoCharacters(input);
-      const wordCharacters = Strings.splitIntoCharacters(word);
+      const wordCharacters = Strings.splitIntoCharacters(word ?? "");
       const correctedCharacters = Strings.splitIntoCharacters(corrected ?? "");
 
       let loop;


### PR DESCRIPTION
### Description

fix:
* The result “input history” panel sometimes rendered nothing because the renderer attempted to split an undefined target word.
added split word ?? "" to handle missing target words in zen.

* The replay view in zen mode could be empty if the last word was just submitted (so input.current was empty at finish), and the replay words list never got updated.
