### PR TITLE
docs: add network hosting and reverse proxy troubleshooting (@isma-021)

### DIFF
--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -10,6 +10,7 @@
   - [Table of contents](#table-of-contents)
   - [Prerequisites](#prerequisites)
   - [Quickstart](#quickstart)
+    - [Hosting over the network (HTTPS)](#hosting-over-the-network-https)
   - [Account System](#account-system)
     - [Setup Firebase](#setup-firebase)
     - [Update backend configuration](#update-backend-configuration)
@@ -35,6 +36,30 @@
 - download the [backend-configuration.json](https://github.com/monkeytypegame/monkeytype/tree/master/docker/backend-configuration.json)
 - run `docker compose up -d`
 - after the command exits successfully you can access [http://localhost:8080](http://localhost:8080)
+
+### Hosting over the network (HTTPS)
+
+If you plan to access your self-hosted Monkeytype instance over a local network or the internet (not using `localhost`), **you must serve it over HTTPS**. Modern browsers restrict key web features, such as `crypto.randomUUID`, to secure contexts. Accessing the site via HTTP over a network will cause the frontend to crash with errors like `Uncaught TypeError: crypto.randomUUID is not a function`.
+
+To solve this, you need to place a reverse proxy (like Nginx, Caddy, or Traefik) in front of your containers to handle HTTPS/TLS termination.
+
+#### Troubleshooting Frontend Connection Issues
+
+If your reverse proxy is up but you see errors like `Looks like the server is experiencing unexpected down time` or network errors when fetching resources, your frontend is likely trying to communicate with the backend over unsecure HTTP, causing a **Mixed Content** block in the browser.
+
+Ensure you configure the frontend to talk to your secure backend URL by following these rules in your `.env` file:
+
+1. **Update the frontend and backend URL:** Set `MONKEYTYPE_FRONTENDURL` and `MONKEYTYPE_BACKENDURL` to your full HTTPS backend domain.
+2. **Do not include a trailing slash:** Ensure the URL does not end with a `/` (e.g., use `https://api.yourdomain.com`, **not** `https://api.yourdomain.com/`). A trailing slash will cause `404 Not Found` errors due to double slashes in the API calls (like `//configuration`).
+3. **Force container recreation:** Monkeytype is a Single Page Application (SPA), meaning environment variables are baked into the static JavaScript files during startup. If you change your `.env`, you must completely recreate the container for the changes to apply:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+> [!TIP]
+>     After updating your configuration and recreating the containers, clear your browser cache or perform a hard reload (Ctrl + F5) to make sure your browser isn't running an old cached version of the frontend.
+
 
 ## Account System
 


### PR DESCRIPTION
### Description 

I noticed that when trying to host Monkeytype over a local network or the internet instead of `localhost`, the frontend crashes with an `Uncaught TypeError: crypto.randomUUID is not a function` error. This happens because modern browsers restrict this API to secure contexts (HTTPS). 

When putting a reverse proxy in front to handle HTTPS, it's very easy to run into Mixed Content blocks or 404 errors due to incorrect `.env` configurations (like adding a trailing slash to `MONKEYTYPE_FRONTENDURL` or forgetting to completely recreate the containers).

This PR updates `SELF_HOSTING.md` to:
- Explain the HTTPS requirement for network deployments.
- Detail how to properly configure the backend URL in the `.env` file to avoid API 404 errors (the trailing slash issue).
- Highlight the importance of using `docker compose up -d --force-recreate` and clearing the browser cache, since environment variables are baked into the SPA static files at startup.

### Checks

- [X] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info) 
- [X] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.