### PR TITLE
fix: rounded table header (@fehmer)

### DIFF
--- a/frontend/src/ts/components/ui/table/DataTable.tsx
+++ b/frontend/src/ts/components/ui/table/DataTable.tsx
@@ -216,6 +216,8 @@ export function DataTable<TData, TValue = any>(
                                   "justify-end text-right":
                                     header.column.columnDef.meta?.align ===
                                     "right",
+                                  "rounded-l": header.column.getIsFirstColumn(),
+                                  "rounded-r": header.column.getIsLastColumn(),
                                 },
                                 header.column.columnDef.meta?.headerClass,
                               )}

--- a/frontend/src/ts/components/ui/table/Table.tsx
+++ b/frontend/src/ts/components/ui/table/Table.tsx
@@ -44,7 +44,7 @@ const TableHead: Component<ComponentProps<"th">> = (props) => {
     <th
       aria-label={local["aria-label"]}
       class={cn(
-        "has-button:p-0 appearance-none p-2 align-bottom text-xs font-normal",
+        "has-button:p-0 appearance-none p-2 align-bottom text-xs font-normal first:rounded-l last:rounded-r",
         local.class,
       )}
       {...others}


### PR DESCRIPTION
Round the table header to match the rows.

This is not visible unless users set their own css or on hover on a sortable table. The fix looks like this on hover:

first column
<img width="211" height="197" alt="image" src="https://github.com/user-attachments/assets/d2baaf41-6590-4972-a5b2-02d90d03fb3c" />
 
last column
<img width="233" height="309" alt="image" src="https://github.com/user-attachments/assets/1f67ed16-cb04-44e9-af6a-3b5963d313d7" />
