### PR TITLE
fix(funbox): apply space balls perspective only to test words (@d1rshan)

### DIFF
--- a/frontend/static/funbox/space_balls.css
+++ b/frontend/static/funbox/space_balls.css
@@ -16,11 +16,11 @@ body {
   background-position: center;
 }
 
-main {
+main .pageTest #typingTest {
   perspective: 500px;
-  overflow: hidden;
 }
 
-main .page {
-  transform: rotateX(35deg);
+main .pageTest #wordsWrapper {
+  transform: rotateX(24deg);
+  transform-origin: center center;
 }


### PR DESCRIPTION
This PR restricts the Space Balls 3D perspective effect only to the words ui to prevent layout issues with other test elements.

Current Behavior:
<img width="1820" height="953" alt="image" src="https://github.com/user-attachments/assets/93fc68d5-8a54-4c49-8a0b-cae1bf2afa6f" />

Now:
<img width="1829" height="957" alt="image" src="https://github.com/user-attachments/assets/7ce39759-9198-491f-8500-7c6fa316c74d" />


ik this changes the original intention for this effect, so understandable if this is not what you guys want but i have tried multiple different options and i think this is probably the cleanest fix for this.