### PR TITLE
fix(typed effect): allow fade effect with reduced motion (@d1rshan)

### DIFF
--- a/frontend/src/styles/media-queries.scss
+++ b/frontend/src/styles/media-queries.scss
@@ -43,7 +43,12 @@ body {
 
 @media (prefers-reduced-motion) {
   body:not(.ignore-reduced-motion)
-    *:not(.fa-spin, .animate-\[loader\], .preloader) {
+    *:not(
+      .fa-spin,
+      .animate-\[loader\],
+      .preloader,
+      .typed-effect-fade .word.typed
+    ) {
     animation: none !important;
     transition: none !important;
 

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -530,6 +530,10 @@
   &.typed-effect-fade {
     .word.typed {
       animation: fadeOut 250ms ease-in 1 forwards;
+
+      @media (prefers-reduced-motion) {
+        opacity: 0;
+      }
     }
   }
 

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -529,11 +529,7 @@
 
   &.typed-effect-fade {
     .word.typed {
-      animation: fadeOut 250ms ease-in 1 forwards;
-
-      @media (prefers-reduced-motion) {
-        opacity: 0;
-      }
+      animation: fadeOut 250ms ease-in 1 forwards !important;
     }
   }
 
@@ -574,7 +570,7 @@
         color: var(--bg-color);
         animation: typedEffectToDust 200ms ease-out 0ms 1 forwards !important;
         &::after {
-          animation: typedEffectFadeIn 100ms ease-in 100ms 1 forwards;
+          animation: typedEffectFadeIn 100ms ease-in 100ms 1 forwards !important;
           background: var(--c-dot);
         }
       }
@@ -587,21 +583,6 @@
     }
     &.withLigatures:not(.blind) .word.broken-ligatures letter.incorrect::after {
       background: var(--c-dot--error);
-    }
-
-    @media (prefers-reduced-motion) {
-      &:not(.withLigatures) .word.typed,
-      &.withLigatures .word.broken-ligatures.typed {
-        letter {
-          animation: none !important;
-          transform: scale(0.4);
-          color: transparent;
-          &::after {
-            animation: none !important;
-            opacity: 1;
-          }
-        }
-      }
     }
   }
 }

--- a/frontend/src/styles/test.scss
+++ b/frontend/src/styles/test.scss
@@ -529,7 +529,7 @@
 
   &.typed-effect-fade {
     .word.typed {
-      animation: fadeOut 250ms ease-in 1 forwards !important;
+      animation: fadeOut 250ms ease-in 1 forwards;
     }
   }
 
@@ -570,7 +570,7 @@
         color: var(--bg-color);
         animation: typedEffectToDust 200ms ease-out 0ms 1 forwards !important;
         &::after {
-          animation: typedEffectFadeIn 100ms ease-in 100ms 1 forwards !important;
+          animation: typedEffectFadeIn 100ms ease-in 100ms 1 forwards;
           background: var(--c-dot);
         }
       }
@@ -583,6 +583,21 @@
     }
     &.withLigatures:not(.blind) .word.broken-ligatures letter.incorrect::after {
       background: var(--c-dot--error);
+    }
+
+    @media (prefers-reduced-motion) {
+      &:not(.withLigatures) .word.typed,
+      &.withLigatures .word.broken-ligatures.typed {
+        letter {
+          animation: none !important;
+          transform: scale(0.4);
+          color: transparent;
+          &::after {
+            animation: none !important;
+            opacity: 1;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Current Behavior for Reduced Motion

1. keep  - Letters stay (No change)                   
2. hide  - Letters vanish instantly (No change)
3. fade - Letters stay **(Effect is lost)**                   
4. dots -  Letters become dots instantly  (has a Fallback)

### Changes
This PR makes sure that `fade` effect works for reduced motion by adding it to the global exclude list for reduced motion.

Closes #7847 
