### PR TITLE
fix(lang): command typo fix (@skywalkerwhack)

### DIFF
--- a/frontend/static/languages/code_bash.json
+++ b/frontend/static/languages/code_bash.json
@@ -185,7 +185,7 @@
     "ffmpeg",
     "mpv",
     "vlc",
-    "ffproble",
+    "ffprobe",
     "mplayer",
     "ip",
     "ifconfig",


### PR DESCRIPTION
modified:   frontend/static/languages/code_bash.json
### Description
fixed command typo in code_bash. 
The correct command should be `ffprobe` instead of `ffproble`.

