### PR TITLE
docs(issue-template): remove account name from account config field placeholder (@Leonabcd123)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -76,7 +76,6 @@ body:
       label: Account config
       description: If your issue only happens when logged in, please provide your config. To export your config, go to the Settings page, scroll all the way down to `import/export settings` and click `export`.
       placeholder: |
-        Miodec
         {"theme":"cyberspace","showKeyTips":false,"showLiveWpm":false,"showTimerProgress":false, ... "smoothCaret":true}
     validations:
       required: false


### PR DESCRIPTION
### Description

Account config doesn't include account name, and there's already a designated field for it.
