### PR TITLE
fix(settings): optional include background link (@fehmer)

### DIFF
--- a/frontend/src/ts/components/pages/settings/custom-setting/Theme.tsx
+++ b/frontend/src/ts/components/pages/settings/custom-setting/Theme.tsx
@@ -125,7 +125,7 @@ export function Theme(): JSXElement {
           onClick={() => {
             showSimpleModal({
               title: "Share custom theme",
-              schema: z.object({ includeBackground: z.boolean() }),
+              schema: z.object({ includeBackground: z.boolean().optional() }),
               inputs: {
                 includeBackground: {
                   label: "Include background link, size and filters",


### PR DESCRIPTION
don't show missing field value message if include background is not clicked in share custom theme modal
