### PR TITLE
fix: added z-index to theme button when hovered (@Ma3ert)

### DIFF
--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -546,6 +546,10 @@
         gap: 0.5rem;
         .button {
           transition: transform 0.125s;
+          position: relative;
+          &:hover {
+            z-index: 10;
+          }
           &:hover .themeBubbles {
             opacity: 1;
           }

--- a/frontend/src/styles/settings.scss
+++ b/frontend/src/styles/settings.scss
@@ -546,7 +546,6 @@
         gap: 0.5rem;
         .button {
           transition: transform 0.125s;
-          position: relative;
           &:hover {
             z-index: 10;
           }


### PR DESCRIPTION
### Description
In the theme section in setting, the selected theme is bigger and outlined, that caused it to appear of top of `themeBubbles`/`themeBubble` of the theme that is hovered on it's left.
What I did is instead of only making the button bigger when hovered, I also added `z-index` so that it appears on top of the already selected theme.

closes #7797 
