### PR TITLE
fix(commandline): prevent false theme apply during perview (@byseif21)

### DIFF
--- a/frontend/src/ts/commandline/commandline.ts
+++ b/frontend/src/ts/commandline/commandline.ts
@@ -564,10 +564,13 @@ async function updateActiveCommand(): Promise<void> {
   keepActiveCommandInView();
 
   clearFontPreview();
-  if (/changeTheme.+/gi.test(command.id)) {
+  if (
+    command.id?.startsWith("changeTheme") ||
+    command.id?.startsWith("setCustomThemeId")
+  ) {
     removeCommandlineBackground();
   } else {
-    void ThemeController.clearPreview(false);
+    void ThemeController.clearPreview();
     addCommandlineBackground();
   }
 


### PR DESCRIPTION

* When leaving a theme item to a non‑theme item inside the mixed commandline list, the preview theme temporarily applied after closing the commandline without selecting it. so switched back to clearPreview() as it was,
 #### to REPRODUCE: type e.g "theme off" in the commandline then close the commandline.

* and to fix the preview flashing issue that the false was added for, in custom themes included setCustomThemeId with changeTheme in the check , so custom theme hovers are now treated as the same preview context and no longer clear the preview between items.


