### PR TITLE
ci: optimize semantic PR title check workflow (@d1rshan)

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -11,11 +11,17 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: semantic-pr-title-${{ github.event.pull_request.number }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: check
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    runs-on: ubuntu-slim
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      (github.event.action != 'edited' || github.event.changes.title != null)
     steps:
       - name: Lint and verify PR title
         uses: amannn/action-semantic-pull-request@v5
@@ -49,6 +55,7 @@ jobs:
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
+          skip_unchanged: true
           message: |
             Hey there and thank you for opening this pull request! 👋🏼
 

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   main:
     name: check
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       (github.event.action != 'edited' || github.event.changes.title != null)


### PR DESCRIPTION
**Optimizes the pr title check workflow by doing these 3 things:**

1. _skip job on non-title edits_: (now the check runs for any event ie such as pr body edit)

2. _add concurrency group:_ (cancels any in-progress run when a newer one is triggered on the same pr)

3. _add `skip_unchanged: true` to comment step_:  (avoids a redundant api call to update the sticky error comment if its content hasn't changed since the last run)