### PR TITLE
feat: add "Previous Test" functionality with button and state management (@abhaychandra123)

### DIFF
--- a/frontend/__tests__/root/config.spec.ts
+++ b/frontend/__tests__/root/config.spec.ts
@@ -56,9 +56,16 @@ describe("Config", () => {
       vi.useFakeTimers();
       mocks.forEach((it) => it.mockClear());
 
-      vi.mock("../../src/ts/test/test-state", () => ({
-        isActive: true,
-      }));
+      vi.mock("../../src/ts/test/test-state", async (importOriginal) => {
+        const actual =
+          await importOriginal<typeof import("../../src/ts/test/test-state")>();
+
+        return {
+          ...actual,
+          isActive: true,
+          resetQuoteHistory: vi.fn(),
+        };
+      });
 
       isConfigValueValidMock.mockReturnValue(true);
       canSetConfigWithCurrentFunboxesMock.mockReturnValue(true);

--- a/frontend/src/html/pages/test.html
+++ b/frontend/src/html/pages/test.html
@@ -162,14 +162,25 @@
 
     <div id="keymap" class="hidden"></div>
 
-    <button
-      id="restartTestButton"
-      aria-label="Restart Test"
-      data-balloon-pos="down"
-      class="text"
-    >
-      <i class="fas fa-fw fa-redo-alt"></i>
-    </button>
+    <div id="testActionButtons">
+      <button
+        id="previousTestButton"
+        aria-label="Previous Test"
+        data-balloon-pos="down"
+        class="text testActionButton hidden"
+      >
+        <i class="fas fa-fw fa-undo-alt"></i>
+      </button>
+
+      <button
+        id="restartTestButton"
+        aria-label="Restart Test"
+        data-balloon-pos="down"
+        class="text testActionButton"
+      >
+        <i class="fas fa-fw fa-redo-alt"></i>
+      </button>
+    </div>
     <div id="liveStatsTextBottom" class="timerMain">
       <div class="wrapper">
         <div class="liveSpeed hidden">123</div>

--- a/frontend/src/styles/media-queries-blue.scss
+++ b/frontend/src/styles/media-queries-blue.scss
@@ -136,6 +136,7 @@
   }
 }
 @media (pointer: coarse) and (max-width: 778px) {
+  #previousTestButton,
   #restartTestButton {
     display: block !important;
   }

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -1321,11 +1321,21 @@
   margin-left: 0.5em;
 }
 
-#restartTestButton {
-  font-size: 1rem;
-  margin: 1rem auto 0 auto;
+#testActionButtons {
   display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1rem auto 0;
+}
+
+.testActionButton {
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 1em 2em;
+  margin: 0;
 }
 
 #compositionDisplay {

--- a/frontend/src/ts/commandline/lists/navigation.ts
+++ b/frontend/src/ts/commandline/lists/navigation.ts
@@ -2,6 +2,9 @@ import { navigate } from "../../controllers/route-controller";
 import { isAuthenticated } from "../../firebase";
 import { toggleFullscreen } from "../../utils/misc";
 import { Command } from "../types";
