### PR TITLE
feat(leaderboard): added page indicator (@Repr-dev)

### DIFF
--- a/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
+++ b/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
@@ -5,6 +5,8 @@ import { showSimpleModal } from "../../../states/simple-modal";
 import { cn } from "../../../utils/cn";
 import { Button } from "../../common/Button";
 import { LoadingCircle } from "../../common/LoadingCircle";
+import { PageIndicator } from "./PageIndicator";
+
 export function Navigation(props: {
   lastPage: number;
   userPage?: number;
@@ -26,6 +28,7 @@ export function Navigation(props: {
       <Show when={props.isLoading}>
         <LoadingCircle color="sub" class="text-2xl" />
       </Show>
+      <PageIndicator currentPage={props.currentPage} />
       <Button
         onClick={() => props.onPageChange(0)}
         fa={{ icon: "fa-crown", fixedWidth: true }}

--- a/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
+++ b/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
@@ -6,7 +6,6 @@ import { showSimpleModal } from "../../../states/simple-modal";
 import { cn } from "../../../utils/cn";
 import { Button } from "../../common/Button";
 import { LoadingCircle } from "../../common/LoadingCircle";
-import { PageIndicator } from "./PageIndicator";
 
 export function Navigation(props: {
   lastPage: number;
@@ -29,7 +28,6 @@ export function Navigation(props: {
       <Show when={props.isLoading}>
         <LoadingCircle color="sub" class="text-2xl" />
       </Show>
-      <PageIndicator currentPage={props.currentPage} />
       <Button
         onClick={() => props.onPageChange(0)}
         fa={{ icon: "fa-crown", fixedWidth: true }}
@@ -98,7 +96,10 @@ export function Navigation(props: {
         fa={{ icon: "fa-hashtag", fixedWidth: true }}
         class={buttonClass}
         disabled={props.lastPage <= 1}
-      />
+      >
+        {" "}
+        {props.currentPage + 1}
+      </Button>
       <Button
         onClick={() => props.onPageChange((old) => old + 1)}
         fa={{ icon: "fa-chevron-right", fixedWidth: true }}

--- a/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
+++ b/frontend/src/ts/components/pages/leaderboard/Navigation.tsx
@@ -6,6 +6,8 @@ import { showSimpleModal } from "../../../states/simple-modal";
 import { cn } from "../../../utils/cn";
 import { Button } from "../../common/Button";
 import { LoadingCircle } from "../../common/LoadingCircle";
+import { PageIndicator } from "./PageIndicator";
+
 export function Navigation(props: {
   lastPage: number;
   userPage?: number;
@@ -27,6 +29,7 @@ export function Navigation(props: {
       <Show when={props.isLoading}>
         <LoadingCircle color="sub" class="text-2xl" />
       </Show>
+      <PageIndicator currentPage={props.currentPage} />
       <Button
         onClick={() => props.onPageChange(0)}
         fa={{ icon: "fa-crown", fixedWidth: true }}

--- a/frontend/src/ts/components/pages/leaderboard/PageIndicator.tsx
+++ b/frontend/src/ts/components/pages/leaderboard/PageIndicator.tsx
@@ -1,0 +1,9 @@
+import { JSXElement } from "solid-js";
+
+export function PageIndicator(props: { currentPage: number }): JSXElement {
+  return (
+    <span class="inline-flex h-min appearance-none items-center justify-center gap-[0.5em] rounded border-0 p-[0.5em] text-center leading-[1.25] text-(--themable-button-text)">
+      Page {props.currentPage + 1}
+    </span>
+  );
+}

--- a/frontend/src/ts/components/pages/leaderboard/PageIndicator.tsx
+++ b/frontend/src/ts/components/pages/leaderboard/PageIndicator.tsx
@@ -1,9 +1,0 @@
-import { JSXElement } from "solid-js";
-
-export function PageIndicator(props: { currentPage: number }): JSXElement {
-  return (
-    <span class="inline-flex h-min appearance-none items-center justify-center gap-[0.5em] rounded border-0 p-[0.5em] text-center leading-[1.25] text-(--themable-button-text)">
-      Page {props.currentPage + 1}
-    </span>
-  );
-}


### PR DESCRIPTION
### Description

At the moment, it is impossible to tell which page of [monkeytype.com/leaderboards](https://www.monkeytype.com/leaderboards) you are on just from the content of the webpage. One must look at the URL parameters (*/leaderboards?...&page=X*) in order to get this information. So, I added a numerical indicator next to the page control buttons.

All this code does is add a **span** element in the same container as the page control buttons. The span is placed to the left of the buttons and is given a lot of the same Tailwind classes. The page number in the span comes from the data that is already being passed down to the buttons.

**Old:**
<img width="1234" height="454" alt="image" src="https://github.com/user-attachments/assets/2e530854-3490-4791-ab72-4dc2c454319c" />

**New** (replication of my approach, made with Chrome Inspector)**:**
<img width="1218" height="514" alt="image" src="https://github.com/user-attachments/assets/ef58d816-ff33-48d8-a300-bdf519f4f549" />

### Closes
Discussion #7815. My first open source contribution