### PR TITLE
refactor(input validation): rework getting current validation status (@miodec)

### DIFF
--- a/frontend/src/ts/elements/input-validation.ts
+++ b/frontend/src/ts/elements/input-validation.ts
@@ -144,7 +144,7 @@ export type ValidationOptions<T> = (T extends string
 };
 
 export type ValidatedHtmlInputElement = HTMLInputElement & {
-  isValid: () => boolean | undefined;
+  getValidationResult: () => ValidationResult;
   setValue: (val: string | null) => void;
   triggerValidation: () => void;
 };
@@ -178,9 +178,11 @@ export function validateWithIndicator<T>(
     },
   });
 
-  let isValid: boolean | undefined = undefined;
+  let currentStatus: ValidationResult = {
+    status: "checking",
+  };
   const callback = (result: ValidationResult): void => {
-    isValid = result.status === "success" || result.status === "warning";
+    currentStatus = result;
     if (result.status === "failed" || result.status === "warning") {
       indicator.show(result.status, result.errorMessage);
     } else {
@@ -198,11 +200,12 @@ export function validateWithIndicator<T>(
   inputElement.addEventListener("input", handler);
 
   const result = inputElement as ValidatedHtmlInputElement;
-  result.isValid = () => isValid;
+  result.getValidationResult = () => {
+    return currentStatus;
+  };
   result.setValue = (val: string | null) => {
     inputElement.value = val ?? "";
     if (val === null) {
-      isValid = undefined;
       indicator.hide();
     } else {
       inputElement.dispatchEvent(new Event("input"));

--- a/frontend/src/ts/modals/edit-preset.ts
+++ b/frontend/src/ts/modals/edit-preset.ts
@@ -262,7 +262,7 @@ async function apply(): Promise<void> {
     return;
   }
 
-  if (presetNameEl?.isValid() === false) {
+  if (presetNameEl?.getValidationResult().status === "failed") {
     Notifications.add("Preset name is not valid", 0);
     return;
   }

--- a/frontend/src/ts/modals/save-custom-text.ts
+++ b/frontend/src/ts/modals/save-custom-text.ts
@@ -89,7 +89,7 @@ function save(): boolean {
 async function setup(modalEl: HTMLElement): Promise<void> {
   modalEl.addEventListener("submit", (e) => {
     e.preventDefault();
-    if (validatedInput.isValid() === true && save()) {
+    if (validatedInput.getValidationResult().status === "success" && save()) {
       void modal.hide();
     }
   });

--- a/frontend/src/ts/pages/login.ts
+++ b/frontend/src/ts/pages/login.ts
@@ -170,9 +170,7 @@ validateWithIndicator(emailVerifyInputEl, {
   debounceDelay: 0,
   callback: (result) => {
     registerForm.email =
-      emailInputEl.isValid() && result.status === "success"
-        ? emailInputEl.value
-        : undefined;
+      result.status === "success" ? emailInputEl.value : undefined;
     updateSignupButton();
   },
 });
@@ -204,9 +202,7 @@ validateWithIndicator(passwordVerifyInputEl, {
   debounceDelay: 0,
   callback: (result) => {
     registerForm.password =
-      passwordInputEl.isValid() && result.status === "success"
-        ? passwordInputEl.value
-        : undefined;
+      result.status === "success" ? passwordInputEl.value : undefined;
     updateSignupButton();
   },
 });


### PR DESCRIPTION
Rename to diffrentiate between the predicate `isValid` and the element `isValid`
Return `ValidationResult` instead of just a boolean.
Update usage to the new format