### PR TITLE
refactor: word navigation correctness approach (@Leonabcd123, @miodec)

### DIFF
--- a/frontend/__tests__/input/helpers/validation.spec.ts
+++ b/frontend/__tests__/input/helpers/validation.spec.ts
@@ -153,17 +153,6 @@ describe("isCharCorrect", () => {
       },
     );
   });
-
-  it("throws error if data is undefined", () => {
-    expect(() =>
-      isCharCorrect({
-        data: undefined as any,
-        inputValue: "val",
-        targetWord: "word",
-        correctShiftUsed: true,
-      }),
-    ).toThrow();
-  });
 });
 
 describe("shouldInsertSpaceCharacter", () => {

--- a/frontend/__tests__/input/helpers/validation.spec.ts
+++ b/frontend/__tests__/input/helpers/validation.spec.ts
@@ -108,6 +108,13 @@ describe("isCharCorrect", () => {
         "word",
         false,
       ],
+      [
+        "returns true when committing a word with a newline",
+        "\n",
+        "word",
+        "word\n",
+        true,
+      ],
     ])("%s", (_desc, char, input, word, expected) => {
       expect(
         isWordCorrect({

--- a/frontend/__tests__/input/helpers/validation.spec.ts
+++ b/frontend/__tests__/input/helpers/validation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import {
   isCharCorrect,
+  isWordCorrect,
   shouldInsertSpaceCharacter,
 } from "../../../src/ts/input/helpers/validation";
 import { __testing } from "../../../src/ts/config/testing";
@@ -76,14 +77,6 @@ describe("isCharCorrect", () => {
 
   describe("Space Handling", () => {
     it.each([
-      ["returns true at the end of a correct word", " ", "word", "word", true],
-      [
-        "returns false at the end of an incorrect word",
-        " ",
-        "worx",
-        "word",
-        false,
-      ],
       ["returns false in the middle of a word", " ", "wor", "word", false],
       ["returns false at the start of a word", " ", "", "word", false],
       [
@@ -96,6 +89,28 @@ describe("isCharCorrect", () => {
     ])("%s", (_desc, char, input, word, expected) => {
       expect(
         isCharCorrect({
+          data: char,
+          inputValue: input,
+          targetWord: word,
+          correctShiftUsed: true,
+        }),
+      ).toBe(expected);
+    });
+  });
+
+  describe("Space Handling at the end of a word", () => {
+    it.each([
+      ["returns true at the end of a correct word", " ", "word", "word", true],
+      [
+        "returns false at the end of an incorrect word",
+        " ",
+        "worx",
+        "word",
+        false,
+      ],
+    ])("%s", (_desc, char, input, word, expected) => {
+      expect(
+        isWordCorrect({
           data: char,
           inputValue: input,
           targetWord: word,

--- a/frontend/__tests__/input/helpers/validation.spec.ts
+++ b/frontend/__tests__/input/helpers/validation.spec.ts
@@ -115,6 +115,13 @@ describe("isCharCorrect", () => {
         "word\n",
         true,
       ],
+      [
+        "returns false when committing an incorrect word with a newline",
+        "\n",
+        "xord",
+        "word\n",
+        false,
+      ],
     ])("%s", (_desc, char, input, word, expected) => {
       expect(
         isWordCorrect({

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -148,7 +148,7 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
   const noSpaceForce =
     isFunboxActiveWithProperty("nospace") &&
     (testInput + data).length === TestWords.words.getCurrentText().length;
-  // does this input try to move to the next word (before stop-on-error can block it)
+  // does this input try to move to the next word (before removeLastChar can block it)
   const goingToNextWord =
     ((charIsSpace || charIsNewline) && !shouldInsertSpace) || noSpaceForce;
 

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -33,6 +33,7 @@ import { goToNextWord } from "../helpers/word-navigation";
 import { onBeforeInsertText } from "./before-insert-text";
 import {
   isCharCorrect,
+  isWordCorrect,
   shouldInsertSpaceCharacter,
 } from "../helpers/validation";
 import { getCurrentInput, logTestEvent } from "../../test/events/data";
@@ -134,7 +135,7 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
     data,
     currentWord[(testInput + data).length - 1] ?? "",
   );
-  const correct =
+  const charCorrect =
     funboxCorrect ??
     isCharCorrect({
       data,
@@ -148,14 +149,14 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
   // like accuracy, keypress errors, and missed words
   let removeLastChar = false;
   let visualInputOverride: string | undefined;
-  if (Config.stopOnError === "letter" && !correct) {
+  if (!charIsSpace && Config.stopOnError === "letter" && !charCorrect) {
     if (!Config.blindMode) {
       visualInputOverride = testInput + data;
     }
     removeLastChar = true;
   }
 
-  if (!isSpace(data) && correctShiftUsed === false) {
+  if (!charIsSpace && correctShiftUsed === false) {
     removeLastChar = true;
     visualInputOverride = undefined;
     incrementIncorrectShiftsInARow();
@@ -176,6 +177,15 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
   const shouldGoToNextWord =
     !removeLastChar &&
     (((charIsSpace || charIsNewline) && !shouldInsertSpace) || noSpaceForce);
+
+  const correct = shouldGoToNextWord
+    ? (funboxCorrect ??
+      isWordCorrect({
+        inputValue: testInput + (charIsSpace ? "" : data),
+        targetWord: currentWord,
+        correctShiftUsed,
+      }))
+    : charCorrect;
 
   if (Config.keymapMode === "react") {
     flash(data, correct);

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -181,7 +181,8 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
   const correct = shouldGoToNextWord
     ? (funboxCorrect ??
       isWordCorrect({
-        inputValue: testInput + (charIsSpace ? "" : data),
+        data,
+        inputValue: testInput,
         targetWord: currentWord,
         correctShiftUsed,
       }))

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -190,7 +190,7 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
     resetIncorrectShiftsInARow();
   }
 
-  // stop-on-error can block navigation, so this is derived after removeLastChar
+  // stop-on-error and opposite shift mode can block navigation, so this is derived after removeLastChar
   const shouldGoToNextWord = goingToNextWord && !removeLastChar;
 
   if (Config.keymapMode === "react") {

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -149,7 +149,7 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
   // like accuracy, keypress errors, and missed words
   let removeLastChar = false;
   let visualInputOverride: string | undefined;
-  if (!charIsSpace && Config.stopOnError === "letter" && !charCorrect) {
+  if (Config.stopOnError === "letter" && !charCorrect) {
     if (!Config.blindMode) {
       visualInputOverride = testInput + data;
     }

--- a/frontend/src/ts/input/handlers/insert-text.ts
+++ b/frontend/src/ts/input/handlers/insert-text.ts
@@ -144,12 +144,32 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
       correctShiftUsed,
     });
 
+  // word navigation check
+  const noSpaceForce =
+    isFunboxActiveWithProperty("nospace") &&
+    (testInput + data).length === TestWords.words.getCurrentText().length;
+  // does this input try to move to the next word (before stop-on-error can block it)
+  const goingToNextWord =
+    ((charIsSpace || charIsNewline) && !shouldInsertSpace) || noSpaceForce;
+
+  // when moving to the next word, correctness is word-level (a correct word-completing
+  // space has charCorrect === false, so charCorrect can't be used below)
+  const correct = goingToNextWord
+    ? (funboxCorrect ??
+      isWordCorrect({
+        data,
+        inputValue: testInput,
+        targetWord: currentWord,
+        correctShiftUsed,
+      }))
+    : charCorrect;
+
   // handing cases where last char needs to be removed
   // this is here and not in beforeInsertText because we want to penalize for incorrect spaces
   // like accuracy, keypress errors, and missed words
   let removeLastChar = false;
   let visualInputOverride: string | undefined;
-  if (Config.stopOnError === "letter" && !charCorrect) {
+  if (Config.stopOnError === "letter" && !correct) {
     if (!Config.blindMode) {
       visualInputOverride = testInput + data;
     }
@@ -170,23 +190,8 @@ export async function onInsertText(options: OnInsertTextParams): Promise<void> {
     resetIncorrectShiftsInARow();
   }
 
-  // word navigation check
-  const noSpaceForce =
-    isFunboxActiveWithProperty("nospace") &&
-    (testInput + data).length === TestWords.words.getCurrentText().length;
-  const shouldGoToNextWord =
-    !removeLastChar &&
-    (((charIsSpace || charIsNewline) && !shouldInsertSpace) || noSpaceForce);
-
-  const correct = shouldGoToNextWord
-    ? (funboxCorrect ??
-      isWordCorrect({
-        data,
-        inputValue: testInput,
-        targetWord: currentWord,
-        correctShiftUsed,
-      }))
-    : charCorrect;
+  // stop-on-error can block navigation, so this is derived after removeLastChar
+  const shouldGoToNextWord = goingToNextWord && !removeLastChar;
 
   if (Config.keymapMode === "react") {
     flash(data, correct);

--- a/frontend/src/ts/input/helpers/validation.ts
+++ b/frontend/src/ts/input/helpers/validation.ts
@@ -2,6 +2,19 @@ import { Config } from "../../config/store";
 import { isSpace } from "../../utils/strings";
 
 /**
+ * Check if a character or a word are always correct/incorrect, used by isCharCorrect
+ * and isWordCorrect.
+ * @param correctShiftUsed - Whether the correct shift state was used. Null means disabled
+ */
+function isCharOrWordAlwaysCorrectOrIncorrect(
+  correctShiftUsed: boolean | null,
+): boolean | null {
+  if (Config.mode === "zen") return true;
+  if (correctShiftUsed === false) return false;
+  return null;
+}
+
+/**
  * Check if the input data is correct
  * @param options - Options object
  * @param options.data - Input data
@@ -17,16 +30,14 @@ export function isCharCorrect(options: {
 }): boolean {
   const { data, inputValue, targetWord, correctShiftUsed } = options;
 
-  if (Config.mode === "zen") return true;
-
-  if (correctShiftUsed === false) return false;
+  const isCharAlwaysCorrectOrIncorrect =
+    isCharOrWordAlwaysCorrectOrIncorrect(correctShiftUsed);
+  if (isCharAlwaysCorrectOrIncorrect !== null) {
+    return isCharAlwaysCorrectOrIncorrect;
+  }
 
   if (data === undefined) {
     throw new Error("Failed to check if char is correct - data is undefined");
-  }
-
-  if (isSpace(data)) {
-    return inputValue === targetWord;
   }
 
   const targetChar = targetWord[inputValue.length];
@@ -35,11 +46,30 @@ export function isCharCorrect(options: {
     return false;
   }
 
-  if (data === targetChar) {
-    return true;
+  return data === targetChar;
+}
+
+/**
+ * Check if the input data is correct
+ * @param options - Options object
+ * @param options.inputValue - Current input value (use getCurrentInput(), not input element value)
+ * @param options.targetWord - Target word
+ * @param options.correctShiftUsed - Whether the correct shift state was used. Null means disabled
+ */
+export function isWordCorrect(options: {
+  inputValue: string;
+  targetWord: string;
+  correctShiftUsed: boolean | null; //null means disabled
+}): boolean {
+  const { inputValue, targetWord, correctShiftUsed } = options;
+
+  const isCharAlwaysCorrectOrIncorrect =
+    isCharOrWordAlwaysCorrectOrIncorrect(correctShiftUsed);
+  if (isCharAlwaysCorrectOrIncorrect !== null) {
+    return isCharAlwaysCorrectOrIncorrect;
   }
 
-  return false;
+  return inputValue === targetWord;
 }
 
 /**

--- a/frontend/src/ts/input/helpers/validation.ts
+++ b/frontend/src/ts/input/helpers/validation.ts
@@ -7,10 +7,14 @@ import { isSpace } from "../../utils/strings";
  * @param correctShiftUsed - Whether the correct shift state was used. Null means disabled
  */
 function isCharOrWordAlwaysCorrectOrIncorrect(
+  data: string,
   correctShiftUsed: boolean | null,
 ): boolean | null {
   if (Config.mode === "zen") return true;
   if (correctShiftUsed === false) return false;
+  if (data === undefined) {
+    throw new Error("Failed to check if char is correct - data is undefined");
+  }
   return null;
 }
 
@@ -30,14 +34,12 @@ export function isCharCorrect(options: {
 }): boolean {
   const { data, inputValue, targetWord, correctShiftUsed } = options;
 
-  const isCharAlwaysCorrectOrIncorrect =
-    isCharOrWordAlwaysCorrectOrIncorrect(correctShiftUsed);
+  const isCharAlwaysCorrectOrIncorrect = isCharOrWordAlwaysCorrectOrIncorrect(
+    data,
+    correctShiftUsed,
+  );
   if (isCharAlwaysCorrectOrIncorrect !== null) {
     return isCharAlwaysCorrectOrIncorrect;
-  }
-
-  if (data === undefined) {
-    throw new Error("Failed to check if char is correct - data is undefined");
   }
 
   const targetChar = targetWord[inputValue.length];
@@ -57,19 +59,23 @@ export function isCharCorrect(options: {
  * @param options.correctShiftUsed - Whether the correct shift state was used. Null means disabled
  */
 export function isWordCorrect(options: {
+  data: string;
   inputValue: string;
   targetWord: string;
   correctShiftUsed: boolean | null; //null means disabled
 }): boolean {
-  const { inputValue, targetWord, correctShiftUsed } = options;
+  const { data, inputValue, targetWord, correctShiftUsed } = options;
 
-  const isCharAlwaysCorrectOrIncorrect =
-    isCharOrWordAlwaysCorrectOrIncorrect(correctShiftUsed);
+  const isCharAlwaysCorrectOrIncorrect = isCharOrWordAlwaysCorrectOrIncorrect(
+    data,
+    correctShiftUsed,
+  );
   if (isCharAlwaysCorrectOrIncorrect !== null) {
     return isCharAlwaysCorrectOrIncorrect;
   }
 
-  return inputValue === targetWord;
+  const finalInputValue = inputValue + (isSpace(data) ? "" : data);
+  return finalInputValue === targetWord;
 }
 
 /**

--- a/frontend/src/ts/input/helpers/validation.ts
+++ b/frontend/src/ts/input/helpers/validation.ts
@@ -12,9 +12,6 @@ function isCharOrWordAlwaysCorrectOrIncorrect(
 ): boolean | null {
   if (Config.mode === "zen") return true;
   if (correctShiftUsed === false) return false;
-  if (data === undefined) {
-    throw new Error("Failed to check if char is correct - data is undefined");
-  }
   return null;
 }
 

--- a/frontend/src/ts/input/helpers/validation.ts
+++ b/frontend/src/ts/input/helpers/validation.ts
@@ -2,20 +2,6 @@ import { Config } from "../../config/store";
 import { isSpace } from "../../utils/strings";
 
 /**
- * Check if a character or a word are always correct/incorrect, used by isCharCorrect
- * and isWordCorrect.
- * @param correctShiftUsed - Whether the correct shift state was used. Null means disabled
- */
-function isCharOrWordAlwaysCorrectOrIncorrect(
-  data: string,
-  correctShiftUsed: boolean | null,
-): boolean | null {
-  if (Config.mode === "zen") return true;
-  if (correctShiftUsed === false) return false;
-  return null;
-}
-
-/**
  * Check if the input data is correct
  * @param options - Options object
  * @param options.data - Input data
@@ -31,13 +17,8 @@ export function isCharCorrect(options: {
 }): boolean {
   const { data, inputValue, targetWord, correctShiftUsed } = options;
 
-  const isCharAlwaysCorrectOrIncorrect = isCharOrWordAlwaysCorrectOrIncorrect(
-    data,
-    correctShiftUsed,
-  );
-  if (isCharAlwaysCorrectOrIncorrect !== null) {
-    return isCharAlwaysCorrectOrIncorrect;
-  }
+  if (Config.mode === "zen") return true;
+  if (correctShiftUsed === false) return false;
 
   const targetChar = targetWord[inputValue.length];
 
@@ -63,13 +44,8 @@ export function isWordCorrect(options: {
 }): boolean {
   const { data, inputValue, targetWord, correctShiftUsed } = options;
 
-  const isCharAlwaysCorrectOrIncorrect = isCharOrWordAlwaysCorrectOrIncorrect(
-    data,
-    correctShiftUsed,
-  );
-  if (isCharAlwaysCorrectOrIncorrect !== null) {
-    return isCharAlwaysCorrectOrIncorrect;
-  }
+  if (Config.mode === "zen") return true;
+  if (correctShiftUsed === false) return false;
 
   const finalInputValue = inputValue + (isSpace(data) ? "" : data);
   return finalInputValue === targetWord;


### PR DESCRIPTION
To reproduce (`nospace`):

1. Set funbox to `nospace`
2. Type the first letter of the first word incorrectly
3. Complete the word
4. Notice how there isn't a red underline under it

To reproduce (newline):

1. Switch to custom mode
2. Change text to:

```
asdf
asdf
```

3. Type `aaaa`
4. Press `enter`
5. Notice how there isn't a red underline under it
