### PR TITLE
fix(quote-length-filter): custom length filter modal not opening (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/components/modals/QuoteSearchModal.tsx
+++ b/frontend/src/ts/components/modals/QuoteSearchModal.tsx
@@ -348,7 +348,9 @@ export function QuoteSearchModal(): JSXElement {
 
   createEffect(
     on(lengthFilter, (lengths) => {
-      if (lengths.includes("4") && !hasCustomFilter()) {
+      if (!lengths.includes("4")) {
+        setHasCustomFilter(false);
+      } else if (!hasCustomFilter()) {
         showSimpleModal({
           title: "Enter minimum and maximum number of words",
           buttonText: "save",
@@ -365,7 +367,7 @@ export function QuoteSearchModal(): JSXElement {
             setCustomFilterMin(min);
             setCustomFilterMax(max);
             setHasCustomFilter(true);
-            return { status: "success", message: "Saved custom filter" };
+            return { status: "success", showNotification: false };
           },
         });
       }


### PR DESCRIPTION
To reproduce:

1. Switch to `quote` mode
2. Click on the search icon
3. Click on `filter by length`
4. Select `custom`
5. Fill out the min and max values and save
6. Remove it by clicking the `x` next to the word `custom`
7. Repeat steps 3-4
8. Notice how it doesn't open the modal anymore

Also removes the notification after saving a custom length filter.