### PR TITLE
fix(challenge): setup funboxes last when loading a challenge (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -28,7 +28,6 @@ import { tryCatch } from "@monkeytype/util/trycatch";
 import { Challenge } from "@monkeytype/schemas/challenges";
 import { qs } from "../utils/dom";
 import { getLoadedChallenge, setLoadedChallenge } from "../states/test";
-import { canSetFunboxWithConfig } from "../config/funbox-validation";
 
 let challengeLoading = false;
 
@@ -340,18 +339,13 @@ export async function setup(challengeName: string): Promise<boolean> {
         });
       }
 
-      const funboxes = challenge.parameters[0] as FunboxName[];
-
-      for (const funbox of funboxes) {
-        if (!canSetFunboxWithConfig(funbox, Config).ok) {
-          throw new Error(
-            `Funbox ${funbox} isn't compatible with the current config`,
-          );
-        }
+      if (
+        !setConfig("funbox", challenge.parameters[0] as FunboxName[], {
+          nosave: true,
+        })
+      ) {
+        throw new Error("Can't load challenge with current config");
       }
-      setConfig("funbox", funboxes, {
-        nosave: true,
-      });
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -318,9 +318,6 @@ export async function setup(challengeName: string): Promise<boolean> {
         nosave: true,
       });
     } else if (challenge.type === "funbox") {
-      setConfig("funbox", challenge.parameters[0] as FunboxName[], {
-        nosave: true,
-      });
       setConfig("difficulty", "normal", {
         nosave: true,
       });
@@ -341,6 +338,9 @@ export async function setup(challengeName: string): Promise<boolean> {
           nosave: true,
         });
       }
+      setConfig("funbox", challenge.parameters[0] as FunboxName[], {
+        nosave: true,
+      });
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -347,7 +347,7 @@ export async function setup(challengeName: string): Promise<boolean> {
           throw new Error("Funbox isn't compatible with the current config");
         }
       }
