### PR TITLE
fix: mouseover labels not working on  static pages (@fehmer)

### DIFF
--- a/frontend/src/email-handler.html
+++ b/frontend/src/email-handler.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Email Handler | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
-    <link rel="stylesheet" href="css/balloon.min.css" />
+    <style>
+      @import "balloon-css/balloon.min.css";
+    </style>
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />
     <link rel="shortcut icon" href="images/fav.png" />

--- a/frontend/src/privacy-policy.html
+++ b/frontend/src/privacy-policy.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Privacy Policy | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
-    <link rel="stylesheet" href="css/balloon.min.css" />
+    <style>
+      @import "balloon-css/balloon.min.css";
+    </style>
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />
     <link rel="shortcut icon" href="images/fav.png" />

--- a/frontend/src/security-policy.html
+++ b/frontend/src/security-policy.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Security Policy | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
-    <link rel="stylesheet" href="css/balloon.min.css" />
+    <style>
+      @import "balloon-css/balloon.min.css";
+    </style>
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />
     <link rel="shortcut icon" href="images/fav.png" />

--- a/frontend/src/terms-of-service.html
+++ b/frontend/src/terms-of-service.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Terms of Service | Monkeytype</title>
     <!-- <link rel="stylesheet" href="css/fa.css" /> -->
-    <link rel="stylesheet" href="css/balloon.min.css" />
+    <style>
+      @import "balloon-css/balloon.min.css";
+    </style>
     <link rel="stylesheet" href="themes/serika_dark.css" id="currentTheme" />
     <link id="favicon" rel="shortcut icon" href="images/fav.png" />
     <link rel="shortcut icon" href="images/fav.png" />


### PR DESCRIPTION
import of balloon.min.css was broken for static html files since we moved it to vendor.css
