### PR TITLE
impr(turbo): enable tui ui (@d1rshan)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": [".env"],
+  "ui": "tui",
   "tasks": {
     "parallel": {
       "dependsOn": ["^parallel"]


### PR DESCRIPTION
Add `"ui": "tui"` to `turbo.json` so Turbo uses the TUI by default,
Makes local turbo output cleaner and easier during dev :)

<img width="1280" height="719" alt="turbo-tui" src="https://github.com/user-attachments/assets/67c3fb8d-7835-4ae9-bddd-55849c464b8c" />