-      setConfig("funbox", challenge.parameters[0] as FunboxName[], {
+      setConfig("funbox", funboxes, {
         nosave: true,
       });
     } else if (challenge.type === "other") {

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -319,25 +319,17 @@ export async function setup(challengeName: string): Promise<boolean> {
         nosave: true,
       });
     } else if (challenge.type === "funbox") {
-      setConfig("difficulty", "normal", {
-        nosave: true,
-      });
+      const tempConfig: Partial<ConfigType> = {};
+
+      tempConfig.difficulty = "normal";
       if (challenge.parameters[1] === "words") {
-        setConfig("words", challenge.parameters[2] as number, {
-          nosave: true,
-        });
+        tempConfig.words = challenge.parameters[2] as number;
       } else if (challenge.parameters[1] === "time") {
-        setConfig("time", challenge.parameters[2] as number, {
-          nosave: true,
-        });
+        tempConfig.time = challenge.parameters[2] as number;
       }
-      setConfig("mode", challenge.parameters[1] as Mode, {
-        nosave: true,
-      });
+      tempConfig.mode = challenge.parameters[1] as Mode;
       if (challenge.parameters[3] !== undefined) {
-        setConfig("difficulty", challenge.parameters[3] as Difficulty, {
-          nosave: true,
-        });
+        tempConfig.difficulty = challenge.parameters[3] as Difficulty;
       }
 
       const funboxes = challenge.parameters[0] as FunboxName[];
@@ -352,6 +344,12 @@ export async function setup(challengeName: string): Promise<boolean> {
       setConfig("funbox", funboxes, {
         nosave: true,
       });
+
+      for (const [key, value] of Object.entries(tempConfig)) {
+        setConfig(key as keyof ConfigType, value, {
+          nosave: true,
+        });
+      }
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -344,7 +344,9 @@ export async function setup(challengeName: string): Promise<boolean> {
 
       for (const funbox of funboxes) {
         if (!canSetFunboxWithConfig(funbox, Config).ok) {
-          throw new Error("Funbox isn't compatible with the current config");
+          throw new Error(
+            `Funbox ${funbox} isn't compatible with the current config`,
+          );
         }
       }
       setConfig("funbox", funboxes, {

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -28,6 +28,7 @@ import { tryCatch } from "@monkeytype/util/trycatch";
 import { Challenge } from "@monkeytype/schemas/challenges";
 import { qs } from "../utils/dom";
 import { getLoadedChallenge, setLoadedChallenge } from "../states/test";
+import { canSetFunboxWithConfig } from "../config/funbox-validation";
 
 let challengeLoading = false;
 
@@ -337,6 +338,14 @@ export async function setup(challengeName: string): Promise<boolean> {
         setConfig("difficulty", challenge.parameters[3] as Difficulty, {
           nosave: true,
         });
+      }
+
+      const funboxes = challenge.parameters[0] as FunboxName[];
+
+      for (const funbox of funboxes) {
+        if (!canSetFunboxWithConfig(funbox, Config).ok) {
+          throw new Error("Funbox isn't compatible with the current config");
+        }
       }
       setConfig("funbox", challenge.parameters[0] as FunboxName[], {
         nosave: true,

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -334,24 +334,22 @@ export async function setup(challengeName: string): Promise<boolean> {
 
       const funboxes = challenge.parameters[0] as FunboxName[];
 
-      const fullTempConfig = { ...Config, ...tempConfig };
       for (const funbox of funboxes) {
-        if (!canSetFunboxWithConfig(funbox, fullTempConfig).ok) {
+        if (!canSetFunboxWithConfig(funbox, Config).ok) {
           throw new Error(
             `Funbox ${funbox} isn't compatible with the current config`,
           );
         }
       }
+      setConfig("funbox", funboxes, {
+        nosave: true,
+      });
 
       for (const [key, value] of Object.entries(tempConfig)) {
         setConfig(key as keyof ConfigType, value, {
           nosave: true,
         });
       }
-
-      setConfig("funbox", funboxes, {
-        nosave: true,
-      });
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -334,22 +334,24 @@ export async function setup(challengeName: string): Promise<boolean> {
 
       const funboxes = challenge.parameters[0] as FunboxName[];
 
+      const fullTempConfig = { ...Config, ...tempConfig };
       for (const funbox of funboxes) {
-        if (!canSetFunboxWithConfig(funbox, Config).ok) {
+        if (!canSetFunboxWithConfig(funbox, fullTempConfig).ok) {
           throw new Error(
             `Funbox ${funbox} isn't compatible with the current config`,
           );
         }
       }
-      setConfig("funbox", funboxes, {
-        nosave: true,
-      });
 
       for (const [key, value] of Object.entries(tempConfig)) {
         setConfig(key as keyof ConfigType, value, {
           nosave: true,
         });
       }
+
+      setConfig("funbox", funboxes, {
+        nosave: true,
+      });
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?

--- a/frontend/src/ts/controllers/challenge-controller.ts
+++ b/frontend/src/ts/controllers/challenge-controller.ts
@@ -319,17 +319,25 @@ export async function setup(challengeName: string): Promise<boolean> {
         nosave: true,
       });
     } else if (challenge.type === "funbox") {
-      const tempConfig: Partial<ConfigType> = {};
-
-      tempConfig.difficulty = "normal";
+      setConfig("difficulty", "normal", {
+        nosave: true,
+      });
       if (challenge.parameters[1] === "words") {
-        tempConfig.words = challenge.parameters[2] as number;
+        setConfig("words", challenge.parameters[2] as number, {
+          nosave: true,
+        });
       } else if (challenge.parameters[1] === "time") {
-        tempConfig.time = challenge.parameters[2] as number;
+        setConfig("time", challenge.parameters[2] as number, {
+          nosave: true,
+        });
       }
-      tempConfig.mode = challenge.parameters[1] as Mode;
+      setConfig("mode", challenge.parameters[1] as Mode, {
+        nosave: true,
+      });
       if (challenge.parameters[3] !== undefined) {
-        tempConfig.difficulty = challenge.parameters[3] as Difficulty;
+        setConfig("difficulty", challenge.parameters[3] as Difficulty, {
+          nosave: true,
+        });
       }
 
       const funboxes = challenge.parameters[0] as FunboxName[];
@@ -344,12 +352,6 @@ export async function setup(challengeName: string): Promise<boolean> {
       setConfig("funbox", funboxes, {
         nosave: true,
       });
-
-      for (const [key, value] of Object.entries(tempConfig)) {
-        setConfig(key as keyof ConfigType, value, {
-          nosave: true,
-        });
-      }
     } else if (challenge.type === "other") {
       if (challenge.name === "semimak") {
         // so can you make a link that sets up 120s, 10k, punct, stop on word, and semimak as the layout?


### PR DESCRIPTION
Fixes #7992

Change the order of config setup when loading a funbox challenge, so that funbox is set last.

When the user has an incompatible config for the challenge (e.g. `numbers` enabled and trying to enable `accountant`), it will throw an error.