### PR TITLE
fix(wikipedia): skip empty sections (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/test/wikipedia.ts
+++ b/frontend/src/ts/test/wikipedia.ts
@@ -100,6 +100,12 @@ export async function getSection(
           // Removing whitespace before and after text
           sectionText = sectionText.trim();
 
+          // If this section is empty, fetch another one
+          if (!sectionText) {
+            res(getSection(language));
+            return;
+          }
+
           const words = sectionText.split(" ");
 
           const section = new JSONData.Section(

--- a/frontend/src/ts/test/wikipedia.ts
+++ b/frontend/src/ts/test/wikipedia.ts
@@ -101,7 +101,7 @@ export async function getSection(
           sectionText = sectionText.trim();
 
           // If this section is empty, fetch another one
-          if (!sectionText) {
+          if (sectionText === "") {
             res(getSection(language));
             return;
           }


### PR DESCRIPTION
Prevents the `Random word is empty` error, which doesn't provide any value to the user, as we fetch again until we get valid text.