### PR TITLE
feat(profile): add barebones achievements (@jonasiwnl)

### DIFF
--- a/frontend/__tests__/utils/achievements.spec.ts
+++ b/frontend/__tests__/utils/achievements.spec.ts
@@ -1,0 +1,116 @@
+import { UserProfile } from "@monkeytype/schemas/users";
+import { describe, expect, it } from "vitest";
+
+import { getAchievements } from "../../src/ts/utils/achievements";
+
+function getProfile(overrides: Partial<UserProfile> = {}): UserProfile {
+  return {
+    name: "test-user",
+    addedAt: 0,
+    xp: 0,
+    banned: false,
+    lbOptOut: false,
+    streak: 0,
+    maxStreak: 0,
+    details: {},
+    allTimeLbs: {
+      time: {},
+    },
+    typingStats: {
+      startedTests: 0,
+      completedTests: 0,
+      timeTyping: 0,
+    },
+    personalBests: {
+      time: {},
+      words: {},
+    },
+    testActivity: {
+      testsByDays: [],
+      lastDay: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("achievements.ts", () => {
+  it("should mark achievements as unlocked when thresholds are met", () => {
+    const achievements = getAchievements(
+      getProfile({
+        xp: 3000,
+        maxStreak: 7,
+        typingStats: {
+          startedTests: 120,
+          completedTests: 100,
+          timeTyping: 10 * 60 * 60,
+        },
+        personalBests: {
+          time: {
+            "60": [
+              {
+                acc: 99,
+                consistency: 80,
+                difficulty: "normal",
+                language: "english",
+                raw: 110,
+                timestamp: 1,
+                wpm: 100,
+              },
+            ],
+          },
+          words: {},
+        },
+      }),
+    );
+
+    expect(achievements.every((it) => it.unlocked)).toBe(true);
+  });
+
+  it("should cap visible progress percentage while keeping raw progress labels", () => {
+    const achievements = getAchievements(
+      getProfile({
+        typingStats: {
+          startedTests: 10,
+          completedTests: 250,
+          timeTyping: 0,
+        },
+      }),
+    );
+
+    const committed = achievements.find((it) => it.id === "hundred_tests");
+
+    expect(committed?.progressPercent).toBe(100);
+    expect(committed?.progressLabel).toBe("250/100");
+  });
+
+  it("should derive wpm and level achievements from saved profile data", () => {
+    const achievements = getAchievements(
+      getProfile({
+        xp: 2000,
+        personalBests: {
+          time: {},
+          words: {
+            "25": [
+              {
+                acc: 98,
+                consistency: 75,
+                difficulty: "normal",
+                language: "english",
+                raw: 130,
+                timestamp: 1,
+                wpm: 123,
+              },
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(achievements.find((it) => it.id === "hundred_wpm")?.unlocked).toBe(
+      true,
+    );
+    expect(
+      achievements.find((it) => it.id === "level_ten")?.progressLabel,
+    ).toBe("Level 8/10");
+  });
+});

--- a/frontend/src/ts/components/pages/profile/Achievements.tsx
+++ b/frontend/src/ts/components/pages/profile/Achievements.tsx
@@ -1,0 +1,69 @@
+import { UserProfile } from "@monkeytype/schemas/users";
+import { For, JSXElement } from "solid-js";
+
+import { Achievement, getAchievements } from "../../../utils/achievements";
+import { cn } from "../../../utils/cn";
+import { Bar } from "../../common/Bar";
+import { Fa } from "../../common/Fa";
+
+export function Achievements(props: { profile: UserProfile }): JSXElement {
+  const achievements = () => getAchievements(props.profile);
+
+  return (
+    <div class="grid gap-4 rounded bg-sub-alt p-4">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <div class="text-lg text-text">Achievements</div>
+          <div class="text-sm text-sub">
+            A barebones read-only overview of profile milestones.
+          </div>
+        </div>
+        <div class="text-sm text-sub">
+          {achievements().filter((it) => it.unlocked).length}/
+          {achievements().length} unlocked
+        </div>
+      </div>
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+        <For each={achievements()}>
+          {(achievement) => <AchievementCard achievement={achievement} />}
+        </For>
+      </div>
+    </div>
+  );
+}
+
+function AchievementCard(props: { achievement: Achievement }): JSXElement {
+  return (
+    <div
+      class={cn(
+        "grid gap-3 rounded bg-bg p-4 transition-colors",
+        props.achievement.unlocked ? "text-text" : "text-sub",
+      )}
+    >
+      <div class="flex items-start gap-3">
+        <div
+          class={cn(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-full",
+            props.achievement.unlocked
+              ? "bg-main text-bg"
+              : "bg-sub-alt text-sub",
+          )}
+        >
+          <Fa icon={props.achievement.icon} />
+        </div>
+        <div class="min-w-0">
+          <div class="font-semibold">{props.achievement.name}</div>
+          <div class="text-sm">{props.achievement.description}</div>
+        </div>
+      </div>
+      <div class="flex items-center gap-3 text-xs">
+        <Bar
+          percent={props.achievement.progressPercent}
+          fill={props.achievement.unlocked ? "main" : "text"}
+          bg="sub-alt"
+        />
+        <div class="shrink-0">{props.achievement.progressLabel}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ts/components/pages/profile/UserProfile.tsx
+++ b/frontend/src/ts/components/pages/profile/UserProfile.tsx
@@ -11,6 +11,7 @@ import * as PbTablesModal from "../../../modals/pb-tables";
 import { Formatting } from "../../../utils/format";
 import { formatTopPercentage } from "../../../utils/misc";
 import { Button } from "../../common/Button";
+import { Achievements } from "./Achievements";
 import { ActivityCalendar } from "./ActivityCalendar";
 import { UserDetails } from "./UserDetails";
 
@@ -30,6 +31,7 @@ export function UserProfile(props: {
           top60={props.profile.allTimeLbs?.time?.["60"]?.["english"]}
         />
       </Show>
+      <Achievements profile={props.profile} />
       <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
         <PbTable
           mode="time"

--- a/frontend/src/ts/utils/achievements.ts
+++ b/frontend/src/ts/utils/achievements.ts
@@ -1,0 +1,125 @@
+import { PersonalBest } from "@monkeytype/schemas/shared";
+import { UserProfile } from "@monkeytype/schemas/users";
+
+import { FaSolidIcon } from "../types/font-awesome";
+import { getLevelFromTotalXp } from "./levels";
+
+type AchievementProgressFormatter = (
+  progress: number,
+  target: number,
+) => string;
+
+export type AchievementDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  icon: FaSolidIcon;
+  target: number;
+  getProgress: (profile: UserProfile) => number;
+  formatProgress?: AchievementProgressFormatter;
+};
+
+export type Achievement = AchievementDefinition & {
+  progress: number;
+  progressPercent: number;
+  unlocked: boolean;
+  progressLabel: string;
+};
+
+const formatIntegerProgress: AchievementProgressFormatter = (
+  progress,
+  target,
+) => `${Math.floor(progress)}/${target}`;
+
+const formatLevelProgress: AchievementProgressFormatter = (progress, target) =>
+  `Level ${Math.floor(progress)}/${target}`;
+
+const formatHourProgress: AchievementProgressFormatter = (progress, target) =>
+  `${Math.floor(progress / 3600)}h/${Math.floor(target / 3600)}h`;
+
+const achievementDefinitions: AchievementDefinition[] = [
+  {
+    id: "first_test",
+    name: "First Steps",
+    description: "Complete your first typing test.",
+    icon: "fa-check-circle",
+    target: 1,
+    getProgress: (profile) => profile.typingStats.completedTests ?? 0,
+  },
+  {
+    id: "hundred_tests",
+    name: "Committed",
+    description: "Complete 100 typing tests.",
+    icon: "fa-tasks",
+    target: 100,
+    getProgress: (profile) => profile.typingStats.completedTests ?? 0,
+  },
+  {
+    id: "typing_marathon",
+    name: "Typing Marathon",
+    description: "Spend 10 hours actively typing.",
+    icon: "fa-hourglass-half",
+    target: 10 * 60 * 60,
+    getProgress: (profile) => profile.typingStats.timeTyping ?? 0,
+    formatProgress: formatHourProgress,
+  },
+  {
+    id: "weekly_streak",
+    name: "On Fire",
+    description: "Reach a 7 day streak.",
+    icon: "fa-fire",
+    target: 7,
+    getProgress: (profile) => profile.maxStreak ?? 0,
+  },
+  {
+    id: "level_ten",
+    name: "Level 10",
+    description: "Reach level 10.",
+    icon: "fa-star",
+    target: 10,
+    getProgress: (profile) => getLevelFromTotalXp(profile.xp ?? 0),
+    formatProgress: formatLevelProgress,
+  },
+  {
+    id: "hundred_wpm",
+    name: "Century",
+    description: "Hit 100 WPM on any saved personal best.",
+    icon: "fa-keyboard",
+    target: 100,
+    getProgress: (profile) => getHighestPersonalBestWpm(profile.personalBests),
+  },
+];
+
+function getHighestPersonalBestWpm(
+  personalBests: UserProfile["personalBests"],
+): number {
+  const allBests = [
+    ...Object.values(personalBests.time),
+    ...Object.values(personalBests.words),
+  ].flat();
+
+  return allBests.reduce(
+    (highest: number, best: PersonalBest) => Math.max(highest, best.wpm ?? 0),
+    0,
+  );
+}
+
+export function getAchievements(profile: UserProfile): Achievement[] {
+  return achievementDefinitions.map((definition) => {
+    const rawProgress = definition.getProgress(profile);
+    const progress = Math.min(rawProgress, definition.target);
+    const unlocked = rawProgress >= definition.target;
+
+    return {
+      ...definition,
+      progress: rawProgress,
+      progressPercent:
+        definition.target === 0 ? 100 : (progress / definition.target) * 100,
+      unlocked,
+      progressLabel: (definition.formatProgress ?? formatIntegerProgress)(
+        rawProgress,
+        definition.target,
+      ),
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- add a frontend-only achievements derivation utility based on existing profile data
- add a profile achievements section for account and public profile pages
- add targeted tests for milestone derivation behavior

## Testing
- pnpm exec vitest run __tests__/utils/achievements.spec.ts
- pnpm exec oxlint src/ts/utils/achievements.ts src/ts/components/pages/profile/Achievements.tsx src/ts/components/pages/profile/UserProfile.tsx __tests__/utils/achievements.spec.ts --type-aware --type-check

## Notes
- implements a barebones interpretation of #64 without backend persistence or schema changes