### PR TITLE
feat: add header streak indicator (@hunterpaulson)

### DIFF
--- a/frontend/__tests__/utils/streak.spec.ts
+++ b/frontend/__tests__/utils/streak.spec.ts
@@ -1,0 +1,245 @@
+import type { Mode } from "@monkeytype/schemas/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { SnapshotResult } from "../../src/ts/constants/default-snapshot";
+import {
+  getStreakExtraText,
+  getStreakIndicatorState,
+  getStreakHoverText,
+  hasClaimedStreakToday,
+} from "../../src/ts/utils/streak";
+
+function resultAt(timestamp: number): SnapshotResult<Mode> {
+  return { timestamp } as SnapshotResult<Mode>;
+}
+
+describe("streak utils", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hides the header indicator when signed out", () => {
+    expect(getStreakIndicatorState(undefined, undefined)).toEqual({
+      show: false,
+      claimedToday: false,
+      hoverText: "",
+    });
+  });
+
+  it("shows a hollow flame with a zero label before the first streak claim", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 0,
+        maxStreak: 0,
+      },
+      undefined,
+    );
+
+    expect(state).toMatchObject({
+      show: true,
+      claimedToday: false,
+      label: "0",
+      hoverText: "Longest streak: 0 days",
+    });
+  });
+
+  it("does not claim a zero streak even if a stale last result is present", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 0,
+        maxStreak: 0,
+      },
+      resultAt(new Date("2026-06-03T09:00:00Z").getTime()),
+    );
+
+    expect(state).toMatchObject({
+      show: true,
+      claimedToday: false,
+      label: "0",
+      hoverText: "Longest streak: 0 days",
+    });
+  });
+
+  it("shows a solid flame and one-day label after the first saved result", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 1,
+        maxStreak: 1,
+      },
+      resultAt(new Date("2026-06-03T09:00:00Z").getTime()),
+    );
+
+    expect(state.show).toBe(true);
+    expect(state.claimedToday).toBe(true);
+    expect(state.label).toBe("1");
+    expect(state.hoverText).toContain("Longest streak: 1 day");
+    expect(state.hoverText).toContain("Claimed today: yes");
+  });
+
+  it("uses the snapshot streak timestamp before result history loads", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 1,
+        maxStreak: 1,
+        streakLastResultTimestamp: new Date("2026-06-03T09:00:00Z").getTime(),
+      },
+      undefined,
+    );
+
+    expect(state.claimedToday).toBe(true);
+    expect(state.label).toBe("1");
+    expect(state.hoverText).toContain("Claimed today: yes");
+  });
+
+  it("prefers the snapshot streak timestamp over a stale cached result", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 365,
+        maxStreak: 365,
+        streakLastResultTimestamp: new Date("2026-06-02T12:00:00Z").getTime(),
+      },
+      resultAt(new Date("2026-06-03T09:00:00Z").getTime()),
+    );
+
+    expect(state.claimedToday).toBe(false);
+    expect(state.label).toBe("365");
+    expect(state.hoverText).toContain("Claimed today: no");
+  });
+
+  it("updates a long streak from unclaimed to claimed after today's result save", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const yesterday = new Date("2026-06-02T12:00:00Z").getTime();
+
+    const beforeToday = getStreakIndicatorState(
+      {
+        streak: 365,
+        maxStreak: 365,
+      },
+      resultAt(yesterday),
+    );
+    const afterToday = getStreakIndicatorState(
+      {
+        streak: 366,
+        maxStreak: 366,
+      },
+      resultAt(new Date("2026-06-03T00:00:00Z").getTime()),
+    );
+
+    expect(beforeToday.show).toBe(true);
+    expect(beforeToday.claimedToday).toBe(false);
+    expect(beforeToday.label).toBe("365");
+    expect(beforeToday.hoverText).toContain("Claimed today: no");
+
+    expect(afterToday.show).toBe(true);
+    expect(afterToday.claimedToday).toBe(true);
+    expect(afterToday.label).toBe("366");
+    expect(afterToday.hoverText).toContain("Longest streak: 366 days");
+    expect(afterToday.hoverText).toContain("Claimed today: yes");
+  });
+
+  it("omits account-only extra text unless opted in", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const yesterday = new Date("2026-06-02T12:00:00Z").getTime();
+
+    expect(getStreakHoverText({ maxStreak: 30 })).toBe(
+      "Longest streak: 30 days",
+    );
+    expect(
+      getStreakHoverText({
+        maxStreak: 30,
+        lastResult: resultAt(yesterday),
+      }),
+    ).toBe("Longest streak: 30 days");
+    expect(
+      getStreakHoverText({
+        maxStreak: 30,
+        lastResult: resultAt(yesterday),
+        showExtraText: true,
+      }),
+    ).toContain("Claimed today: no");
+  });
+
+  it("describes a streak at risk after yesterday's last result", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 5,
+        maxStreak: 10,
+      },
+      resultAt(new Date("2026-06-02T12:00:00Z").getTime()),
+    );
+
+    expect(state.claimedToday).toBe(false);
+    expect(state.label).toBe("5");
+    expect(state.hoverText).toContain("Claimed today: no");
+    expect(state.hoverText).toContain("Streak lost in:");
+  });
+
+  it("shows a zero label when the current streak is already lost", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const state = getStreakIndicatorState(
+      {
+        streak: 7,
+        maxStreak: 12,
+      },
+      resultAt(new Date("2026-06-01T12:00:00Z").getTime()),
+    );
+
+    expect(state.claimedToday).toBe(false);
+    expect(state.label).toBe("0");
+    expect(state.hoverText).toContain("Longest streak: 12 days");
+    expect(state.hoverText).toContain("Streak lost ");
+  });
+
+  it("describes lost streaks from the actual reset time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T20:00:00Z"));
+    const extraText = getStreakExtraText(
+      resultAt(new Date("2026-06-01T12:00:00Z").getTime()),
+      undefined,
+    );
+
+    expect(extraText).toContain("Streak lost 20 hours ago");
+  });
+
+  it("uses the streak hour offset when checking today's claim", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T01:00:00Z"));
+    const lateYesterdayUtc = resultAt(
+      new Date("2026-06-02T23:30:00Z").getTime(),
+    );
+
+    expect(hasClaimedStreakToday(lateYesterdayUtc, undefined)).toBe(false);
+    expect(hasClaimedStreakToday(lateYesterdayUtc, 6)).toBe(true);
+  });
+
+  it("describes an already lost streak without the timezone hint when offset is set", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-03T12:00:00Z"));
+    const extraText = getStreakExtraText(
+      resultAt(new Date("2026-06-01T12:00:00Z").getTime()),
+      2,
+    );
+
+    expect(extraText).toContain("Streak lost ");
+    expect(extraText).toContain("(+2 offset)");
+    expect(extraText).toContain(
+      "It will be removed from your profile on the next result save",
+    );
+    expect(extraText).not.toContain("If the streak reset time");
+  });
+});

