### PR TITLE
fix(blind-mode): on button has incorrect height on firefox (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/config/metadata.tsx
+++ b/frontend/src/ts/config/metadata.tsx
@@ -304,7 +304,7 @@ export const configMetadata: ConfigMetadataObject = {
     fa: { icon: "fa-eye-slash" },
     optionsMetadata: {
       true: {
-        displayString: "‎",
+        displayString: " ",
       },
     },
     displayString: "blind mode",

--- a/frontend/src/ts/config/metadata.tsx
+++ b/frontend/src/ts/config/metadata.tsx
@@ -304,6 +304,8 @@ export const configMetadata: ConfigMetadataObject = {
     fa: { icon: "fa-eye-slash" },
     optionsMetadata: {
       true: {
+        // Need to have space here so that the `on` button for blind mode will have the
+        // same height on both Chromium and Firefox.
         displayString: " ",
       },
     },


### PR DESCRIPTION
<img width="1551" height="83" alt="image" src="https://github.com/user-attachments/assets/29a61ec0-9e8e-4b3f-8c0b-4693fef9ac3e" />

For some reason, Chromium and Firefox differ on the height of a button containing only `&lrm;`, use `&ensp;` like we did before 1cefe7cf40c1ed42cb68dc0e837a07bcfc5d7325.