### PR TITLE
fix(utils): preserve newlines in sanitizeString (@bijanmurmu)

### DIFF
--- a/backend/__tests__/utils/misc.spec.ts
+++ b/backend/__tests__/utils/misc.spec.ts
@@ -197,43 +197,6 @@ describe("Misc Utils", () => {
     );
   });
 
-  it("sanitizeString", () => {
-    const testCases = [
-      {
-        input: "h̶̼͔̭͈̏́̀́͋͜ͅe̵̺̞̦̫̫͔̋́̅̅̃̀͝͝ļ̶̬̯͚͇̺͍̞̫̟͖͋̓͛̆̒̓͜ĺ̴̗̘͇̬̆͂͌̈͊͝͝ỡ̴̡̦̩̠̞̐̃͆̚͠͝",
-        expected: "hello",
-      },
-      {
-        input: "hello",
-        expected: "hello",
-      },
-      {
-        input: "hel   lo",
-        expected: "hel  lo",
-      },
-      {
-        input: "   hel   lo   ",
-        expected: "hel  lo",
-      },
-      {
-        input: "",
-        expected: "",
-      },
-      {
-        input: "   \n\n\n",
-        expected: "",
-      },
-      {
-        input: undefined,
-        expected: undefined,
-      },
-    ];
-
-    testCases.forEach(({ input, expected }) => {
-      expect(Misc.sanitizeString(input)).toEqual(expected);
-    });
-  });
-
   it("getOrdinalNumberString", () => {
     const testCases = [
       {

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -124,7 +124,7 @@ export function sanitizeString(str: string | undefined): string | undefined {
     .replace(/[\u0300-\u036F]/g, "")
     .trim()
     .replace(/\n{3,}/g, "\n\n")
-    .replace(/\s{3,}/g, "  ");
+    .replace(/[^\S\r\n]{3,}/g, "  ");
 }
 
 const suffixes = ["th", "st", "nd", "rd"];

--- a/backend/src/utils/misc.ts
+++ b/backend/src/utils/misc.ts
@@ -1,5 +1,6 @@
 import { MILLISECONDS_IN_DAY } from "@monkeytype/util/date-and-time";
 import { roundTo2 } from "@monkeytype/util/numbers";
+export { sanitizeString } from "@monkeytype/util/strings";
 import uaparser from "ua-parser-js";
 import { MonkeyRequest } from "../api/types";
 import { ObjectId } from "mongodb";
@@ -113,18 +114,6 @@ export function flattenObjectDeep(
   });
 
   return result;
-}
-
-export function sanitizeString(str: string | undefined): string | undefined {
-  if (str === undefined || str === "") {
-    return str;
-  }
-
-  return str
-    .replace(/[\u0300-\u036F]/g, "")
-    .trim()
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/[^\S\r\n]{3,}/g, "  ");
 }
 
 const suffixes = ["th", "st", "nd", "rd"];

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -22,6 +22,9 @@
     "lint": "oxlint . --type-aware --type-check",
     "lint-fast": "oxlint ."
   },
