### PR TITLE
fix: reset animation fps limit to native when custom field is cleared on blur

### DIFF
--- a/frontend/src/ts/components/pages/settings/custom-setting/AnimationFpsLimit.tsx
+++ b/frontend/src/ts/components/pages/settings/custom-setting/AnimationFpsLimit.tsx
@@ -62,7 +62,13 @@ export function AnimationFpsLimit(): JSXElement {
                     value: val,
                   });
                 },
-                onBlur: () => {
+                onBlur: ({ value }) => {
+                  if (String(value) === "") {
+                    setfpsLimit(1000);
+                    form.setFieldValue("fpsLimit", "");
+                    savedIndicator.hide();
+                    return;
+                  }
                   void form.handleSubmit();
                 },
               }}
@@ -73,7 +79,6 @@ export function AnimationFpsLimit(): JSXElement {
                     placeholder={"custom limit"}
                     type="number"
                     schema={fpsLimitSchema}
-                    resetToDefaultIfEmptyOnBlur
                   />
                   <savedIndicator.component />
                 </div>


### PR DESCRIPTION
## Description

Fixes #8119

### Problem
When a user set a custom animation fps limit (e.g. `60`), then cleared the input field and clicked away, nothing happened — the `native` button stayed inactive, the field stayed empty, and the previous custom value was still in effect (no visual feedback).

**Root cause:** The `onBlur` validator called `form.handleSubmit()` with an empty string, which failed the `onChange` validator (`"Must be a number"`), so `onSubmit` was never called. The `resetToDefaultIfEmptyOnBlur` prop had no effect because the form's `defaultValues.fpsLimit` was `""` — already empty.

### Fix
In the `onBlur` validator, explicitly detect an empty value and call `setfpsLimit(1000)` to reset to native, making the **native** button active and clearing the indicator — which matches the expected behavior described in the issue.

```tsx
// Before
onBlur: () => {
  void form.handleSubmit();
},

// After
onBlur: ({ value }) => {
  if (String(value) === "") {
    setfpsLimit(1000);
    form.setFieldValue("fpsLimit", "");
    savedIndicator.hide();
    return;
  }
  void form.handleSubmit();
},
```

Also removed the now-redundant `resetToDefaultIfEmptyOnBlur` prop from `<InputField>` since blur is handled manually.

### Testing
1. Go to Settings → search **animation fps limit**
2. Enter `60` in the custom limit field → click away → ✅ saved indicator flashes, native button inactive
3. Clear the field → click away → ✅ **native** button becomes active, field stays empty