### PR TITLE
refactor: loading page rework (@miodec)

### DIFF
--- a/frontend/src/html/pages/account.html
+++ b/frontend/src/html/pages/account.html
@@ -1,14 +1,9 @@
 <div class="page pageAccount hidden full-width" id="pageAccount">
-  <div class="preloader hidden">
+  <div class="error hidden content-grid">
     <div class="icon">
-      <i class="fas fa-fw fa-spin fa-circle-notch"></i>
+      <i class="fas fa-fw fa-times"></i>
     </div>
-    <div class="barWrapper hidden">
-      <div class="bar">
-        <div class="fill"></div>
-      </div>
-      <div class="text">‎</div>
-    </div>
+    <div class="text">Error</div>
   </div>
   <div class="content full-width content-grid">
     <div class="profile">

--- a/frontend/src/styles/account.scss
+++ b/frontend/src/styles/account.scss
@@ -1,6 +1,21 @@
 .pageAccount {
   height: 100%;
 
+  .error {
+    display: grid;
+    place-items: center;
+    align-content: center;
+    height: 100%;
+    .icon {
+      font-size: 2rem;
+      color: var(--error-color);
+    }
+    .text {
+      font-size: 1rem;
+      text-align: center;
+    }
+  }
+
   .accountVerificatinNotice {
     background: var(--bg-color);
     border-radius: var(--roundness);
@@ -21,13 +36,6 @@
     button {
       padding: 1rem;
     }
-  }
-
-  .preloader {
-    align-self: center;
-    text-align: center;
-    align-items: center;
-    height: 100%;
   }
 
   .content {

--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -208,46 +208,6 @@ key {
   align-items: center;
 }
 
-.pageLoading,
-.pageAccount {
-  .preloader {
-    text-align: center;
-    justify-self: center;
-    display: grid;
-    .barWrapper {
-      justify-content: center;
-      display: grid;
-      gap: 1rem;
-      grid-row: 1;
-      grid-column: 1;
-      .text {
-        height: 1.25em;
-      }
-      .bar {
-        width: 20rem;
-        height: 0.5rem;
-        background: var(--sub-alt-color);
-        border-radius: var(--roundness);
-        justify-self: center;
-        .fill {
-          height: 100%;
-          width: 0%;
-          background: var(--main-color);
-          border-radius: var(--roundness);
-          // transition: 1s;
-        }
-      }
-    }
-    .icon {
-      grid-row: 1;
-      grid-column: 1;
-      font-size: 2rem;
-      color: var(--main-color);
-      margin-bottom: 1rem;
-    }
-  }
-}
-
 .devIndicator {
   position: fixed;
   font-size: 3rem;

--- a/frontend/src/styles/core.scss
+++ b/frontend/src/styles/core.scss
@@ -220,11 +220,15 @@ key {
       gap: 1rem;
       grid-row: 1;
       grid-column: 1;
+      .text {
+        height: 1.25em;
+      }
       .bar {
         width: 20rem;
         height: 0.5rem;
         background: var(--sub-alt-color);
         border-radius: var(--roundness);
+        justify-self: center;
         .fill {
           height: 100%;
           width: 0%;

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -1,4 +1,5 @@
 @import "buttons", "fonts", "404", "ads", "about", "account", "animations",
   "banners", "caret", "commandline", "core", "footer", "inputs", "keymap",
   "login", "monkey", "nav", "notifications", "popups", "profile", "scroll",
-  "settings", "account-settings", "leaderboards", "test", "media-queries";
+  "settings", "account-settings", "leaderboards", "test", "loading",
+  "media-queries";

--- a/frontend/src/styles/loading.scss
+++ b/frontend/src/styles/loading.scss
@@ -1,0 +1,38 @@
+.pageLoading {
+  .preloader {
+    text-align: center;
+    justify-self: center;
+    display: grid;
+    .barWrapper {
+      justify-content: center;
+      display: grid;
+      gap: 1rem;
+      grid-row: 1;
+      grid-column: 1;
+      .text {
+        height: 1.25em;
+      }
+      .bar {
+        width: 20rem;
+        height: 0.5rem;
+        background: var(--sub-alt-color);
+        border-radius: var(--roundness);
+        justify-self: center;
+        .fill {
+          height: 100%;
+          width: 0%;
+          background: var(--main-color);
+          border-radius: var(--roundness);
+          // transition: 1s;
+        }
+      }
+    }
+    .icon {
+      grid-row: 1;
+      grid-column: 1;
+      font-size: 2rem;
+      color: var(--main-color);
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/frontend/src/ts/controllers/account-controller.ts
+++ b/frontend/src/ts/controllers/account-controller.ts
@@ -185,7 +185,7 @@ export async function onAuthStateChanged(
   let keyframes = [
     {
       percentage: 90,
-      duration: 2000,
+      duration: 1000,
       text: "Downloading user data...",
     },
   ];

--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -43,6 +43,7 @@ import {
 } from "../test/funbox/list";
 import { tryCatchSync } from "@monkeytype/util/trycatch";
 import { canQuickRestart } from "../utils/quick-restart";
+import * as PageTransition from "../states/page-transition";
 
 let dontInsertSpace = false;
 let correctShiftUsed = true;
@@ -899,8 +900,8 @@ $("#wordsInput").on("keydown", (event) => {
 let lastBailoutAttempt = -1;
 
 $(document).on("keydown", async (event) => {
-  if (ActivePage.get() === "loading") {
-    console.debug("Ignoring keydown event on loading page.");
+  if (PageTransition.get()) {
+    console.debug("Ignoring keydown during page transition.");
     return;
   }
 

--- a/frontend/src/ts/controllers/page-controller.ts
+++ b/frontend/src/ts/controllers/page-controller.ts
@@ -146,7 +146,6 @@ export async function change(
 
   //between
   updateTitle(nextPage);
-  Focus.set(false);
   ActivePage.set(nextPage.id);
   updateOpenGraphUrl();
 
@@ -195,6 +194,8 @@ export async function change(
     await pages.loading.afterHide();
     pages.loading.element.addClass("hidden");
   }
+
+  Focus.set(false);
 
   //next page
   await nextPage?.beforeShow({

--- a/frontend/src/ts/controllers/page-controller.ts
+++ b/frontend/src/ts/controllers/page-controller.ts
@@ -176,7 +176,7 @@ export async function change(
 
     if (loadingOptions.barKeyframes !== undefined) {
       await getLoadingPromiseWithBarKeyframes(loadingOptions);
-      await PageLoading.updateBar(100, 0);
+      void PageLoading.updateBar(100, 125);
       PageLoading.updateText("Done");
     } else {
       await loadingOptions.promise();

--- a/frontend/src/ts/controllers/route-controller.ts
+++ b/frontend/src/ts/controllers/route-controller.ts
@@ -5,6 +5,7 @@ import { isAuthAvailable, isAuthenticated } from "../firebase";
 import { isFunboxActive } from "../test/funbox/list";
 import * as TestState from "../test/test-state";
 import * as Notifications from "../elements/notifications";
+import { LoadingOptions } from "../pages/page";
 
 //source: https://www.youtube.com/watch?v=OstALBk-jTc
 // https://www.youtube.com/watch?v=OstALBk-jTc
@@ -13,6 +14,7 @@ import * as Notifications from "../elements/notifications";
 type NavigateOptions = {
   empty?: boolean;
   data?: unknown;
+  overrideLoadingOptions?: LoadingOptions;
 };
 
 function pathToRegex(path: string): RegExp {
@@ -52,89 +54,86 @@ const route404: Route = {
 const routes: Route[] = [
   {
     path: "/",
-    load: (): void => {
-      void PageController.change("test");
+    load: (_params, options): void => {
+      void PageController.change("test", options);
     },
   },
   {
     path: "/verify",
-    load: (): void => {
-      void PageController.change("test");
+    load: (_params, options): void => {
+      void PageController.change("test", options);
     },
   },
   {
     path: "/leaderboards",
-    load: (): void => {
-      void PageController.change("leaderboards");
+    load: (_params, options): void => {
+      void PageController.change("leaderboards", options);
     },
   },
   {
     path: "/about",
-    load: (): void => {
-      void PageController.change("about");
+    load: (_params, options): void => {
+      void PageController.change("about", options);
     },
   },
   {
     path: "/settings",
-    load: (): void => {
-      void PageController.change("settings");
+    load: (_params, options): void => {
+      void PageController.change("settings", options);
     },
   },
   {
     path: "/login",
-    load: (): void => {
+    load: (_params, options): void => {
       if (!isAuthAvailable()) {
-        navigate("/");
+        navigate("/", options);
         return;
       }
 
       if (isAuthenticated()) {
-        navigate("/account");
+        navigate("/account", options);
         return;
       }
-      void PageController.change("login");
+      void PageController.change("login", options);
     },
   },
   {
     path: "/account",
     load: (_params, options): void => {
       if (!isAuthAvailable()) {
-        navigate("/");
+        navigate("/", options);
         return;
       }
 
-      void PageController.change("account", {
-        data: options.data,
-      });
+      void PageController.change("account", options);
     },
   },
   {
     path: "/account-settings",
     load: (_params, options): void => {
       if (!isAuthAvailable()) {
-        navigate("/");
+        navigate("/", options);
         return;
       }
 
       if (!isAuthenticated()) {
-        navigate("/login");
+        navigate("/login", options);
         return;
       }
-      void PageController.change("accountSettings", {
-        data: options.data,
-      });
+      void PageController.change("accountSettings", options);
     },
   },
   {
     path: "/profile",
-    load: (_params): void => {
-      void PageController.change("profileSearch");
+    load: (_params, options): void => {
+      void PageController.change("profileSearch", options);
     },
   },
   {
     path: "/profile/:uidOrName",
     load: (params, options): void => {
       void PageController.change("profile", {
+        ...options,
         force: true,
         params: {
           uidOrName: params["uidOrName"] as string,

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -1,6 +1,5 @@
 import Ape from "./ape";
 import * as Notifications from "./elements/notifications";
-import * as LoadingPage from "./pages/loading";
 import { isAuthenticated } from "./firebase";
 import * as ConnectionState from "./states/connection";
 import { lastElementFromArray } from "./utils/arrays";
@@ -80,12 +79,6 @@ export async function initSnapshot(): Promise<Snapshot | false> {
   const snap = getDefaultSnapshot();
   try {
     if (!isAuthenticated()) return false;
-    // if (ActivePage.get() === "loading") {
-    //   LoadingPage.updateBar(22.5);
-    // } else {
-    //   LoadingPage.updateBar(16);
-    // }
-    // LoadingPage.updateText("Downloading user...");
 
     const [userResponse, configResponse, presetsResponse] = await Promise.all([
       Ape.users.get(),
@@ -183,12 +176,7 @@ export async function initSnapshot(): Promise<Snapshot | false> {
     if (userData.lbMemory !== undefined) {
       snap.lbMemory = userData.lbMemory;
     }
-    // if (ActivePage.get() === "loading") {
-    //   LoadingPage.updateBar(45);
-    // } else {
-    //   LoadingPage.updateBar(32);
-    // }
-    // LoadingPage.updateText("Downloading config...");
+
     if (configData === undefined || configData === null) {
       snap.config = {
         ...getDefaultConfig(),
@@ -196,12 +184,7 @@ export async function initSnapshot(): Promise<Snapshot | false> {
     } else {
       snap.config = migrateConfig(configData);
     }
-    // if (ActivePage.get() === "loading") {
-    //   LoadingPage.updateBar(67.5);
-    // } else {
-    //   LoadingPage.updateBar(48);
-    // }
-    // LoadingPage.updateText("Downloading tags...");
+
     snap.customThemes = userData.customThemes ?? [];
 
     // const userDataTags: MonkeyTypes.UserTagWithDisplay[] = userData.tags ?? [];
@@ -238,13 +221,6 @@ export async function initSnapshot(): Promise<Snapshot | false> {
         return 0;
       }
     });
-
-    // if (ActivePage.get() === "loading") {
-    //   LoadingPage.updateBar(90);
-    // } else {
-    //   LoadingPage.updateBar(64);
-    // }
-    // LoadingPage.updateText("Downloading presets...");
 
     if (presetsData !== undefined && presetsData !== null) {
       const presetsWithDisplay = presetsData.map((preset) => {
@@ -289,11 +265,6 @@ export async function getUserResults(offset?: number): Promise<boolean> {
 
   if (!ConnectionState.get()) {
     return false;
-  }
-
-  if (dbSnapshot.results === undefined) {
-    LoadingPage.updateText("Downloading results...");
-    LoadingPage.updateBar(90);
   }
 
   const response = await Ape.results.get({ query: { offset } });

--- a/frontend/src/ts/pages/about.ts
+++ b/frontend/src/ts/pages/about.ts
@@ -201,6 +201,19 @@ export const page = new Page({
   id: "about",
   element: $(".page.pageAbout"),
   path: "/about",
+  loading: {
+    shouldLoad: () => true,
+    promise: async () => {
+      return Misc.sleep(3000);
+    },
+    barKeyframes: [
+      { percentage: 25, duration: 950, text: "Loading contributors..." },
+      { percentage: 50, duration: 950, text: "Loading supporters..." },
+      { percentage: 75, duration: 950, text: "Loading global stats..." },
+      { percentage: 90, duration: 950, text: "Loading speed histogram..." },
+      { percentage: 90, duration: 2000, text: "Loading speed histogram..." },
+    ],
+  },
   afterHide: async (): Promise<void> => {
     reset();
     Skeleton.remove("pageAbout");

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -1378,7 +1378,7 @@ export const page = new Page({
       snapshot !== undefined ? new Date(snapshot.addedAt).getFullYear() : 2020
     );
 
-    void update().then(() => {
+    await update().then(() => {
       void updateChartColors();
       $(".pageAccount .content .accountVerificatinNotice").remove();
       if (getAuthenticatedUser()?.emailVerified === false) {

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -966,19 +966,8 @@ async function fillContent(): Promise<void> {
   ChartController.accountActivity.update();
   ChartController.accountHistogram.update();
   Focus.set(false);
-  void Misc.swapElements(
-    $(".pageAccount .preloader"),
-    $(".pageAccount .content"),
-    250,
-    async () => {
-      $(".page.pageAccount").css("height", "unset"); //weird safari fix
-    },
-    async () => {
-      setTimeout(() => {
-        Profile.updateNameFontSize("account");
-      }, 10);
-    }
-  );
+  $(".page.pageAccount").css("height", "unset"); //weird safari fix
+  Profile.updateNameFontSize("account");
 }
 
 export async function downloadResults(offset?: number): Promise<void> {
@@ -997,9 +986,12 @@ export async function downloadResults(offset?: number): Promise<void> {
 }
 
 async function update(): Promise<void> {
-  if (DB.getSnapshot() === null) {
-    Notifications.add(`Missing account data. Please refresh.`, -1);
-    $(".pageAccount .preloader").html("Missing account data. Please refresh.");
+  if (DB.getSnapshot() !== null) {
+    $(".pageAccount .error .text").html(
+      "Looks like your account data didn't download correctly. Please refresh the page.<br>If this error persists, please contact support."
+    );
+    $(".pageAccount .error").removeClass("hidden");
+    $(".pageAccount .content").remove();
   } else {
     await downloadResults();
     try {

--- a/frontend/src/ts/pages/loading.ts
+++ b/frontend/src/ts/pages/loading.ts
@@ -1,42 +1,37 @@
-import * as Misc from "../utils/misc";
 import Page from "./page";
 import * as Skeleton from "../utils/skeleton";
 
-export function updateBar(percentage: number, fast = false): void {
-  const speed = fast ? 100 : 1000;
-  $(".pageLoading .fill, .pageAccount .preloader .fill")
-    .stop(true, fast)
-    .animate(
-      {
-        width: percentage + "%",
-      },
-      speed
-    );
+export async function updateBar(
+  percentage: number,
+  duration: number
+): Promise<void> {
+  return new Promise((resolve) => {
+    $(".pageLoading .fill, .pageAccount .preloader .fill")
+      .stop(true, false)
+      .animate(
+        {
+          width: percentage + "%",
+        },
+        duration,
+        () => {
+          resolve();
+        }
+      );
+  });
 }
 
 export function updateText(text: string): void {
   $(".pageLoading .text, .pageAccount .preloader .text").text(text);
 }
 
+export function showSpinner(): void {
+  $(".pageLoading .preloader .icon").removeClass("hidden");
+  $(".pageLoading .preloader .barWrapper").addClass("hidden");
+}
+
 export async function showBar(): Promise<void> {
-  return new Promise((resolve) => {
-    void Misc.swapElements(
-      $(".pageLoading .preloader .icon"),
-      $(".pageLoading .preloader .barWrapper"),
-      125,
-      async () => {
-        resolve();
-      }
-    );
-    void Misc.swapElements(
-      $(".pageAccount .preloader .icon"),
-      $(".pageAccount .preloader .barWrapper"),
-      125,
-      async () => {
-        resolve();
-      }
-    );
-  });
+  $(".pageLoading .preloader .icon").addClass("hidden");
+  $(".pageLoading .preloader .barWrapper").removeClass("hidden");
 }
 
 export const page = new Page({

--- a/frontend/src/ts/pages/loading.ts
+++ b/frontend/src/ts/pages/loading.ts
@@ -6,7 +6,7 @@ export async function updateBar(
   duration: number
 ): Promise<void> {
   return new Promise((resolve) => {
-    $(".pageLoading .fill, .pageAccount .preloader .fill")
+    $(".pageLoading .fill")
       .stop(true, false)
       .animate(
         {
@@ -21,7 +21,7 @@ export async function updateBar(
 }
 
 export function updateText(text: string): void {
-  $(".pageLoading .text, .pageAccount .preloader .text").text(text);
+  $(".pageLoading .text").text(text);
 }
 
 export function showSpinner(): void {

--- a/frontend/src/ts/pages/page.ts
+++ b/frontend/src/ts/pages/page.ts
@@ -22,11 +22,22 @@ type Options<T> = {
   data?: T;
 };
 
+export type LoadingOptions = {
+  shouldLoad: () => boolean;
+  promise: () => Promise<void>;
+  barKeyframes?: {
+    percentage: number;
+    duration: number;
+    text?: string;
+  }[];
+};
+
 type PageProperties<T> = {
   id: PageName;
   display?: string;
   element: JQuery;
   path: string;
+  loading?: LoadingOptions;
   beforeHide?: () => Promise<void>;
   afterHide?: () => Promise<void>;
   beforeShow?: (options: Options<T>) => Promise<void>;
@@ -41,6 +52,7 @@ export default class Page<T> {
   public display: string | undefined;
   public element: JQuery;
   public pathname: string;
+  public loading: LoadingOptions | undefined;
 
   public beforeHide: () => Promise<void>;
   public afterHide: () => Promise<void>;
@@ -52,6 +64,7 @@ export default class Page<T> {
     this.display = props.display;
     this.element = props.element;
     this.pathname = props.path;
+    this.loading = props.loading;
     this.beforeHide = props.beforeHide ?? empty;
     this.afterHide = props.afterHide ?? empty;
     this._beforeShow = props.beforeShow ?? empty;

--- a/frontend/src/ts/test/focus.ts
+++ b/frontend/src/ts/test/focus.ts
@@ -1,9 +1,9 @@
 import * as Caret from "./caret";
-import * as ActivePage from "../states/active-page";
 import * as LiveSpeed from "./live-speed";
 import * as LiveBurst from "./live-burst";
 import * as LiveAcc from "./live-acc";
 import * as TimerProgress from "./timer-progress";
+import * as PageTransition from "../states/page-transition";
 
 const unfocusPx = 3;
 let state = false;
@@ -56,9 +56,8 @@ export function set(foc: boolean, withCursor = false): void {
 }
 
 $(document).on("mousemove", function (event) {
+  if (PageTransition.get()) return;
   if (!state) return;
-  if (ActivePage.get() === "loading") return;
-  if (ActivePage.get() === "account" && state) return;
   if (
     event.originalEvent &&
     // To avoid mouse/desk vibration from creating a flashy effect, we'll unfocus @ >5px instead of >0px


### PR DESCRIPTION
 - Moved all loading page logic to the page controller. No other module handles text or bar updating. The page controller displays either the spinner or loading bar (depending on the configuration) inbetween the source and target page. Once a promise resolves the page change continues.
 - Pages can now say they require a loading page before opening the page
 - Navigate function call can override that / add a loading page to any page load
 - Simplified account controller flow a lot - only one `navigate` call remains
 - Removed the preloader from the account page which simplifies things aswell
 - Moved loading page styles