### PR TITLE
fix(navigation): level up animation showing wrong level (@miodec)

### DIFF
--- a/frontend/src/ts/constants/default-snapshot.ts
+++ b/frontend/src/ts/constants/default-snapshot.ts
@@ -7,7 +7,7 @@ import {
 import { getDefaultConfig } from "./default-config";
 import { Mode } from "@monkeytype/schemas/shared";
 import { Result } from "@monkeytype/schemas/results";
-import { Config, FunboxName } from "@monkeytype/schemas/configs";
+import { Config, Difficulty, FunboxName } from "@monkeytype/schemas/configs";
 import {
   ModifiableTestActivityCalendar,
   TestActivityCalendar,
@@ -41,7 +41,7 @@ export type SnapshotResult<M extends Mode> = Omit<
   bailedOut: boolean;
   blindMode: boolean;
   lazyMode: boolean;
-  difficulty: string;
+  difficulty: Difficulty;
   funbox: FunboxName[];
   language: Language;
   numbers: boolean;

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -51,7 +51,7 @@ export function getSnapshot(): Snapshot | undefined {
 
 export function setSnapshot(
   newSnapshot: Snapshot | undefined,
-  noEventDispatch = false
+  options: { dispatchEvent: boolean } = { dispatchEvent: true }
 ): void {
   const originalBanned = dbSnapshot?.banned;
   const originalVerified = dbSnapshot?.verified;
@@ -74,7 +74,7 @@ export function setSnapshot(
     dbSnapshot.lbOptOut = lbOptOut;
   }
 
-  if (!noEventDispatch) {
+  if (options.dispatchEvent) {
     AuthEvent.dispatch({ type: "snapshotUpdated", data: { isInitial: false } });
   }
 }
@@ -994,7 +994,9 @@ export function saveLocalResult(data: SaveLocalResultData): void {
     }
   }
 
-  setSnapshot(snapshot, true);
+  setSnapshot(snapshot, {
+    dispatchEvent: false,
+  });
 }
 
 export function addXp(xp: number): void {
@@ -1005,7 +1007,9 @@ export function addXp(xp: number): void {
     snapshot.xp = 0;
   }
   snapshot.xp += xp;
-  setSnapshot(snapshot, true);
+  setSnapshot(snapshot, {
+    dispatchEvent: false,
+  });
 }
 
 export function updateInboxUnreadSize(newSize: number): void {

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -634,7 +634,7 @@ export async function getLocalPB<M extends Mode>(
   );
 }
 
-export function saveLocalPB<M extends Mode>(
+function saveLocalPB<M extends Mode>(
   mode: M,
   mode2: Mode2<M>,
   punctuation: boolean,

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -629,7 +629,7 @@ export async function getLocalPB<M extends Mode>(
   );
 }
 
-export async function saveLocalPB<M extends Mode>(
+export function saveLocalPB<M extends Mode>(
   mode: M,
   mode2: Mode2<M>,
   punctuation: boolean,
@@ -641,7 +641,7 @@ export async function saveLocalPB<M extends Mode>(
   acc: number,
   raw: number,
   consistency: number
-): Promise<void> {
+): void {
   if (mode === "quote") return;
   if (!dbSnapshot) return;
   function cont(): void {

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -51,7 +51,7 @@ export function getSnapshot(): Snapshot | undefined {
 
 export function setSnapshot(
   newSnapshot: Snapshot | undefined,
-  options: { dispatchEvent: boolean } = { dispatchEvent: true }
+  options?: { dispatchEvent?: boolean }
 ): void {
   const originalBanned = dbSnapshot?.banned;
   const originalVerified = dbSnapshot?.verified;
@@ -74,7 +74,7 @@ export function setSnapshot(
     dbSnapshot.lbOptOut = lbOptOut;
   }
 
-  if (options.dispatchEvent) {
+  if (options?.dispatchEvent !== false) {
     AuthEvent.dispatch({ type: "snapshotUpdated", data: { isInitial: false } });
   }
 }

--- a/frontend/src/ts/pages/account.ts
+++ b/frontend/src/ts/pages/account.ts
@@ -27,12 +27,7 @@ import * as ResultBatches from "../elements/result-batches";
 import Format from "../utils/format";
 import * as TestActivity from "../elements/test-activity";
 import { ChartData } from "@monkeytype/schemas/results";
-import {
-  Difficulty,
-  Mode,
-  Mode2,
-  Mode2Custom,
-} from "@monkeytype/schemas/shared";
+import { Mode, Mode2, Mode2Custom } from "@monkeytype/schemas/shared";
 import { ResultFiltersGroupItem } from "@monkeytype/schemas/users";
 import { findLineByLeastSquares } from "../utils/numbers";
 import defaultResultFilters from "../constants/default-result-filters";
@@ -300,7 +295,7 @@ async function fillContent(): Promise<void> {
       if (resdiff === undefined) {
         resdiff = "normal";
       }
-      if (!ResultFilters.getFilter("difficulty", resdiff as Difficulty)) {
+      if (!ResultFilters.getFilter("difficulty", resdiff)) {
         if (filterDebug) {
           console.log(`skipping result due to difficulty filter`, result);
         }
@@ -1287,7 +1282,6 @@ $(".pageAccount .group.presetFilterButtons").on(
 );
 
 $(".pageAccount .content .group.aboveHistory .exportCSV").on("click", () => {
-  //@ts-expect-error dont really wanna figure out the types here but it works
   void Misc.downloadResultsCSV(filteredResults);
 });
 

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -1288,6 +1288,8 @@ async function saveResult(
   );
   $("#result .stats .tags .editTagsButton").removeClass("invisible");
 
+  const dataToSave: DB.SaveLocalResultData = {};
+
   if (data.xp !== undefined) {
     const snapxp = DB.getSnapshot()?.xp ?? 0;
 
@@ -1296,11 +1298,11 @@ async function saveResult(
       data.xp,
       TestUI.resultVisible ? data.xpBreakdown : undefined
     );
-    DB.addXp(data.xp);
+    dataToSave.xp = data.xp;
   }
 
   if (data.streak !== undefined) {
-    DB.setStreak(data.streak);
+    dataToSave.streak = data.streak;
   }
 
   if (data.insertedId !== undefined) {
@@ -1314,13 +1316,7 @@ async function saveResult(
     if (data.isPb !== undefined && data.isPb) {
       result.isPb = true;
     }
-    DB.saveLocalResult(result);
-    DB.updateLocalStats(
-      completedEvent.incompleteTests.length + 1,
-      completedEvent.testDuration +
-        completedEvent.incompleteTestSeconds -
-        completedEvent.afkDuration
-    );
+    dataToSave.result = result;
   }
 
   void AnalyticsController.log("testCompleted");
@@ -1343,33 +1339,10 @@ async function saveResult(
     }
     Result.showCrown("normal");
 
-    await DB.saveLocalPB(
-      completedEvent.mode,
-      completedEvent.mode2,
-      completedEvent.punctuation,
-      completedEvent.numbers,
-      completedEvent.language,
-      completedEvent.difficulty,
-      completedEvent.lazyMode,
-      completedEvent.wpm,
-      completedEvent.acc,
-      completedEvent.rawWpm,
-      completedEvent.consistency
-    );
+    dataToSave.isPb = true;
   } else {
     Result.showErrorCrownIfNeeded();
   }
-
-  // if (response.data.dailyLeaderboardRank) {
-  //   Notifications.add(
-  //     `New ${completedEvent.language} ${completedEvent.mode} ${completedEvent.mode2} rank: ` +
-  //       Misc.getPositionString(response.data.dailyLeaderboardRank),
-  //     1,
-  //     10,
-  //     "Daily Leaderboard",
-  //     "list-ol"
-  //   );
-  // }
 
   if (data.dailyLeaderboardRank === undefined) {
     $("#result .stats .dailyLeaderboard").addClass("hidden");
@@ -1396,6 +1369,7 @@ async function saveResult(
   if (isRetrying) {
     Notifications.add("Result saved", 1, { important: true });
   }
+  DB.saveLocalResult(dataToSave);
 }
 
 export function fail(reason: string): void {

--- a/frontend/src/ts/utils/debug.ts
+++ b/frontend/src/ts/utils/debug.ts
@@ -1,0 +1,64 @@
+import { mean, roundTo2, stdDev } from "@monkeytype/util/numbers";
+
+const timings = new Map<string, number[]>();
+
+// Overloads for sync and async functions
+export function debugFunctionExecutionTime<T>(
+  func: (...options: unknown[]) => T,
+  funcName: string
+): T;
+export function debugFunctionExecutionTime<T>(
+  func: (...options: unknown[]) => Promise<T>,
+  funcName: string
+): Promise<T>;
+export function debugFunctionExecutionTime<T>(
+  func: (...options: unknown[]) => T | Promise<T>,
+  funcName: string
+): T | Promise<T> {
+  const start = performance.now();
+  const ret = func();
+
+  // Check if the result is a Promise
+  if (ret instanceof Promise) {
+    // Handle async case
+    return ret.then((resolvedValue) => {
+      logTiming(start, funcName);
+      return resolvedValue;
+    });
+  } else {
+    // Handle sync case
+    logTiming(start, funcName);
+    return ret;
+  }
+}
+
+function logTiming(start: number, funcName: string): void {
+  const end = performance.now();
+  const time = end - start;
+
+  if (!timings.has(funcName)) {
+    timings.set(funcName, []);
+  }
+
+  const arr = timings.get(funcName) as number[];
+  arr.push(time);
+
+  console.log(`${funcName} took ${roundTo2(time)} ms`);
+  console.log(funcName, {
+    average: `${roundTo2(mean(arr))} ms`,
+    stdDev: `${roundTo2(stdDev(arr))} ms`,
+    min: `${roundTo2(Math.min(...arr))} ms`,
+    max: `${roundTo2(Math.max(...arr))} ms`,
+    count: arr.length,
+  });
+  const endOverhead = performance.now();
+  //@ts-expect-error chrome api thingy
+  console.timeStamp(`#${arr.length} ${funcName}`, start, end, funcName);
+  console.timeStamp(
+    `#${arr.length} profiling overhead`,
+    //@ts-expect-error chrome api thingy
+    end,
+    endOverhead,
+    funcName
+  );
+}

--- a/frontend/src/ts/utils/results.ts
+++ b/frontend/src/ts/utils/results.ts
@@ -27,15 +27,19 @@ export async function syncNotSignedInLastResult(uid: string): Promise<void> {
   const result = structuredClone(
     notSignedInLastResult
   ) as unknown as SnapshotResult<Mode>;
+
+  const dataToSave: DB.SaveLocalResultData = {
+    xp: response.body.data.xp,
+    streak: response.body.data.streak,
+    result,
+    isPb: response.body.data.isPb,
+  };
+
   result._id = response.body.data.insertedId;
   if (response.body.data.isPb) {
     result.isPb = true;
   }
-  DB.saveLocalResult(result);
-  DB.updateLocalStats(
-    1,
-    result.testDuration + result.incompleteTestSeconds - result.afkDuration
-  );
+  DB.saveLocalResult(dataToSave);
   TestLogic.clearNotSignedInResult();
   Notifications.add(
     `Last test result saved ${response.body.data.isPb ? `(new pb!)` : ""}`,


### PR DESCRIPTION
Introduced in #6865, caused by account button reacting to the `snapshotUpdate` triggered by `addXp` function.

Fixed by merging result related snapshot functions into one and adding a `noDispatchEvent` param to `setSnapshot` and using it in the new function and `addXp`. This works because result and alerts panel both call the `XPBar.update` directly to animate the xp gain.