### PR TITLE
fix(CustomTextModal): Resolve limit validation error on mode switch (@akartsky)

### DIFF
--- a/frontend/src/ts/components/modals/CustomTextModal.tsx
+++ b/frontend/src/ts/components/modals/CustomTextModal.tsx
@@ -383,7 +383,7 @@ export function CustomTextModal(): JSXElement {
         const text = cleanUpText();
         form.setFieldValue("limitWord", `${text.length}`);
         form.setFieldValue("limitTime", "");
-        form.setFieldValue("limitSection", `${text.length}`);
+        form.setFieldValue("limitSection", "");
       }
     });
   };

--- a/frontend/src/ts/components/modals/CustomTextModal.tsx
+++ b/frontend/src/ts/components/modals/CustomTextModal.tsx
@@ -381,9 +381,12 @@ export function CustomTextModal(): JSXElement {
         form.setFieldValue("limitSection", "");
       } else if (previousMode === "simple") {
         const text = cleanUpText();
-        form.setFieldValue("limitWord", `${text.length}`);
         form.setFieldValue("limitTime", "");
-        form.setFieldValue("limitSection", "");
+        if (form.getFieldValue("pipeDelimiter")) {
+          form.setFieldValue("limitSection", `${text.length}`);
+        } else {
+          form.setFieldValue("limitWord", `${text.length}`);
+        }
       }
     });
   };


### PR DESCRIPTION
Fixes bug https://github.com/monkeytypegame/monkeytype/issues/8007

-----
### Root cause :
Looks like there is a ["limitSection"](https://github.com/monkeytypegame/monkeytype/blob/35a211854b528d356766228c3be28be875605f5a/frontend/src/ts/components/modals/CustomTextModal.tsx#L386) (hidden in UI) which was also being set during mode switch. Resulting in [validation error](https://github.com/monkeytypegame/monkeytype/blob/35a211854b528d356766228c3be28be875605f5a/frontend/src/ts/components/modals/CustomTextModal.tsx#L83-L93).

### Testing :
I temporarily made the hidden limit 'sections' input visible just to debug and validate the fix