### PR TITLE
fix: InputField story broken (@d1rshan)

### DIFF
--- a/frontend/storybook/stories/InputField.stories.tsx
+++ b/frontend/storybook/stories/InputField.stories.tsx
@@ -17,6 +17,7 @@ function createFieldMock(options: {
   name?: string;
   value?: string;
   meta?: MetaState;
+  validators?: object;
 }) {
   const stateMeta = {
     isTouched: true,
@@ -28,7 +29,7 @@ function createFieldMock(options: {
   return {
     name: options.name ?? "test",
     options: {
-      validators: undefined,
+      validators: options.validators,
     },
     get state() {
       return {
@@ -50,7 +51,6 @@ const meta = preview.meta({
   component: InputField as Component<{
     field: Accessor<AnyFieldApi>;
     placeholder?: string;
-    showIndicator?: true;
     autocomplete?: string;
     type?: string;
     disabled?: boolean;
@@ -62,7 +62,6 @@ const meta = preview.meta({
   tags: ["autodocs"],
   argTypes: {
     placeholder: { control: "text" },
-    showIndicator: { control: "boolean" },
     autocomplete: { control: "text" },
     type: { control: "text" },
     disabled: { control: "boolean" },
@@ -77,8 +76,10 @@ export const Default = meta.story({
 
 export const withIndicator = meta.story({
   args: {
-    showIndicator: true,
-    field: () => createFieldMock({}),
+    field: () =>
+      createFieldMock({
+        validators: { onChange: () => undefined },
+      }),
   },
 });
 

--- a/frontend/storybook/stories/InputField.stories.tsx
+++ b/frontend/storybook/stories/InputField.stories.tsx
@@ -27,6 +27,9 @@ function createFieldMock(options: {
   };
   return {
     name: options.name ?? "test",
+    options: {
+      validators: undefined,
+    },
     get state() {
       return {
         value: options.value ?? "",


### PR DESCRIPTION
### Regression
Commit 0c07e1074 (PR #7918) removed the `showIndicator` prop from InputField and switched to `props.field().options.validators` as the "Gate" to show/hide FieldIndicator, but didn't update InputField.stories.tsx. The story's field mock was missing options, causing props.field().options throw error

### Fix
Added options: { validators } support to createFieldMock, updated withIndicator to pass a dummy validator, and removed the dead showIndicator prop.