### PR TITLE
fix(user): migrate lastReultHashes typo to lastResultHashes safely (@mukundangopalachary)

### DIFF
--- a/backend/src/api/controllers/result.ts
+++ b/backend/src/api/controllers/result.ts
@@ -402,7 +402,7 @@ export async function addResult(
   }
 
   if (req.ctx.configuration.users.lastHashesCheck.enabled) {
-    let lastHashes = user.lastReultHashes ?? [];
+    let lastHashes = user.lastResultHashes ?? user.lastReultHashes ?? [];
     if (lastHashes.includes(resulthash)) {
       void addLog(
         "duplicate_result",

--- a/backend/src/api/controllers/user.ts
+++ b/backend/src/api/controllers/user.ts
@@ -509,7 +509,8 @@ type RelevantUserInfo = Omit<
   | "nameHistory"
   | "lastNameChange"
   | "_id"
-  | "lastReultHashes" //TODO fix typo
+  | "lastResultHashes"
+  | "lastReultHashes"
   | "note"
   | "ips"
   | "testActivity"
@@ -524,7 +525,8 @@ function getRelevantUserInfo(user: UserDAL.DBUser): RelevantUserInfo {
     "nameHistory",
     "lastNameChange",
     "_id",
-    "lastReultHashes", //TODO fix typo
+    "lastResultHashes",
+    "lastReultHashes",
     "note",
     "ips",
     "testActivity",

--- a/backend/src/dal/user.ts
+++ b/backend/src/dal/user.ts
@@ -589,7 +589,10 @@ export async function updateLastHashes(
     { uid },
     {
       $set: {
-        lastReultHashes: lastHashes, //TODO fix typo
+        lastResultHashes: lastHashes,
+      },
+      $unset: {
+        lastReultHashes: 1,
       },
     },
   );

--- a/packages/schemas/src/users.ts
+++ b/packages/schemas/src/users.ts
@@ -243,7 +243,8 @@ export const UserSchema = z.object({
   uid: z.string(), //defined by firebase, no validation should be applied
   addedAt: z.number().int().nonnegative(),
   personalBests: PersonalBestsSchema,
-  lastReultHashes: z.array(z.string()).optional(), //TODO: fix typo (it's in the db too)
+  lastResultHashes: z.array(z.string()).optional(),
+  lastReultHashes: z.array(z.string()).optional(), //legacy typo, kept for backwards compatibility
   completedTests: z.number().int().nonnegative().optional(),
   startedTests: z.number().int().nonnegative().optional(),
   timeTyping: z


### PR DESCRIPTION
### Description
This PR fixes a typo in the user hashes field used for duplicate-result detection.

#### Problem:
- The codebase used a misspelled key: `lastReultHashes`.
- This creates long-term schema/DB inconsistency and makes future updates risky.


#### Repro (before this change):
1. Inspect user schema and backend result logic.
2. Notice reads/writes use `lastReultHashes` (typo) instead of `lastResultHashes`.
3. Any new code using the correct key would not align with existing data shape.


#### Approach:
- Read from both keys for backward compatibility:
  - `lastResultHashes ?? lastReultHashes ?? []`
- Write to the corrected key `lastResultHashes`.
- Unset legacy key `lastReultHashes` during updates.
- Keep both keys in schema for compatibility during migration.
- Exclude both keys from relevant user response shaping.
 
### Checks
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.
Closes #
Suggested PR title format (per their rule):
- fix(user): migrate lastReultHashes to lastResultHashes safely (@mukundangopalachary)