### PR TITLE
fix(theme): problems with theme preview (@fehmer)

### DIFF
--- a/frontend/src/ts/commandline/commandline.ts
+++ b/frontend/src/ts/commandline/commandline.ts
@@ -556,7 +556,7 @@ async function updateActiveCommand(): Promise<void> {
   activeCommand = command ?? null;
   if (element === undefined || command === undefined) {
     clearFontPreview();
-    void ThemeController.clearPreview();
+    void ThemeController.clearPreview(false);
     addCommandlineBackground();
     return;
   }
@@ -567,7 +567,7 @@ async function updateActiveCommand(): Promise<void> {
   if (/changeTheme.+/gi.test(command.id)) {
     removeCommandlineBackground();
   } else {
-    void ThemeController.clearPreview();
+    void ThemeController.clearPreview(false);
     addCommandlineBackground();
   }
 

--- a/frontend/src/ts/controllers/theme-controller.ts
+++ b/frontend/src/ts/controllers/theme-controller.ts
@@ -154,7 +154,8 @@ async function apply(
     customColorsOverride,
     isPreview
   );
-  if (!Config.customTheme) {
+
+  if (themeName !== "custom") {
     clearCustomTheme();
   }
   const name = customColorsOverride ? "custom" : themeName;


### PR DESCRIPTION
1. when a custom theme is active preview of regular theme was not applied, introduced with https://github.com/monkeytypegame/monkeytype/commit/fdead53ba90be76406dab1e6810e9b252d7451bf
2. when custom theme is active previewing other custom themes set the color to the active custom theme first, then the selected one causing flashing

To reproduce:

1. preview of regular theme not working 
- create a custom theme with black background, activate it
- open commandline to preview a regular theme

2. custom theme colors get set multiple times
- create a custom theme with white background called white and activate it
- create to custom themes with black background called black1 and black2
- switch preview between black1 and black2

