### PR TITLE
impr: support mixed-height line jumps (@nadalaba)

### DIFF
--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -206,20 +206,6 @@
     width: inherit;
   }
 
-  .beforeNewline {
-    display: inline-block;
-    vertical-align: top;
-    margin: 0.25em 0;
-    box-sizing: content-box;
-    height: 1em; //.word line-height
-    border-top: 0.05em solid transparent; // letter border-bottom
-    border-bottom: 2px solid transparent; //.word border
-  }
-
-  .afterNewline {
-    display: inline-block;
-  }
-
   --correct-letter-color: var(--text-color);
   --correct-letter-animation: none;
   --untyped-letter-color: var(--sub-color);
@@ -313,6 +299,24 @@
       display: inline-block;
       vertical-align: top;
     }
+    .beforeNewline {
+      display: inline-block;
+      vertical-align: top;
+      margin: 0.25em 0;
+      box-sizing: content-box;
+      height: 1em; //.word line-height
+      border-top: 0.05em solid transparent; // letter border-bottom
+      border-bottom: 2px solid transparent; //.word border
+    }
+    .afterNewline {
+      display: inline-block;
+    }
+    &.withLigatures {
+      .beforeNewline {
+        border-top: unset;
+        padding-bottom: 0.05em;
+      }
+    }
   }
 
   /* a little hack for right-to-left languages */
@@ -336,10 +340,6 @@
       letter {
         display: inline;
       }
-    }
-    .beforeNewline {
-      border-top: unset;
-      padding-bottom: 0.05em;
     }
   }
   &.blurred {

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -202,20 +202,6 @@
     width: inherit;
   }
 
-  .beforeNewline {
-    display: inline-block;
-    vertical-align: top;
-    margin: 0.25em 0;
-    box-sizing: content-box;
-    height: 1em; //.word line-height
-    border-top: 0.05em solid transparent; // letter border-bottom
-    border-bottom: 2px solid transparent; //.word border
-  }
-
-  .afterNewline {
-    display: inline-block;
-  }
-
   --correct-letter-color: var(--text-color);
   --correct-letter-animation: none;
   --untyped-letter-color: var(--sub-color);
@@ -309,6 +295,24 @@
       display: inline-block;
       vertical-align: top;
     }
+    .beforeNewline {
+      display: inline-block;
+      vertical-align: top;
+      margin: 0.25em 0;
+      box-sizing: content-box;
+      height: 1em; //.word line-height
+      border-top: 0.05em solid transparent; // letter border-bottom
+      border-bottom: 2px solid transparent; //.word border
+    }
+    .afterNewline {
+      display: inline-block;
+    }
+    &.joiningScript {
+      .beforeNewline {
+        border-top: unset;
+        padding-bottom: 0.05em;
+      }
+    }
   }
 
   /* a little hack for right-to-left languages */
@@ -332,10 +336,6 @@
       letter {
         display: inline;
       }
