### PR TITLE
fix: prevent collection cleanup (@fehmer)

### DIFF
--- a/frontend/src/ts/collections/custom-themes.ts
+++ b/frontend/src/ts/collections/custom-themes.ts
@@ -44,6 +44,10 @@ const customThemesCollection = createCollection(
         );
       }
 
+      if (_keepAlive === null) {
+        _keepAlive = useCustomThemesLiveQuery();
+      }
+
       return response.body.data.map(applyIdWorkaround);
     },
   }),
@@ -174,3 +178,10 @@ export const __nonReactive = {
   getCustomThemes,
   getCustomTheme,
 };
+
+/**
+ * On prod the collection gets cleaned up after a while.
+ * Keeping a query active fixes that. Remove when removing __nonReactive
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+let _keepAlive: any = null;

--- a/frontend/src/ts/collections/presets.ts
+++ b/frontend/src/ts/collections/presets.ts
@@ -203,3 +203,9 @@ export const __nonReactive = {
   getPresets,
   getPreset,
 };
+
+/**
+ * On prod the collection gets cleaned up after a while.
+ * Keeping a query active fixes that. Remove when removing __nonReactive
+ */
+const _keepAlive = usePresetsLiveQuery();

--- a/frontend/src/ts/collections/results.ts
+++ b/frontend/src/ts/collections/results.ts
@@ -239,6 +239,12 @@ const resultsCollection = createCollection(
         setLastResult(lastResult);
       }
 
+      if (_keepAlive === null) {
+        _keepAlive = useLiveQuery((q) =>
+          q.from({ results: resultsCollection }),
+        );
+      }
+
       return results;
     },
     queryClient,
@@ -683,3 +689,10 @@ function getResults(): SnapshotResult<Mode>[] {
 export const __nonReactive = {
   getResults,
 };
+
+/**
+ * On prod the collection gets cleaned up after a while.
+ * Keeping a query active fixes that. Remove when removing __nonReactive
+ */
+// oxlint-disable-next-line typescript/no-explicit-any
+let _keepAlive: any = null;

--- a/frontend/src/ts/collections/tags.ts
+++ b/frontend/src/ts/collections/tags.ts
@@ -41,6 +41,7 @@ const tagsCollection = createCollection(
     queryFn: async () => {
       const activeIds = activeTagsLS.get();
       const userData = await fetchUserFromApi();
+
       if (userData === undefined) return [];
 
       return (userData.tags ?? [])
@@ -552,3 +553,9 @@ export const __nonReactive = {
   getTag,
   getActiveTags,
 };
+
+/**
+ * On prod the collection gets cleaned up after a while.
+ * Keeping a query active fixes that. Remove when removing __nonReactive
+ */
+const _keepAlive = useTagsLiveQuery();


### PR DESCRIPTION
But only occurs on prod  builds. After a while the tags collection gets cleaned up because there is no active query. 
The commandline fetches the tags each time on open, causing them to "disappear" from the commandline after a while.

As a workaround we keep one liveQuery open for each collection exposing __nonreactive