### PR TITLE
impr(hotkeys): don't create mod+shift+p hotkey on firefox (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/components/hotkeys/CommandlineHotkey.tsx
+++ b/frontend/src/ts/components/hotkeys/CommandlineHotkey.tsx
@@ -1,5 +1,6 @@
 import { Show } from "solid-js";
 
+import { nonFirefoxCommandlineHotkey } from "../../input/hotkeys/commandline";
 import { hotkeys } from "../../states/hotkeys";
 import { isFirefox } from "../../utils/misc";
 import { Kbd } from "../common/Kbd";
@@ -10,7 +11,7 @@ export function CommandlineHotkey() {
       <Kbd hotkey={hotkeys.commandline} />
       <Show when={!isFirefox()}>
         &nbsp;or&nbsp;
-        <Kbd hotkey="Mod+Shift+P" />
+        <Kbd hotkey={nonFirefoxCommandlineHotkey} />
       </Show>
     </>
   );

--- a/frontend/src/ts/input/hotkeys/commandline.ts
+++ b/frontend/src/ts/input/hotkeys/commandline.ts
@@ -1,7 +1,9 @@
 import { hotkeys } from "../../states/hotkeys";
 import { showModal } from "../../states/modals";
-import { isAnyPopupVisible } from "../../utils/misc";
+import { isAnyPopupVisible, isFirefox } from "../../utils/misc";
 import { createHotkey } from "./utils";
+
+export const nonFirefoxCommandlineHotkey = "Mod+Shift+P";
 
 function openCommandline(): void {
   if (isAnyPopupVisible()) return;
@@ -9,4 +11,7 @@ function openCommandline(): void {
 }
 
 createHotkey(() => hotkeys.commandline, openCommandline);
-createHotkey("Mod+Shift+P", openCommandline);
+
+if (!isFirefox()) {
+  createHotkey(nonFirefoxCommandlineHotkey, openCommandline);
+}


### PR DESCRIPTION
Now only the required hotkeys are created.