### PR TITLE
fix: show notice when monkey is enabled with text-style live stats (@brovoski69)

### DIFF
--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1872,6 +1872,14 @@ export async function afterTestWordChange(
 
 export function onTestStart(): void {
   Focus.set(true);
+  if (
+    Config.monkey &&
+    (Config.liveSpeedStyle === "text" || Config.liveAccStyle === "text")
+  ) {
+    showNoticeNotification(
+      "Monkey is not compatible with text-style live speed or accuracy",
+    );
+  }
   Monkey.show();
   TimerProgress.show();
   LiveSpeed.show();

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1877,7 +1877,7 @@ export function onTestStart(): void {
     (Config.liveSpeedStyle === "text" || Config.liveAccStyle === "text")
   ) {
     showNoticeNotification(
-      "Monkey is not compatible with text-style live speed or accuracy",
+      'Monkey is not compatible with text-style live speed or accuracy. Consider changing the live speed/accuracy style away from "text" in Settings.',
     );
   }
   Monkey.show();


### PR DESCRIPTION
## What changed
Added a notice notification in `onTestStart()` when the monkey setting is enabled alongside text-style live speed or accuracy, as these combinations cause the monkey mascot to overlap the live stats text.

## How to reproduce
1. Enable monkey
2. Set live speed style or live accuracy style to "text"
3. Start a test

## Before
Monkey overlaps the live stats text with no warning shown to the user.

## After
A notice notification is shown: "Monkey is not compatible with text-style live speed or accuracy"

## Files changed
`frontend/src/ts/test/test-ui.ts` - added incompatibility check in `onTestStart()`