-    }
-    .beforeNewline {
-      border-top: unset;
-      padding-bottom: 0.05em;
     }
   }
   &.blurred {

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1149,20 +1149,7 @@ export function updatePremid(): void {
   qs(".pageTest #premidSecondsLeft")?.setText(`${Config.time}`);
 }
 
-function removeTestElements(lastElementIndexToRemove: number): void {
-  const wordsChildren = wordsEl.getChildren();
-
-  if (wordsChildren === undefined) return;
-
-  for (let i = lastElementIndexToRemove; i >= 0; i--) {
-    const child = wordsChildren[i];
-    if (!child || !child.native.isConnected) continue;
-    child.remove();
-  }
-}
-
 let currentLinesJumping = 0;
-
 export async function lineJump(
   currentTop: number,
   force = false,
@@ -1172,34 +1159,25 @@ export async function lineJump(
     const hideBound = currentTop;
 
     const activeWordEl = getActiveWordElement();
-    if (!activeWordEl) {
-      // resolve();
-      return;
-    }
+    if (!activeWordEl) return;
+
+    const wordsChildren = wordsEl.getChildren();
+    const removeTestElements = (lastWordToRemoveIndex: number): void => {
+      let i = lastWordToRemoveIndex;
+      while (i >= 0) wordsChildren[i--]?.remove();
+    };
 
     // index of the active word in all #words.children
     // (which contains .word/.newline/.beforeNewline/.afterNewline elements)
-    const wordsChildren = wordsEl.getChildren();
-    const activeWordElementIndex = wordsChildren.indexOf(activeWordEl);
-
-    let lastElementIndexToRemove: number | undefined = undefined;
-    for (let i = activeWordElementIndex - 1; i >= 0; i--) {
-      const child = wordsChildren[i] as ElementWithUtils;
-      if (child.hasClass("hidden")) continue;
-      if (Math.floor(child.getOffsetTop()) < hideBound) {
-        if (child.hasClass("word")) {
-          lastElementIndexToRemove = i;
-          break;
-        } else if (child.hasClass("beforeNewline")) {
-          // set it to .newline but check .beforeNewline.offsetTop
-          // because it's more reliable
-          lastElementIndexToRemove = i + 1;
-          break;
-        }
-      }
+    let i = wordsChildren.indexOf(activeWordEl);
+    let word: ElementWithUtils | undefined;
+    // find i: index of last word to remove
+    while (i >= 0 && (word = wordsChildren[--i])) {
+      if (word.isHidden()) continue;
+      if (word.hasClass("word") && word.getOffsetTop() < hideBound) break;
     }
 
-    if (lastElementIndexToRemove === undefined) {
+    if (i < 0) {
       currentTestLine++;
       updateWordsWrapperHeight();
       return;
@@ -1210,6 +1188,14 @@ export async function lineJump(
     const wordHeight = activeWordEl.getOuterHeight();
     const newMarginTop = -1 * wordHeight * currentLinesJumping;
     const duration = 125;
+
+    // remove leading .beforeNewline and .newline after last word to remove
+    while (
+      wordsChildren[i + 1]?.hasClass("beforeNewline") ||
+      wordsChildren[i + 1]?.hasClass("newline")
+    ) {
+      i++;
+    }
 
     const caretLineJumpOptions = {
       newMarginTop,
@@ -1227,12 +1213,12 @@ export async function lineJump(
       currentLinesJumping = 0;
       activeWordTop = activeWordEl.getOffsetTop();
       activeWordHeight = activeWordEl.getOffsetHeight();
-      removeTestElements(lastElementIndexToRemove);
+      removeTestElements(i);
       wordsEl.setStyle({ marginTop: "0" });
       lineTransition = false;
     } else {
       currentLinesJumping = 0;
-      removeTestElements(lastElementIndexToRemove);
+      removeTestElements(i);
     }
   }
   currentTestLine++;

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1149,7 +1149,7 @@ export function updatePremid(): void {
   qs(".pageTest #premidSecondsLeft")?.setText(`${Config.time}`);
 }
 
-let currentLinesJumping = 0;
+let currentHeightJumping = 0;
 export async function lineJump(
   currentTop: number,
   force = false,
@@ -1183,10 +1183,10 @@ export async function lineJump(
       return;
     }
 
-    currentLinesJumping++;
+    currentHeightJumping +=
+      word?.getOuterHeight() ?? activeWordEl.getOuterHeight();
 
-    const wordHeight = activeWordEl.getOuterHeight();
-    const newMarginTop = -1 * wordHeight * currentLinesJumping;
+    const newMarginTop = -1 * currentHeightJumping;
     const duration = 125;
 
     // remove leading .beforeNewline and .newline after last word to remove
@@ -1210,14 +1210,14 @@ export async function lineJump(
         marginTop: newMarginTop,
         duration,
       });
-      currentLinesJumping = 0;
+      currentHeightJumping = 0;
       activeWordTop = activeWordEl.getOffsetTop();
       activeWordHeight = activeWordEl.getOffsetHeight();
       removeTestElements(i);
       wordsEl.setStyle({ marginTop: "0" });
       lineTransition = false;
     } else {
-      currentLinesJumping = 0;
+      currentHeightJumping = 0;
       removeTestElements(i);
     }
   }

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1161,18 +1161,6 @@ export function updatePremid(): void {
   qs(".pageTest #premidSecondsLeft")?.setText(`${Config.time}`);
 }
 
-function removeTestElements(lastElementIndexToRemove: number): void {
-  const wordsChildren = wordsEl.getChildren();
-
-  if (wordsChildren === undefined) return;
-
-  for (let i = lastElementIndexToRemove; i >= 0; i--) {
-    const child = wordsChildren[i];
-    if (!child || !child.native.isConnected) continue;
-    child.remove();
-  }
-}
-
 let currentLinesJumping = 0;
 
 async function lineJump(currentTop: number, force = false): Promise<void> {
@@ -1183,29 +1171,23 @@ async function lineJump(currentTop: number, force = false): Promise<void> {
     const activeWordEl = getActiveWordElement();
     if (!activeWordEl) return;
 
+    const wordsChildren = wordsEl.getChildren();
+    const removeTestElements = (lastWordToRemoveIndex: number): void => {
+      let i = lastWordToRemoveIndex;
+      while (i >= 0) wordsChildren[i--]?.remove();
+    };
+
     // index of the active word in all #words.children
     // (which contains .word/.newline/.beforeNewline/.afterNewline elements)
-    const wordsChildren = wordsEl.getChildren();
-    const activeWordElementIndex = wordsChildren.indexOf(activeWordEl);
-
-    let lastElementIndexToRemove: number | undefined = undefined;
-    for (let i = activeWordElementIndex - 1; i >= 0; i--) {
-      const child = wordsChildren[i] as ElementWithUtils;
-      if (child.hasClass("hidden")) continue;
-      if (Math.floor(child.getOffsetTop()) < hideBound) {
-        if (child.hasClass("word")) {
-          lastElementIndexToRemove = i;
-          break;
-        } else if (child.hasClass("beforeNewline")) {
-          // set it to .newline but check .beforeNewline.offsetTop
-          // because it's more reliable
-          lastElementIndexToRemove = i + 1;
-          break;
-        }
-      }
+    let i = wordsChildren.indexOf(activeWordEl);
+    let word: ElementWithUtils | undefined;
+    // find i: index of last word to remove
+    while (i >= 0 && (word = wordsChildren[--i])) {
+      if (word.isHidden()) continue;
+      if (word.hasClass("word") && word.getOffsetTop() < hideBound) break;
     }
 
-    if (lastElementIndexToRemove === undefined) {
+    if (i < 0) {
       currentTestLine++;
       updateWordsWrapperHeight();
       return;
@@ -1216,6 +1198,14 @@ async function lineJump(currentTop: number, force = false): Promise<void> {
     const wordHeight = activeWordEl.getOuterHeight();
     const newMarginTop = -1 * wordHeight * currentLinesJumping;
     const duration = 125;
+
+    // remove leading .beforeNewline and .newline after last word to remove
+    while (
+      wordsChildren[i + 1]?.hasClass("beforeNewline") ||
+      wordsChildren[i + 1]?.hasClass("newline")
+    ) {
+      i++;
+    }
 
     const caretLineJumpOptions = {
       newMarginTop,
@@ -1233,12 +1223,12 @@ async function lineJump(currentTop: number, force = false): Promise<void> {
       currentLinesJumping = 0;
       activeWordTop = activeWordEl.getOffsetTop();
       activeWordHeight = activeWordEl.getOffsetHeight();
-      removeTestElements(lastElementIndexToRemove);
+      removeTestElements(i);
       wordsEl.setStyle({ marginTop: "0" });
       lineTransition = false;
     } else {
       currentLinesJumping = 0;
-      removeTestElements(lastElementIndexToRemove);
+      removeTestElements(i);
     }
   }
   currentTestLine++;

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1161,7 +1161,7 @@ export function updatePremid(): void {
   qs(".pageTest #premidSecondsLeft")?.setText(`${Config.time}`);
 }
 
-let currentLinesJumping = 0;
+let currentHeightJumping = 0;
 
 async function lineJump(currentTop: number, force = false): Promise<void> {
   //last word of the line
@@ -1193,10 +1193,10 @@ async function lineJump(currentTop: number, force = false): Promise<void> {
       return;
     }
 
-    currentLinesJumping++;
+    currentHeightJumping +=
+      word?.getOuterHeight() ?? activeWordEl.getOuterHeight();
 
-    const wordHeight = activeWordEl.getOuterHeight();
-    const newMarginTop = -1 * wordHeight * currentLinesJumping;
+    const newMarginTop = -1 * currentHeightJumping;
     const duration = 125;
 
     // remove leading .beforeNewline and .newline after last word to remove
@@ -1220,14 +1220,14 @@ async function lineJump(currentTop: number, force = false): Promise<void> {
         marginTop: newMarginTop,
         duration,
       });
-      currentLinesJumping = 0;
+      currentHeightJumping = 0;
       activeWordTop = activeWordEl.getOffsetTop();
       activeWordHeight = activeWordEl.getOffsetHeight();
       removeTestElements(i);
       wordsEl.setStyle({ marginTop: "0" });
       lineTransition = false;
     } else {
-      currentLinesJumping = 0;
+      currentHeightJumping = 0;
       removeTestElements(i);
     }
   }


### PR DESCRIPTION
**commit 1:** `.beforeNewline` was not inline with preceding word when the word was multi-line, causing `.newline` to have a height.
<img width="582" height="254" alt="newlineWithHeight" src="https://github.com/user-attachments/assets/df0055d7-ff2a-42e1-8f12-2a407013bfa4" />

**commit 2:** support mixed-height line jumps
<img width="720" height="480" alt="long-short-lineJump" src="https://github.com/user-attachments/assets/eca47915-7ff7-4e6f-9425-e9cd492a0c00" />
<img width="720" height="480" alt="short-long-lineJump" src="https://github.com/user-attachments/assets/74bcf11a-ed65-4539-89b7-efc69b84d621" />