### PR TITLE
fix(contracts): enforce password complexity requirements on update endpoint (@d1rshan)

### DIFF
--- a/backend/__tests__/api/controllers/user.spec.ts
+++ b/backend/__tests__/api/controllers/user.spec.ts
@@ -1524,7 +1524,7 @@ describe("user controller test", () => {
         validationErrors: ["Unrecognized key(s) in object: 'extra'"],
       });
     });
-    it("should fail with password too short", async () => {
+    it("should fail with invalid password", async () => {
       //WHEN
       const { body } = await mockApp
         .patch("/users/password")

--- a/backend/__tests__/api/controllers/user.spec.ts
+++ b/backend/__tests__/api/controllers/user.spec.ts
@@ -1487,7 +1487,7 @@ describe("user controller test", () => {
       const { body } = await mockApp
         .patch("/users/password")
         .set("Authorization", `Bearer ${uid}`)
-        .send({ newPassword: "sw0rdf1sh" })
+        .send({ newPassword: "Sw0rdf1sh!" })
         .expect(200);
 
       //THEN
@@ -1495,7 +1495,7 @@ describe("user controller test", () => {
         message: "Password updated",
         data: null,
       });
-      expect(updatePasswordMock).toHaveBeenCalledWith(uid, "sw0rdf1sh");
+      expect(updatePasswordMock).toHaveBeenCalledWith(uid, "Sw0rdf1sh!");
     });
     it("should fail without mandatory properties", async () => {
       //WHEN
@@ -1515,7 +1515,7 @@ describe("user controller test", () => {
       const { body } = await mockApp
         .patch("/users/password")
         .set("Authorization", `Bearer ${uid}`)
-        .send({ newPassword: "sw0rdf1sh", extra: "value" })
+        .send({ newPassword: "Sw0rdf1sh!", extra: "value" })
         .expect(422);
 
       //THEN
@@ -1536,7 +1536,10 @@ describe("user controller test", () => {
       expect(body).toEqual({
         message: "Invalid request data schema",
         validationErrors: [
-          '"newPassword" String must contain at least 6 character(s)',
+          '"newPassword" must be at least 8 characters',
+          '"newPassword" must contain at least one capital letter',
+          '"newPassword" must contain at least one number',
+          '"newPassword" must contain at least one special character',
         ],
       });
     });

--- a/packages/contracts/src/users.ts
+++ b/packages/contracts/src/users.ts
@@ -14,6 +14,7 @@ import {
   CustomThemeSchema,
   FavoriteQuotesSchema,
   MonkeyMailSchema,
+  PasswordSchema,
   ResultFiltersSchema,
   StreakHourOffsetSchema,
   TagNameSchema,
@@ -88,7 +89,7 @@ export const UpdateEmailRequestSchema = z.object({
 export type UpdateEmailRequest = z.infer<typeof UpdateEmailRequestSchema>;
 
 export const UpdatePasswordRequestSchema = z.object({
-  newPassword: z.string().min(6),
+  newPassword: PasswordSchema,
 });
 export type UpdatePasswordRequest = z.infer<typeof UpdatePasswordRequestSchema>;
 


### PR DESCRIPTION
The backend `UpdatePasswordRequestSchema` only enforced `z.string().min(6)`, while the frontend `PasswordSchema` requires min 8, max 64, uppercase, number, and special character. This allowed weak passwords to be set via direct API calls, bypassing frontend validation.

Updated the backend contract to use `PasswordSchema` from `@monkeytype/schemas/users`, ensuring consistent validation across frontend and backend.