### PR TITLE
fix(theme): prevent preview theme CSS from leaking after quick hover exit (@PlutoDog95)

### DIFF
--- a/frontend/src/ts/controllers/theme-controller.ts
+++ b/frontend/src/ts/controllers/theme-controller.ts
@@ -138,6 +138,7 @@ async function set(
 
 export async function clearPreview(applyTheme = true): Promise<void> {
   previewState = null;
+  debouncedPreview.cancel();
 
   if (isPreviewingTheme) {
     isPreviewingTheme = false;


### PR DESCRIPTION
## Summary

Fixes theme preview CSS leaking when hovering over a theme and quickly closing the theme menu without selecting it.

## Root Cause

Theme preview is triggered from the theme command hover handler using `ThemeController.preview(theme.name)`.

This uses a debounced preview function before applying the preview theme.

When the user exits the menu quickly, `clearPreview()` resets the preview state, but the pending debounced preview can still execute afterward and apply preview styles after cleanup.

This causes parts of the preview theme CSS to remain visible, matching issue #7875.

## Fix

Cancel the pending debounced preview inside `clearPreview()` before restoring the original theme:

`debouncedPreview.cancel();`

This ensures delayed preview application cannot happen after cleanup.

Closes #7875