--- a/frontend/src/ts/components/layout/header/Nav.tsx
+++ b/frontend/src/ts/components/layout/header/Nav.tsx
@@ -34,6 +34,7 @@ import { NotificationBubble } from "../../common/NotificationBubble";
 import { User } from "../../common/User";
 import { AccountMenu } from "./AccountMenu";
 import { AccountXpBar } from "./AccountXpBar";
+import { StreakIndicator } from "./StreakIndicator";
 
 export function Nav(): JSXElement {
   const [getAccountMenuOpen, setAccountMenuOpen] = createSignal(false);
@@ -143,6 +144,7 @@ export function Nav(): JSXElement {
         router-link
       />
       <div class="grow"></div>
+      <StreakIndicator />
       <Button
         variant="text"
         fa={{

--- a/frontend/src/ts/components/layout/header/StreakIndicator.tsx
+++ b/frontend/src/ts/components/layout/header/StreakIndicator.tsx
@@ -1,0 +1,48 @@
+import { JSXElement, Show } from "solid-js";
+
+import { getStreakIndicatorState } from "../../../states/streak";
+import { getFocus } from "../../../states/test";
+import { cn } from "../../../utils/cn";
+import { Button } from "../../common/Button";
+
+export function StreakIndicator(): JSXElement {
+  const state = getStreakIndicatorState;
+  const flameClass = (): string =>
+    cn(
+      "transition-colors",
+      state().claimedToday
+        ? "text-main"
+        : "text-sub [-webkit-text-fill-color:transparent] [-webkit-text-stroke:0.075em_var(--sub-color)]",
+    );
+
+  return (
+    <Show when={state().show}>
+      <Button
+        variant="text"
+        href="/account"
+        router-link
+        class={cn("h-full min-w-8 px-2 tabular-nums", {
+          "opacity-(--nav-focus-opacity)": getFocus(),
+        })}
+        dataset={{
+          "data-nav-item": "streak",
+        }}
+        fa={{
+          icon: "fa-fire",
+          fixedWidth: true,
+          class: flameClass(),
+        }}
+        balloon={{
+          text: state().hoverText,
+          position: "down",
+          break: true,
+          length: "large",
+        }}
+      >
+        <Show when={state().label}>
+          {(label) => <span class="text-text">{label()}</span>}
+        </Show>
+      </Button>
+    </Show>
+  );
+}

--- a/frontend/src/ts/components/pages/profile/UserDetails.tsx
+++ b/frontend/src/ts/components/pages/profile/UserDetails.tsx
@@ -3,29 +3,22 @@ import {
   UserProfile,
   UserProfileDetails,
 } from "@monkeytype/schemas/users";
-import {
-  isToday as dateIsToday,
-  isYesterday as dateIsYesterday,
-  getCurrentDayTimestamp,
-} from "@monkeytype/util/date-and-time";
-import { isSafeNumber } from "@monkeytype/util/numbers";
 import { differenceInDays } from "date-fns/differenceInDays";
 import { formatDate } from "date-fns/format";
-import { formatDistanceToNowStrict } from "date-fns/formatDistanceToNowStrict";
 import { For, JSXElement, Show } from "solid-js";
 
 import { addConnection, hasConnection } from "../../../collections/connections";
-import { Snapshot } from "../../../constants/default-snapshot";
 import { bp } from "../../../states/breakpoints";
 import { getUserId, isAuthenticated } from "../../../states/core";
 import { showModal } from "../../../states/modals";
 import { showNoticeNotification } from "../../../states/notifications";
-import { getLastResult } from "../../../states/snapshot";
+import { getStreakIndicatorState } from "../../../states/streak";
 import { setUserToReport } from "../../../states/user-report";
 import { cn } from "../../../utils/cn";
 import { secondsToString } from "../../../utils/date-and-time";
 import { formatXp, getXpDetails } from "../../../utils/levels";
 import { formatTypingStatsRatio } from "../../../utils/misc";
+import { formatStreak, getStreakHoverText } from "../../../utils/streak";
 import { AutoShrink } from "../../common/AutoShrink";
 import { Balloon, BalloonProps } from "../../common/Balloon";
 import { Bar } from "../../common/Bar";
@@ -207,52 +200,17 @@ function AvatarAndName(props: {
     return `${diffDays} day${diffDays !== 1 ? "s" : ""} ago`;
   };
 
-  const formatStreak = (length: number) =>
-    `${length} ${length === 1 ? "day" : "days"}`;
+  const currentStreak = () =>
+    props.isAccountPage
+      ? Number(getStreakIndicatorState().label ?? 0)
+      : (props.profile.streak ?? 0);
 
-  const extraStreakText = () => {
-    if (!props.isAccountPage) return "";
-    let hoverText = "";
-
-    const lastResult = getLastResult();
-    if (lastResult === undefined) return "";
-
-    const streakOffset = (props.profile as Snapshot).streakHourOffset;
-
-    const dayInMilis = 1000 * 60 * 60 * 24;
-
-    let target = getCurrentDayTimestamp(streakOffset) + dayInMilis;
-    if (target < Date.now()) {
-      target += dayInMilis;
-    }
-    const timeDif = formatDistanceToNowStrict(target);
-
-    if (lastResult !== undefined) {
-      //check if the last result is from today
-      const isToday = dateIsToday(lastResult.timestamp, streakOffset);
-      const isYesterday = dateIsYesterday(lastResult.timestamp, streakOffset);
-
-      const offsetString = isSafeNumber(streakOffset)
-        ? `(${streakOffset > 0 ? "+" : ""}${streakOffset} offset)`
-        : "";
-
-      if (isToday) {
-        hoverText += `\nClaimed today: yes`;
-        hoverText += `\nCome back in: ${timeDif} ${offsetString}`;
-      } else if (isYesterday) {
-        hoverText += `\nClaimed today: no`;
-        hoverText += `\nStreak lost in: ${timeDif} ${offsetString}`;
-      } else {
-        hoverText += `\nStreak lost ${timeDif} ${offsetString} ago`;
-        hoverText += `\nIt will be removed from your profile on the next result save`;
-      }
-
-      if (streakOffset === undefined) {
-        hoverText += `\n\nIf the streak reset time doesn't line up with your timezone, you can change it in Account Settings > Account > Set streak hour offset.`;
-      }
-    }
-    return hoverText;
-  };
+  const streakHoverText = () =>
+    props.isAccountPage
+      ? getStreakIndicatorState().hoverText
+      : getStreakHoverText({
+          maxStreak: props.profile.maxStreak,
+        });
 
   const balloonPosition = (): BalloonProps["position"] =>
     bp().md ? "right" : "up";
@@ -319,15 +277,15 @@ function AvatarAndName(props: {
           <Balloon inline text={accountAgeHint()} position={balloonPosition()}>
             Joined {formatDate(props.profile.addedAt ?? 0, "dd MMM yyyy")}
           </Balloon>
-          <Show when={(props.profile.streak ?? 0) > 1}>
+          <Show when={currentStreak() > 0}>
             <Balloon
               inline
-              text={`Longest streak: ${formatStreak(props.profile.maxStreak)}${extraStreakText()}`}
+              text={streakHoverText()}
               position={balloonPosition()}
               break
               length="large"
             >
-              Current streak {formatStreak(props.profile.streak)}
+              Current streak {formatStreak(currentStreak())}
             </Balloon>
           </Show>
         </div>

--- a/frontend/src/ts/constants/default-snapshot.ts
+++ b/frontend/src/ts/constants/default-snapshot.ts
@@ -67,6 +67,7 @@ export type Snapshot = Omit<
   streak: number;
   maxStreak: number;
   isPremium: boolean;
+  streakLastResultTimestamp?: number;
   streakHourOffset?: number;
   xp: number;
   testActivity?: ModifiableTestActivityCalendar;
@@ -103,6 +104,7 @@ const defaultSnap = {
   inboxUnreadSize: 0,
   streak: 0,
   maxStreak: 0,
+  streakLastResultTimestamp: undefined,
   streakHourOffset: undefined,
   allTimeLbs: {
     time: {

--- a/frontend/src/ts/db.ts
+++ b/frontend/src/ts/db.ts
@@ -128,6 +128,8 @@ export async function initSnapshot(): Promise<Snapshot | false> {
     snap.inboxUnreadSize = userData.inboxUnreadSize ?? 0;
     snap.streak = userData?.streak?.length ?? 0;
     snap.maxStreak = userData?.streak?.maxLength ?? 0;
+    snap.streakLastResultTimestamp =
+      userData?.streak?.lastResultTimestamp ?? undefined;
     snap.isPremium = userData?.isPremium ?? false;
     snap.allTimeLbs = userData.allTimeLbs;
 
@@ -314,6 +316,7 @@ export function saveLocalResult(data: SaveLocalResultData): void {
   if (data.result !== undefined) {
     void insertLocalResult({ result: data.result });
     setLastResult(data.result);
+    snapshot.streakLastResultTimestamp = data.result.timestamp;
     if (snapshot.testActivity !== undefined) {
       snapshot.testActivity.increment(new Date(data.result.timestamp));
     }

--- a/frontend/src/ts/states/streak.ts
+++ b/frontend/src/ts/states/streak.ts
@@ -1,0 +1,22 @@
+import { createEffect, createSignal } from "solid-js";
+
+import type { StreakIndicatorState } from "../utils/streak";
+import { getStreakIndicatorState as getStreakIndicatorStateFromSnapshot } from "../utils/streak";
+import { getLastResult, getSnapshot } from "./snapshot";
+
+const [getNow, setNow] = createSignal(Date.now());
+export const [getStreakIndicatorState, setStreakIndicatorState] =
+  createSignal<StreakIndicatorState>(
+    getStreakIndicatorStateFromSnapshot(undefined, undefined),
+  );
+
+window.setInterval(() => {
+  setNow(Date.now());
+}, 60_000);
+
+createEffect(() => {
+  getNow();
+  setStreakIndicatorState(
+    getStreakIndicatorStateFromSnapshot(getSnapshot(), getLastResult()),
+  );
+});

--- a/frontend/src/ts/utils/streak.ts
+++ b/frontend/src/ts/utils/streak.ts
@@ -1,0 +1,157 @@
+import type { Mode } from "@monkeytype/schemas/shared";
+import {
+  getCurrentDayTimestamp,
+  getStartOfDayTimestamp,
+  MILISECONDS_IN_HOUR,
+  MILLISECONDS_IN_DAY,
+  isToday as dateIsToday,
+  isYesterday as dateIsYesterday,
+} from "@monkeytype/util/date-and-time";
+import { isSafeNumber } from "@monkeytype/util/numbers";
+import { formatDistanceToNowStrict } from "date-fns/formatDistanceToNowStrict";
+
+import type { SnapshotResult } from "../constants/default-snapshot";
+
+type StreakLastResult = Pick<SnapshotResult<Mode>, "timestamp">;
+
+type StreakSnapshot = {
+  streak: number;
+  maxStreak: number;
+  streakLastResultTimestamp?: number;
+  streakHourOffset?: number;
+};
+
+export type StreakIndicatorState = {
+  show: boolean;
+  claimedToday: boolean;
+  label?: string;
+  hoverText: string;
+};
+
+export function formatStreak(length: number): string {
+  return `${length} ${length === 1 ? "day" : "days"}`;
+}
+
+export function hasClaimedStreakToday(
+  lastResult: StreakLastResult | undefined,
+  streakHourOffset: number | undefined,
+): boolean {
+  return (
+    lastResult !== undefined &&
+    dateIsToday(lastResult.timestamp, streakHourOffset)
+  );
+}
+
+export function hasLostStreak(
+  lastResult: StreakLastResult | undefined,
+  streakHourOffset: number | undefined,
+): boolean {
+  return (
+    lastResult !== undefined &&
+    !dateIsToday(lastResult.timestamp, streakHourOffset) &&
+    !dateIsYesterday(lastResult.timestamp, streakHourOffset)
+  );
+}
+
+export function getStreakExtraText(
+  lastResult: StreakLastResult | undefined,
+  streakHourOffset: number | undefined,
+): string {
+  if (lastResult === undefined) return "";
+
+  let hoverText = "";
+  let target = getCurrentDayTimestamp(streakHourOffset) + MILLISECONDS_IN_DAY;
+  if (target < Date.now()) {
+    target += MILLISECONDS_IN_DAY;
+  }
+  const timeDif = formatDistanceToNowStrict(target);
+  const isToday = dateIsToday(lastResult.timestamp, streakHourOffset);
+  const isYesterday = dateIsYesterday(lastResult.timestamp, streakHourOffset);
+  const offsetString = isSafeNumber(streakHourOffset)
+    ? ` (${streakHourOffset > 0 ? "+" : ""}${streakHourOffset} offset)`
+    : "";
+
+  if (isToday) {
+    hoverText += `\nClaimed today: yes`;
+    hoverText += `\nCome back in: ${timeDif}${offsetString}`;
+  } else if (isYesterday) {
+    hoverText += `\nClaimed today: no`;
+    hoverText += `\nStreak lost in: ${timeDif}${offsetString}`;
+  } else {
+    const offsetMilis = (streakHourOffset ?? 0) * MILISECONDS_IN_HOUR;
+    const lostAt =
+      getStartOfDayTimestamp(lastResult.timestamp, offsetMilis) +
+      MILLISECONDS_IN_DAY * 2;
+    const lostTimeDif = formatDistanceToNowStrict(lostAt);
+    hoverText += `\nStreak lost ${lostTimeDif}${offsetString} ago`;
+    hoverText += `\nIt will be removed from your profile on the next result save`;
+  }
+
+  if (streakHourOffset === undefined) {
+    hoverText += `\n\nIf the streak reset time doesn't line up with your timezone, you can change it in Account Settings > Account > Set streak hour offset.`;
+  }
+
+  return hoverText;
+}
+
+export function getStreakHoverText(args: {
+  maxStreak: number;
+  lastResult?: StreakLastResult;
+  streakHourOffset?: number;
+  showExtraText?: boolean;
+}): string {
+  return `Longest streak: ${formatStreak(args.maxStreak)}${
+    args.showExtraText === true
+      ? getStreakExtraText(args.lastResult, args.streakHourOffset)
+      : ""
+  }`;
+}
+
+export function getStreakLastResult(
+  snapshot: StreakSnapshot,
+  lastResult: SnapshotResult<Mode> | undefined,
+): StreakLastResult | undefined {
+  const timestamp = snapshot.streakLastResultTimestamp ?? lastResult?.timestamp;
+
+  if (timestamp === undefined || timestamp <= 0) {
+    return undefined;
+  }
+
+  return { timestamp };
+}
+
+export function getStreakIndicatorState(
+  snapshot: StreakSnapshot | undefined,
+  lastResult: SnapshotResult<Mode> | undefined,
+): StreakIndicatorState {
+  if (snapshot === undefined) {
+    return {
+      show: false,
+      claimedToday: false,
+      hoverText: "",
+    };
+  }
+
+  const hasActiveStreak = snapshot.streak > 0;
+  const streakLastResult = getStreakLastResult(snapshot, lastResult);
+  const claimedToday =
+    hasActiveStreak &&
+    hasClaimedStreakToday(streakLastResult, snapshot.streakHourOffset);
+  const lostStreak =
+    hasActiveStreak &&
+    hasLostStreak(streakLastResult, snapshot.streakHourOffset);
+
+  const label = lostStreak ? "0" : `${snapshot.streak}`;
+
+  return {
+    show: true,
+    claimedToday,
+    label,
+    hoverText: getStreakHoverText({
+      maxStreak: snapshot.maxStreak,
+      lastResult: hasActiveStreak ? streakLastResult : undefined,
+      streakHourOffset: snapshot.streakHourOffset,
+      showExtraText: hasActiveStreak,
+    }),
+  };
+}


### PR DESCRIPTION
### Description

Problem being solved: 

In order to see your current streak, and whether it was claimed today, you have to click your profile then hover over your streak under your username.

Solution:

Add a streak indicator in the header next to the notification bell that shows your current streak along with a fire icon to indicate whether or not you claimed your streak for today.

<img width="470" height="185" alt="image" src="https://github.com/user-attachments/assets/c4fc7ad3-48c4-41b5-9bfd-dcf2f58aa3a1" />

### Design

- When the streak is not claimed yet today the icon is hollow and its border uses the theme's `sub` color. matching the rest of the heading
- When the streak *is claimed* for the day the icon uses the theme's `main` color with solid fill. matching the monkeytype keyboard logo
- The streak number uses the theme's normal `text` color and inherits the existing header navigation font size. 
    - used tabular numerals to prevent the layout from shifting as the number changes

### examples

Logged out. shows no streak indicator (notice nothing next to the bell)

<img width="743" height="841" alt="Screenshot 2026-06-03 190517" src="https://github.com/user-attachments/assets/53ed4be6-fe2f-4472-9c2e-937fd635f565" />

Before streak is claimed. Logged in users see a hollow indicator and the length of the current streak. hinting to them to begin/claim their streak for the day.

<img width="451" height="202" alt="Screenshot 2026-06-03 182530" src="https://github.com/user-attachments/assets/c7ec3c92-7ec1-40b2-8df7-28732f808319" />

After streak is claimed. Indicator becomes solid and uses main color

<img width="449" height="189" alt="Screenshot 2026-06-03 182603" src="https://github.com/user-attachments/assets/5d4a0448-cf19-41fb-8eba-572479269b8c" />

Timezone streak hour offset tool tip still shows when hovering streak on profile page

<img width="694" height="361" alt="Screenshot 2026-06-03 184920" src="https://github.com/user-attachments/assets/bc4af5f3-b6cf-4116-8da2-632d4e851328" />

When streak is lost it goes back to zero. 

<img width="433" height="174" alt="Screenshot 2026-06-03 182825" src="https://github.com/user-attachments/assets/758df1ed-a147-4986-879d-4cc2df5e4182" />

<!-- 
  Please describe the change(s) made in your PR:
  - explain the problem being solved
  - for bug fixes without an open issue, include steps to reproduce the issue
  - summarize the approach taken
  
  Use your own words. Do not rely on AI-generated descriptions. 
  They do not demonstrate your understanding of the problem or the solution.
  Writing the description yourself helps you verify the scope of your work and 
  helps us better understand your intent, reasoning and level of insight.
-->

### Implementation notes

The account page now displays a one-day streak instead of waiting until day two, keeping it consistent with the header indicator. [previously it took two days to show streak indicator](https://github.com/monkeytypegame/monkeytype/discussions/4155).

Moved the streak formatting and tooltip logic from the profile component into `utils/streak.ts` so the header and account page share the same behavior and wording. account-only tooltips like the changing timezone hour offset remain opt-in.

In order to determine whether today's streak was claimed immediately after login, before result history is first loaded I used the existing `streak.lastResultTimestamp` value from the user response as `streakLastResultTimestamp`. It is also updated after saving a result so the indicator changes immediately.

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

related discussion [#5799](https://github.com/monkeytypegame/monkeytype/discussions/5799)