### PR TITLE
fix(account-settings): restore responsiveness in notice card and page (@d1rshan)

### DIFF
--- a/frontend/src/styles/media-queries-blue.scss
+++ b/frontend/src/styles/media-queries-blue.scss
@@ -39,6 +39,22 @@
     }
   }
 
+  .pageAccountSettings {
+    .main {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto;
+      .tabs {
+        padding: 0;
+        display: grid;
+        grid-auto-flow: row;
+        button {
+          justify-content: center;
+          padding: 1em 0.5em;
+        }
+      }
+    }
+  }
+
   .pageFriends {
     .content .friends table,
     .content .pendingRequests table {

--- a/frontend/src/ts/components/pages/settings/Settings.tsx
+++ b/frontend/src/ts/components/pages/settings/Settings.tsx
@@ -265,7 +265,7 @@ function AccountSettingsNotice(): JSXElement {
   });
   return (
     <Show when={!dismissed()}>
-      <div class="grid grid-cols-[auto_1fr_auto] items-center gap-8 rounded px-8 py-4 ring-4 ring-sub-alt">
+      <div class="grid grid-cols-[auto_1fr] items-center gap-4 rounded px-4 py-4 ring-4 ring-sub-alt md:grid-cols-[auto_1fr_auto] md:gap-8">
         <Fa icon="fa-user-cog" class="text-4xl text-sub" />
         <div>
           Account settings have moved. You can now access them by hovering over
@@ -275,7 +275,7 @@ function AccountSettingsNotice(): JSXElement {
         <Button
           text="go to account settings"
           href="/account-settings"
-          class="p-4"
+          class="col-span-2 p-4 md:col-span-1"
           router-link
           onClick={() => {
             setDismissed(true);


### PR DESCRIPTION
### account settings notice card in settings page:
<table>
<tr>
<td align="center"><b>Before</b></td>
<td align="center"><b>After</b></td>
</tr>
<tr>
<td>
<img width="404" alt="before" src="https://github.com/user-attachments/assets/66712751-07cc-447e-bbaa-e912493ff691" />
</td>
<td>
<img width="404" alt="now" src="https://github.com/user-attachments/assets/7ef9aa1e-a891-448c-ba7e-b164e44974a8" />
</td>
</tr>
</table>

---

### account-settings page:
(fix: add back accidentally removed media query '.pageAccountSettings' in #7854)

<table>
<tr>
<td align="center"><b>Before</b></td>
<td align="center"><b>After</b></td>
</tr>
<tr>
<td>
<img width="406" height="859" alt="image" src="https://github.com/user-attachments/assets/1140009e-7451-4990-a9ea-8a0a5eb25230" />
</td>
<td>
<img width="401" height="859" alt="image" src="https://github.com/user-attachments/assets/2ec82d8a-e927-404f-8e42-293e07f20533" />
</td>
</tr>
</table>


Closes #8017 