### PR TITLE
fix: use quote group for length label in quote search modal

### DIFF
--- a/frontend/src/ts/components/modals/QuoteSearchModal.tsx
+++ b/frontend/src/ts/components/modals/QuoteSearchModal.tsx
@@ -92,11 +92,10 @@ function exactSearch(quotes: Quote[], captured: RegExp[]): [Quote[], string[]] {
   return [matches, Array.from(exactSearchQueryTerms)];
 }
 
+const LENGTH_LABELS = ["short", "medium", "long", "thicc"] as const;
+
 function getLengthDesc(quote: Quote): string {
-  if (quote.length < 101) return "short";
-  if (quote.length < 301) return "medium";
-  if (quote.length < 601) return "long";
-  return "thicc";
+  return LENGTH_LABELS[quote.group] ?? "unknown";
 }
 
 function Item(props: {


### PR DESCRIPTION
## Description

Fixes #8081

### Problem
`getLengthDesc()` in `QuoteSearchModal.tsx` used hardcoded character-count thresholds (`< 101` → short, `< 301` → medium, `< 601` → long, else → thicc) that were derived from typical English quote lengths.

For languages with different length group definitions (e.g. `code_systemverilog` defines `short` as 0–500 chars, `medium` as 501–4000 chars, etc.), these thresholds produce the wrong label. A 365-character quote that belongs to group 0 (`short`) was displayed as **long** in the search modal.

### Fix
Use `quote.group` — which is already assigned correctly from the language's own `groups` JSON field — to look up the label. This is the same value the filter buttons already use.

```ts
// Before
function getLengthDesc(quote: Quote): string {
  if (quote.length < 101) return "short";
  if (quote.length < 301) return "medium";
  if (quote.length < 601) return "long";
  return "thicc";
}

// After
const LENGTH_LABELS = ["short", "medium", "long", "thicc"] as const;

function getLengthDesc(quote: Quote): string {
  return LENGTH_LABELS[quote.group] ?? "unknown";
}
```

### Testing
1. Set language to `code systemverilog`
2. Switch to `quote` mode
3. Open the quote search modal and filter by `short`
4. Each result should now display **short** in the length field (not **long**)