### PR TITLE
fix(key-tips): add missing space to commandline key tip (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/components/pages/settings/Settings.tsx
+++ b/frontend/src/ts/components/pages/settings/Settings.tsx
@@ -68,7 +68,7 @@ export function Settings(): JSXElement {
         <div class="text-center text-sub">
           tip: You can also change all these settings quickly using the command
           line
-          <br />(<CommandlineHotkey /> )
+          <br />( <CommandlineHotkey /> )
         </div>
       </Show>
       <AccountSettingsNotice />


### PR DESCRIPTION
Before:
<img width="797" height="81" alt="image" src="https://github.com/user-attachments/assets/35198ef6-ca44-4300-9ddc-601345305a47" />

After:
<img width="801" height="81" alt="image" src="https://github.com/user-attachments/assets/48591f5d-c58c-4f60-915c-832b5b26a0f6" />