### PR TITLE
impr(themes): add cookie theme (@TemperTimothy)

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -2322,6 +2322,18 @@ export const themes: Record<ThemeName, Theme> = {
     colorfulError: "#b29a91",
     colorfulErrorExtra: "#b29a91",
   },
+   cookie: {
+    bg: "#784b26",
+    caret: "#5e3d38",
+    main: "#b38c56",
+    sub: "#b38c56",
+    subAlt: "#9d7345",
+    text: "#56322d",
+    error: "#ca4754",
+    errorExtra: "#7e2a33",
+    colorfulError: "#ca4754",
+    colorfulErrorExtra: "#7e2a33",
+   },
 };
 
 export type ThemeWithName = Theme & { name: ThemeName };

--- a/packages/schemas/src/themes.ts
+++ b/packages/schemas/src/themes.ts
@@ -190,6 +190,7 @@ export const ThemeNameSchema = z.enum(
     "witch_girl",
     "pale_nimbus",
     "spiderman",
+    "cookie",
   ],
   {
     errorMap: customEnumErrorHandler("Must be a known theme"),


### PR DESCRIPTION
### Description
  I added a cookie theme to the website. Closest to it is leather but it's very different definitely. 
### Checks
WITH FLIP AND COLORFUL ON:
<img width="824" height="725" alt="image" src="https://github.com/user-attachments/assets/897f8e4c-0ba5-4603-8b5d-4d9be0c8eb58" />
<img width="801" height="775" alt="image" src="https://github.com/user-attachments/assets/a199092b-310d-4420-b926-f6751840118f" />
<img width="790" height="387" alt="image" src="https://github.com/user-attachments/assets/6b9c2aa0-94ad-4bce-8809-e4a1e2249a89" />
BOTH OFF:
<img width="873" height="628" alt="image" src="https://github.com/user-attachments/assets/666b367b-91fc-468f-a582-76b40ed4377d" />
<img width="820" height="772" alt="image" src="https://github.com/user-attachments/assets/4f487028-778c-48df-908a-bea27f5ef72f" />
<img width="808" height="581" alt="image" src="https://github.com/user-attachments/assets/0e4f7bd9-ce63-447e-85b3-0406cb03b458" />
Closes #
My monkeytype username is Iqfaa.
