### PR TITLE
feat(theme): add ayu-dark theme (@Yhorx)

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -2322,6 +2322,18 @@ export const themes: Record<ThemeName, Theme> = {
     colorfulError: "#b29a91",
     colorfulErrorExtra: "#b29a91",
   },
+  ayu_dark: {
+    bg: "#10141c",
+    caret: "#39bae6",
+    main: "#59c2ff",
+    sub: "#ffb454",
+    subAlt: "#10141c",
+    text: "#aad94c",
+    error: "#f07171",
+    errorExtra: "#f07171",
+    colorfulError: "#f07171",
+    colorfulErrorExtra: "#f07171",
+  },
 };
 
 export type ThemeWithName = Theme & { name: ThemeName };

--- a/packages/schemas/src/themes.ts
+++ b/packages/schemas/src/themes.ts
@@ -190,6 +190,7 @@ export const ThemeNameSchema = z.enum(
     "witch_girl",
     "pale_nimbus",
     "spiderman",
+    "ayu_dark",
   ],
   {
     errorMap: customEnumErrorHandler("Must be a known theme"),


### PR DESCRIPTION
Related to #3833.
Adds a new theme based on the color palette from https://ayutheme.com/.

- [x] Adding a theme?
  - [x] Add theme to `packages/schemas/src/themes.ts`
  - [x] Add theme to `frontend/src/ts/constants/themes.ts`
  - [ ] (optional) Add theme css file to `frontend/static/themes`
  - [x] Add some screenshots of the theme, especially with different test settings (colorful, flip colors) to your pull request

### Screenshots

**Normal**

<img width="1901" height="861" alt="normal" src="https://github.com/user-attachments/assets/53e0dc36-3429-42a9-8256-99f82668fed0" />

**Colorful**

<img width="1886" height="863" alt="colorful" src="https://github.com/user-attachments/assets/a0c32b60-9f14-4419-805e-20b68974de4a" />

**Flip colors**

<img width="1895" height="860" alt="flip-colors" src="https://github.com/user-attachments/assets/f1f14376-a70d-4f7e-9abc-56ae37bf024b" />
