### PR TITLE
feat: add hide timer while typing option

### DIFF
--- a/frontend/src/html/popups.html
+++ b/frontend/src/html/popups.html
@@ -803,6 +803,10 @@
     <div class="title">Test duration</div>
     <div class="preview"></div>
     <input value="1" title="test duration" min="0" />
+    <label class="checkbox hideTimerWhileTyping">
+      <input type="checkbox" />
+      Hide timer while typing
+    </label>
     <div class="tip">
       You can use "h" for hours and "m" for minutes, for example "1h30m".
       <br />

--- a/frontend/src/ts/commandline/commandline-metadata.ts
+++ b/frontend/src/ts/commandline/commandline-metadata.ts
@@ -532,6 +532,13 @@ export const commandlineConfigMetadata: CommandlineConfigMetadataObject = {
       alias: () => "timer",
     },
   },
+  hideTimerWhileTyping: {
+    display: "Hide timer while typing...",
+    alias: "timer hide",
+    subgroup: {
+      options: "fromSchema",
+    },
+  },
   highlightMode: {
     subgroup: {
       options: "fromSchema",

--- a/frontend/src/ts/config-metadata.ts
+++ b/frontend/src/ts/config-metadata.ts
@@ -490,6 +490,11 @@ export const configMetadata: ConfigMetadataObject = {
     displayString: "timer opacity",
     changeRequiresRestart: false,
   },
+  hideTimerWhileTyping: {
+    icon: "fa-eye-slash",
+    displayString: "hide timer while typing",
+    changeRequiresRestart: false,
+  },
   highlightMode: {
     icon: "fa-highlighter",
     displayString: "highlight mode",

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -542,6 +542,13 @@ export function setTimerOpacity(
   return genericSet("timerOpacity", opacity, nosave);
 }
 
+export function setHideTimerWhileTyping(
+  hide: boolean,
+  nosave?: boolean
+): boolean {
+  return genericSet("hideTimerWhileTyping", hide, nosave);
+}
+
 //key tips
 export function setKeyTips(keyTips: boolean, nosave?: boolean): boolean {
   return genericSet("showKeyTips", keyTips, nosave);

--- a/frontend/src/ts/constants/default-config.ts
+++ b/frontend/src/ts/constants/default-config.ts
@@ -50,6 +50,7 @@ const obj = {
   randomTheme: "off",
   timerColor: "main",
   timerOpacity: "1",
+  hideTimerWhileTyping: false,
   stopOnError: "off",
   showAllLines: false,
   keymapMode: "off",

--- a/frontend/src/ts/controllers/input-controller.ts
+++ b/frontend/src/ts/controllers/input-controller.ts
@@ -464,6 +464,9 @@ async function handleChar(
     return;
   }
 
+  // Call timer hiding functionality on typing
+  TimerProgress.onTyping();
+
   if (char === "…" && TestWords.words.getCurrent()[charIndex] !== "…") {
     for (let i = 0; i < 3; i++) {
       await handleChar(".", charIndex + i);

--- a/frontend/src/ts/modals/custom-test-duration.ts
+++ b/frontend/src/ts/modals/custom-test-duration.ts
@@ -76,6 +76,20 @@ export function show(showOptions?: ShowOptions): void {
       (
         modalEl.querySelector("input") as HTMLInputElement
       ).value = `${Config.time}`;
+
+      // Set the toggle state based on current config
+      const toggleCheckbox = modalEl.querySelector(
+        ".checkbox.hideTimerWhileTyping input[type='checkbox']"
+      );
+      if (toggleCheckbox !== null) {
+        const configWithNewProp = Config as typeof Config & {
+          hideTimerWhileTyping?: boolean;
+        };
+        (toggleCheckbox as HTMLInputElement).checked = Boolean(
+          configWithNewProp.hideTimerWhileTyping
+        );
+      }
+
       previewDuration();
     },
   });
@@ -90,8 +104,17 @@ function hide(clearChain = false): void {
 function apply(): void {
   const val = parseInput($("#customTestDurationModal input").val() as string);
 
+  // Get the toggle state
+  const hideTimerToggle = $(
+    "#customTestDurationModal .checkbox.hideTimerWhileTyping input[type='checkbox']"
+  ).prop("checked") as boolean;
+
   if (val !== null && !isNaN(val) && val >= 0 && isFinite(val)) {
     UpdateConfig.setTimeConfig(val);
+
+    // Update the hide timer while typing config
+    UpdateConfig.setHideTimerWhileTyping(hideTimerToggle);
+
     ManualRestart.set();
     TestLogic.restart();
     if (val >= 1800) {

--- a/packages/schemas/src/configs.ts
+++ b/packages/schemas/src/configs.ts
@@ -77,6 +77,9 @@ export type TimerColor = z.infer<typeof TimerColorSchema>;
 export const TimerOpacitySchema = z.enum(["0.25", "0.5", "0.75", "1"]);
 export type TimerOpacity = z.infer<typeof TimerOpacitySchema>;
 
+export const HideTimerWhileTypingSchema = z.boolean();
+export type HideTimerWhileTyping = z.infer<typeof HideTimerWhileTypingSchema>;
+
 export const StopOnErrorSchema = z.enum(["off", "word", "letter"]);
 export type StopOnError = z.infer<typeof StopOnErrorSchema>;
 
@@ -421,6 +424,7 @@ export const ConfigSchema = z
     liveBurstStyle: LiveSpeedAccBurstStyleSchema,
     timerColor: TimerColorSchema,
     timerOpacity: TimerOpacitySchema,
+    hideTimerWhileTyping: HideTimerWhileTypingSchema,
     highlightMode: HighlightModeSchema,
     tapeMode: TapeModeSchema,
     tapeMargin: TapeMarginSchema,
@@ -556,6 +560,7 @@ export const ConfigGroupsLiteral = {
   liveBurstStyle: "appearance",
   timerColor: "appearance",
   timerOpacity: "appearance",
+  hideTimerWhileTyping: "appearance",
   highlightMode: "appearance",
   tapeMode: "appearance",
   tapeMargin: "appearance",


### PR DESCRIPTION
## 🎯 **Problem**
Many users experience typing anxiety when they see the timer counting down during tests. This pressure can cause:
- Increased stress and mistakes during typing tests  
- Loss of focus on accuracy due to time pressure
- Reduced enjoyment of the typing experience
- Anxiety especially for users who are still building their skills

## 💡 **Solution**
This PR adds a "Hide Timer While Typing" feature that allows users to optionally hide the timer while actively typing, reducing anxiety and improving focus.

## ✨ **Features**
- **🎛️ Toggle Control**: Added checkbox in custom test duration modal
- **⚡ Immediate Hide**: Timer disappears instantly when typing starts
- **⏱️ Smart Show**: Timer reappears after 3 seconds of typing inactivity  
- **🎨 All Timer Styles**: Supports bar, text, and mini timer styles
- **⌨️ Command Line**: Full command line support for power users
- **🔧 Proper Integration**: Follows Monkeytype's config system patterns

## 🎬 **How it Works**
1. User enables "Hide timer while typing" in custom test duration modal
2. During test, timer hides immediately when user starts typing
3. Timer stays hidden while user continues typing (resets 3s delay on each keystroke)
4. Timer reappears automatically after 3 seconds of no typing activity
5. Timer behaves normally when feature is disabled

## 📁 **Files Changed**
### Schema & Configuration
- `packages/schemas/src/configs.ts` - Added Zod schema and type definitions
- `frontend/src/ts/constants/default-config.ts` - Added default value (false)
- `frontend/src/ts/config.ts` - Added setter function

### User Interface  
- `frontend/src/html/popups.html` - Added checkbox to custom duration modal
- `frontend/src/ts/modals/custom-test-duration.ts` - Added toggle handling logic

### Core Functionality
- `frontend/src/ts/test/timer-progress.ts` - Implemented hiding/showing logic with delay
- `frontend/src/ts/controllers/input-controller.ts` - Connected typing events to timer

### Metadata & Command Line
- `frontend/src/ts/config-metadata.ts` - Added UI metadata with eye-slash icon
- `frontend/src/ts/commandline/commandline-metadata.ts` - Added command line support

## 🧪 **Testing**
- ✅ Feature works with all timer styles (bar, text, mini)
- ✅ 3-second delay mechanism functions correctly
- ✅ Toggle state persists across test sessions
- ✅ No conflicts with existing timer functionality  
- ✅ Command line integration working
- ✅ No TypeScript compilation errors
- ✅ Follows existing code patterns and conventions

## 🔍 **Implementation Details**
- Uses existing Monkeytype config system for persistence
- Integrates with current timer animation system (jQuery)
- Follows established patterns for modal checkboxes
- Properly typed with Zod schemas for validation
- Handles all edge cases (test restart, manual timer hide/show)
- Non-breaking change - feature is opt-in

## 📸 **Screenshots/Demo**
This is default Configuration
<img width="1868" height="927" alt="image" src="https://github.com/user-attachments/assets/cd2eafa2-23eb-48a5-ae8b-f7162a959311" />
After enabling hide time
<img width="724" height="530" alt="image" src="https://github.com/user-attachments/assets/f9309937-da8d-46ae-955d-275a48f86cfb" />
Timer will not be visible while typing
<img width="1850" height="967" alt="image" src="https://github.com/user-attachments/assets/dc501674-79d5-4108-bbdc-78c7557a5b5e" />


## 🎊 **Impact**
This feature addresses a common user pain point and provides an optional way to reduce typing anxiety while maintaining all existing functionality for users who prefer to see the timer.

---
**Related Issue**: Addresses user requests for anxiety-reducing features
**Type**: Enhancement/Feature
**Breaking Changes**: None