+import { Config } from "../../config/store";
+import * as TestState from "../../test/test-state";
+import * as TestLogic from "../../test/test-logic";
 
 const commands: Command[] = [
   {
@@ -56,6 +59,15 @@ const commands: Command[] = [
     icon: "fa-expand",
     exec: (): void => {
       toggleFullscreen();
+    },
+  },
+  {
+    id: "previousTest",
+    display: "Previous Test (Quotes)",
+    icon: "fa-undo-alt",
+    available: () => Config.mode === "quote" && TestState.quoteHistoryIndex > 0,
+    exec: (): void => {
+      TestLogic.restart({ isPrevious: true });
     },
   },
 ];

--- a/frontend/src/ts/config/setters.ts
+++ b/frontend/src/ts/config/setters.ts
@@ -121,6 +121,15 @@ export function setConfig<T extends keyof ConfigSchemas.Config>(
   }
 
   Config[key] = value;
+
+  if (key === "mode" && previousValue === "quote" && value !== "quote") {
+    TestState.resetQuoteHistory();
+  }
+
+  if (key === "language" && previousValue !== value) {
+    TestState.resetQuoteHistory();
+  }
+
   if (!options?.nosave) saveToLocalStorage(key, options?.nosave);
 
   // @ts-expect-error i can't figure this out

--- a/frontend/src/ts/event-handlers/test.ts
+++ b/frontend/src/ts/event-handlers/test.ts
@@ -6,6 +6,9 @@ import * as EditResultTagsModal from "../modals/edit-result-tags";
 import * as MobileTestConfigModal from "../modals/mobile-test-config";
 import * as CustomTestDurationModal from "../modals/custom-test-duration";
 import * as TestWords from "../test/test-words";
+import * as TestLogic from "../test/test-logic";
+import * as TestState from "../test/test-state";
+import * as TestUI from "../test/test-ui";
 import {
   showNoticeNotification,
   showErrorNotification,
@@ -119,4 +122,11 @@ qs(".pageTest #dailyLeaderboardRank")?.on("click", async () => {
       null,
     )}&goToUserPage=true`,
   );
+});
+
+testPage?.onChild("click", "#previousTestButton", () => {
+  if (TestUI.resultCalculating) return;
+  if (Config.mode === "quote" && TestState.quoteHistoryIndex > 0) {
+    TestLogic.restart({ isPrevious: true });
+  }
 });

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -169,6 +169,7 @@ type RestartOptions = {
   practiseMissed?: boolean;
   noAnim?: boolean;
   isQuickRestart?: boolean;
+  isPrevious?: boolean;
 };
 
 export function restart(options = {} as RestartOptions): void {
@@ -346,7 +347,7 @@ export function restart(options = {} as RestartOptions): void {
       TestState.setPaceRepeat(repeatWithPace);
       TestInitFailed.hide();
       TestState.setTestInitSuccess(true);
-      const initResult = await init();
+      const initResult = await init(options.isPrevious ?? false);
 
       if (!initResult) {
         TestState.setTestRestarting(false);
@@ -380,7 +381,7 @@ let lastInitError: Error | null = null;
 let showedLazyModeNotification: boolean = false;
 let testReinitCount = 0;
 
-async function init(): Promise<boolean> {
+async function init(loadPreviousQuote = false): Promise<boolean> {
   console.debug("Initializing test");
   testReinitCount++;
   if (testReinitCount > 3) {
@@ -413,7 +414,7 @@ async function init(): Promise<boolean> {
   }
 
   if (!language || language.name !== Config.language) {
-    return await init();
+    return await init(loadPreviousQuote);
   }
 
   if (getActivePage() === "test") {
@@ -512,7 +513,9 @@ async function init(): Promise<boolean> {
   let generatedWords: string[] = [];
   let generatedSectionIndexes: number[] = [];
   try {
-    const gen = await WordsGenerator.generateWords(language);
+    const gen = await WordsGenerator.generateWords(language, {
+      loadPreviousQuote,
+    });
     generatedWords = gen.words;
     generatedSectionIndexes = gen.sectionIndexes;
     wordsHaveTab = gen.hasTab;
@@ -537,7 +540,7 @@ async function init(): Promise<boolean> {
       });
     }
 
-    return await init();
+    return await init(loadPreviousQuote);
   }
 
   let hasNumbers = false;

--- a/frontend/src/ts/test/test-state.ts
+++ b/frontend/src/ts/test/test-state.ts
@@ -13,6 +13,11 @@ export let isLanguageRightToLeft = false;
 export let isDirectionReversed = false;
 export let testRestarting = false;
 export let resultVisible = false;
+/** Max quotes remembered for "previous quote" navigation (per session). */
+export const MAX_QUOTE_HISTORY_LENGTH = 50;
+
+export const quoteHistory: number[] = [];
+export let quoteHistoryIndex = -1;
 
 export function setRepeated(tf: boolean): void {
   isRepeated = tf;
@@ -81,4 +86,43 @@ export function setTestRestarting(val: boolean): void {
 
 export function setResultVisible(val: boolean): void {
   resultVisible = val;
+}
+
+/**
+ * Id of the quote that would load if we navigate back, without mutating history.
+ * Call {@link commitPreviousNavigation} only after that quote was resolved successfully.
+ */
+export function peekPreviousQuoteId(): number | null {
+  if (quoteHistoryIndex <= 0) {
+    return null;
+  }
+  const val = quoteHistory[quoteHistoryIndex - 1];
+  return val ?? null;
+}
+
+/** Apply a successful "previous quote" navigation (decrements the history cursor). */
+export function commitPreviousNavigation(): void {
+  if (quoteHistoryIndex <= 0) {
+    return;
+  }
+  quoteHistoryIndex--;
+}
+
+export function pushQuoteToHistory(quoteId: number): void {
+  if (quoteHistoryIndex < quoteHistory.length - 1) {
+    quoteHistory.splice(quoteHistoryIndex + 1);
+  }
+
+  quoteHistory.push(quoteId);
+  quoteHistoryIndex++;
+
+  if (quoteHistory.length > MAX_QUOTE_HISTORY_LENGTH) {
+    quoteHistory.shift();
+    quoteHistoryIndex--;
+  }
+}
+
+export function resetQuoteHistory(): void {
+  quoteHistory.length = 0;
+  quoteHistoryIndex = -1;
 }

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1935,6 +1935,7 @@ export function onTestRestart(source: "testPage" | "resultPage"): void {
   void SoundController.clearAllSounds();
   cancelPendingAnimationFramesStartingWith("test-ui");
   showWords();
+  updatePreviousButtonVisibility();
 }
 
 export function onTestFinish(): void {
@@ -2090,4 +2091,18 @@ configEvent.subscribe(({ key, newValue }) => {
   if (["tapeMode", "tapeMargin"].includes(key)) {
     updateLiveStatsMargin();
   }
+  if (key === "mode" || key === "language") {
+    updatePreviousButtonVisibility();
+  }
 });
+
+export function updatePreviousButtonVisibility(): void {
+  const prevBtn = document.getElementById("previousTestButton");
+  if (!prevBtn) return;
+
+  if (Config.mode === "quote" && TestState.quoteHistoryIndex > 0) {
+    prevBtn.classList.remove("hidden");
+  } else {
+    prevBtn.classList.add("hidden");
+  }
+}

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -496,7 +496,8 @@ export function getLimit(): number {
 
 async function getQuoteWordList(
   language: LanguageObject,
-  wordOrder?: FunboxWordOrder,
+  wordOrder: FunboxWordOrder | undefined,
+  options: GenerateWordsOptions,
 ): Promise<string[]> {
   if (TestState.isRepeated) {
     if (currentWordset === null) {
@@ -534,33 +535,59 @@ async function getQuoteWordList(
   }
 
   let rq: Quote;
-  if (Config.quoteLength.includes(-2) && Config.quoteLength.length === 1) {
-    const targetQuote = QuotesController.getQuoteById(
-      TestState.selectedQuoteId,
-    );
-    if (targetQuote === undefined) {
-      setQuoteLengthAll();
-      throw new WordGenError(
-        `Quote ${TestState.selectedQuoteId} does not exist`,
+  let wasPrevious = false;
+
+  function pickQuoteFromCurrentSettings(): Quote {
+    if (Config.quoteLength.includes(-2) && Config.quoteLength.length === 1) {
+      const targetQuote = QuotesController.getQuoteById(
+        TestState.selectedQuoteId,
       );
+      if (targetQuote === undefined) {
+        setQuoteLengthAll();
+        throw new WordGenError(
+          `Quote ${TestState.selectedQuoteId} does not exist`,
+        );
+      }
+      return targetQuote;
     }
-    rq = targetQuote;
-  } else if (Config.quoteLength.includes(-3)) {
-    const randomQuote = QuotesController.getRandomFavoriteQuote(
-      Config.language,
-    );
-    if (randomQuote === null) {
-      setQuoteLengthAll();
-      throw new WordGenError("No favorite quotes found");
+    if (Config.quoteLength.includes(-3)) {
+      const randomQuote = QuotesController.getRandomFavoriteQuote(
+        Config.language,
+      );
+      if (randomQuote === null) {
+        setQuoteLengthAll();
+        throw new WordGenError("No favorite quotes found");
+      }
+      return randomQuote;
     }
-    rq = randomQuote;
-  } else {
     const randomQuote = QuotesController.getRandomQuote();
     if (randomQuote === null) {
       setQuoteLengthAll();
       throw new WordGenError("No quotes found for selected quote length");
     }
-    rq = randomQuote;
+    return randomQuote;
+  }
+
+  if (options.loadPreviousQuote) {
+    const prevQuoteId = TestState.peekPreviousQuoteId();
+    if (prevQuoteId !== null) {
+      const targetQuote = QuotesController.getQuoteById(prevQuoteId);
+      if (targetQuote === undefined) {
+        setQuoteLengthAll();
+        throw new WordGenError(`Quote ${prevQuoteId} does not exist`);
+      }
+      TestState.commitPreviousNavigation();
+      rq = targetQuote;
+      wasPrevious = true;
+    } else {
+      rq = pickQuoteFromCurrentSettings();
+    }
+  } else {
+    rq = pickQuoteFromCurrentSettings();
+  }
+
+  if (!TestState.isRepeated && !wasPrevious) {
+    TestState.pushQuoteToHistory(rq.id);
   }
 
   rq.language = Strings.removeLanguageSize(Config.language);
@@ -605,10 +632,17 @@ type GenerateWordsReturn = {
   allLigatures?: boolean;
 };
 
+/** Options for a single generation pass (explicit intent, not global test flags). */
+export type GenerateWordsOptions = {
+  /** Load the previous quote from session history (quote mode only). */
+  loadPreviousQuote?: boolean;
+};
+
 let previousRandomQuote: QuoteWithTextSplit | null = null;
 
 export async function generateWords(
   language: LanguageObject,
+  options: GenerateWordsOptions = {},
 ): Promise<GenerateWordsReturn> {
   if (!TestState.isRepeated) {
     previousGetNextWordReturns = [];
@@ -637,7 +671,7 @@ export async function generateWords(
   if (Config.mode === "custom") {
     wordList = CustomText.getText();
   } else if (Config.mode === "quote") {
-    wordList = await getQuoteWordList(language, wordOrder);
+    wordList = await getQuoteWordList(language, wordOrder, options);
   } else if (Config.mode === "zen") {
     wordList = [];
   }


### PR DESCRIPTION
### Title
feat(frontend): add previous quote navigation + align test action buttons (@abhaychandra123)

## Summary
This PR adds session-based previous-quote navigation in quote mode and refactors test action button layout so Previous and Restart are consistently sized, aligned, and centered.

## What changed
- Added a new Previous Test button next to Restart and wrapped both in a shared flex container in frontend/src/html/pages/test.html.
- Added shared button styling and centered flex layout in frontend/src/styles/test.scss.
- Updated coarse-pointer media query so both buttons keep consistent behavior on mobile/touch in frontend/src/styles/media-queries-blue.scss.
- Added a command line command for previous quote navigation in frontend/src/ts/commandline/lists/navigation.ts.
- Added quote history reset on mode/language transitions in frontend/src/ts/config/setters.ts.
- Added click handler for Previous Test button in frontend/src/ts/event-handlers/test.ts.
- Extended restart/init flow to support loading previous quote in frontend/src/ts/test/test-logic.ts.
- Added quote history state management helpers in frontend/src/ts/test/test-state.ts.
- Added previous button visibility updates on restart and config changes in frontend/src/ts/test/test-ui.ts.
- Extended quote generation to support explicit previous-quote loading and safe history updates in frontend/src/ts/test/words-generator.ts.

## Behavior details
- Previous quote navigation is available only in quote mode and only when history exists.
- History is session-scoped, capped at 50 entries, and cursor-based.
- History resets when leaving quote mode or changing language.
- Restart button styling is preserved; Previous now shares the same visual style and dimensions.

### Checks
- [x] Not adding quotes
- [x] Not adding a language
- [x] Not adding a theme
- [x] Not adding a layout
- [x] Not adding a font
- [x ] PR title follows Conventional Commits and includes GitHub username
- [ ] Related issues linked below (if applicable)