### PR TITLE
fix(account): fix "load more" button state for filtered results (@d1rshan)

### DIFF
--- a/frontend/src/ts/collections/results.ts
+++ b/frontend/src/ts/collections/results.ts
@@ -667,10 +667,6 @@ export async function waitForResultsReady(): Promise<void> {
   await resultsCollection.stateWhenReady();
 }
 
-export function getResultsSize(): number {
-  return resultsCollection.size;
-}
-
 /**
  *
  */

--- a/frontend/src/ts/components/pages/account/AccountPage.tsx
+++ b/frontend/src/ts/components/pages/account/AccountPage.tsx
@@ -4,7 +4,6 @@ import { createMemo, createSignal, JSXElement, Show } from "solid-js";
 import {
   createResultsQueryState,
   getResultsQueryOnce,
-  getResultsSize,
   useResultsLiveQuery,
 } from "../../../collections/results";
 import { SnapshotResult } from "../../../constants/default-snapshot";
@@ -124,7 +123,8 @@ export function AccountPage(): JSXElement {
                   <Button
                     text="load more"
                     disabled={
-                      resultsQuery.isLoading || getResultsSize() < limit() + 10
+                      resultsQuery.isLoading ||
+                      resultsQueryData().length < limit()
                     }
                     onClick={() => setLimit((limit) => limit + 10)}
                     class="w-full text-center"

--- a/frontend/src/ts/components/pages/account/AccountPage.tsx
+++ b/frontend/src/ts/components/pages/account/AccountPage.tsx
@@ -45,13 +45,11 @@ export function AccountPage(): JSXElement {
   );
   const [isExporting, setIsExporting] = createSignal(false);
 
-  const queryLimit = createMemo(() => limit() + 1);
   const resultsQuery = useResultsLiveQuery({
     queryState,
     sorting,
-    limit: queryLimit,
+    limit: () => limit() + 1,
   });
-  const hasMoreResults = createMemo(() => resultsQuery()?.length > limit());
 
   return (
     <Show when={isAuthenticated() && isOpen()}>
@@ -128,7 +126,10 @@ export function AccountPage(): JSXElement {
                   />
                   <Button
                     text="load more"
-                    disabled={resultsQuery.isLoading || !hasMoreResults()}
+                    disabled={
+                      resultsQuery.isLoading ||
+                      resultsQueryData().length <= limit()
+                    }
                     onClick={() => setLimit((limit) => limit + 10)}
                     class="w-full text-center"
                   />

--- a/frontend/src/ts/components/pages/account/AccountPage.tsx
+++ b/frontend/src/ts/components/pages/account/AccountPage.tsx
@@ -45,7 +45,13 @@ export function AccountPage(): JSXElement {
   );
   const [isExporting, setIsExporting] = createSignal(false);
 
-  const resultsQuery = useResultsLiveQuery({ queryState, sorting, limit });
+  const queryLimit = createMemo(() => limit() + 1);
+  const resultsQuery = useResultsLiveQuery({
+    queryState,
+    sorting,
+    limit: queryLimit,
+  });
+  const hasMoreResults = createMemo(() => resultsQuery()?.length > limit());
 
   return (
     <Show when={isAuthenticated() && isOpen()}>
@@ -116,16 +122,13 @@ export function AccountPage(): JSXElement {
               {({ resultsQueryData }) => (
                 <>
                   <Table
-                    data={[...resultsQueryData()]}
+                    data={resultsQueryData().slice(0, limit())}
                     onSortingChange={(val) => setSorting(val)}
                     selectedRowId={selectedResultId}
                   />
                   <Button
                     text="load more"
-                    disabled={
-                      resultsQuery.isLoading ||
-                      resultsQueryData().length < limit()
-                    }
+                    disabled={resultsQuery.isLoading || !hasMoreResults()}
                     onClick={() => setLimit((limit) => limit + 10)}
                     class="w-full text-center"
                   />


### PR DESCRIPTION
"load more" button used `getResultsSize()` (unfiltered total) to decide if more results exist. With active filters this always showed the button as enabled. 

### Fix
  - fetch `limit + 1` filtered results
  - render only the first `limit`
  - use the extra row to determine whether more results exist