+  "dependencies": {
+    "@monkeytype/util": "workspace:*"
+  },
   "devDependencies": {
     "@monkeytype/tsup-config": "workspace:*",
     "@monkeytype/typescript-config": "workspace:*",

--- a/packages/schemas/src/validation/validation.ts
+++ b/packages/schemas/src/validation/validation.ts
@@ -1,4 +1,5 @@
 import { replaceHomoglyphs } from "./homoglyphs";
+import { sanitizeString } from "@monkeytype/util/strings";
 import { ZodEffects, ZodString } from "zod";
 
 // Sorry for the bad words
@@ -390,18 +391,6 @@ const disallowedWords = [
   "wichser",
   "zabourah",
 ];
-
-function sanitizeString(str: string | undefined): string | undefined {
-  if (str === undefined || str === "") {
-    return str;
-  }
-
-  return str
-    .replace(/[\u0300-\u036F]/g, "")
-    .trim()
-    .replace(/\n{3,}/g, "\n\n")
-    .replace(/[^\S\r\n]{3,}/g, "  ");
-}
 
 function containsDisallowedWords(
   text: string,

--- a/packages/schemas/src/validation/validation.ts
+++ b/packages/schemas/src/validation/validation.ts
@@ -400,7 +400,7 @@ function sanitizeString(str: string | undefined): string | undefined {
     .replace(/[\u0300-\u036F]/g, "")
     .trim()
     .replace(/\n{3,}/g, "\n\n")
-    .replace(/\s{3,}/g, "  ");
+    .replace(/[^\S\r\n]{3,}/g, "  ");
 }
 
 function containsDisallowedWords(

--- a/packages/util/__test__/strings.spec.ts
+++ b/packages/util/__test__/strings.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { kebabToCamelCase } from "../src/strings";
+import { kebabToCamelCase, sanitizeString } from "../src/strings";
 
 describe("strings", () => {
   describe("kebabToCamelCase", () => {
@@ -10,5 +10,57 @@ describe("strings", () => {
         kebabToCamelCase("one-two-three-four-five-six-seven-eight-nine-ten"),
       ).toEqual("oneTwoThreeFourFiveSixSevenEightNineTen");
     });
+  });
+
+  describe("sanitizeString", () => {
+    const testCases = [
+      {
+        input: "h̶̼͔̭͈̏́̀́͋͜ͅe̵̺̞̦̫̫͔̋́̅̅̃̀͝͝ļ̶̬̯͚͇̺͍̞̫̟͖͋̓͛̆̒̓͜ĺ̴̗̘͇̬̆͂͌̈͊͝͝ỡ̴̡̦̩̠̞̐̃͆̚͠͝",
+        expected: "hello",
+      },
+      {
+        input: "hello",
+        expected: "hello",
+      },
+      {
+        input: "hel   lo",
+        expected: "hel  lo",
+      },
+      {
+        input: "   hel   lo   ",
+        expected: "hel  lo",
+      },
+      {
+        input: "",
+        expected: "",
+      },
+      {
+        input: "   \n\n\n",
+        expected: "",
+      },
+      {
+        input: undefined,
+        expected: undefined,
+      },
+      {
+        input: "hello\r\n\r\nworld",
+        expected: "hello\r\n\r\nworld",
+      },
+      {
+        input: "hello\n\nworld",
+        expected: "hello\n\nworld",
+      },
+      {
+        input: "test   \r\n   test",
+        expected: "test  \r\n  test",
+      },
+    ];
+
+    it.each(testCases)(
+      "sanitizeString with input '$input' expects '$expected'",
+      ({ input, expected }) => {
+        expect(sanitizeString(input)).toEqual(expected);
+      },
+    );
   });
 });

--- a/packages/util/src/strings.ts
+++ b/packages/util/src/strings.ts
@@ -1,3 +1,15 @@
 export function kebabToCamelCase(kebab: string): string {
   return kebab.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
 }
+
+export function sanitizeString(str: string | undefined): string | undefined {
+  if (str === undefined || str === "") {
+    return str;
+  }
+
+  return str
+    .replace(/[\u0300-\u036F]/g, "")
+    .trim()
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[^\S\r\n]{3,}/g, "  ");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,6 +749,9 @@ importers:
 
   packages/schemas:
     dependencies:
+      '@monkeytype/util':
+        specifier: workspace:*
+        version: link:../util
       zod:
         specifier: 3.23.8
         version: 3.23.8


### PR DESCRIPTION
Closes #8033.
Changes the regex in  sanitizeString  to only collapse horizontal spaces so it no longer accidentally deletes newlines.

This PR fixes an issue where the `sanitizeString` utility deletes intentional newlines if they are surrounded by spaces. The regex `/\s{3,}/g` was replaced with `/[^\S\r\n]{3,}/g` so that it only collapses horizontal whitespace and preserves user line breaks (such as those used in profile bios).