### PR TITLE
fix: fix caret error on incorrect final word (@Positiveoo1)

### DIFF
--- a/frontend/src/ts/elements/caret.ts
+++ b/frontend/src/ts/elements/caret.ts
@@ -395,13 +395,19 @@ export class Caret {
     isDirectionReversed: boolean;
   }): { left: number; top: number; width: number } {
     const letters = options.word?.qsa("letter");
-    let letter = letters?.[options.letterIndex] ?? letters?.at(-1);
-    if (letter === undefined) {
-      return {
-        left: options.word.getOffsetLeft(),
-        top: options.word.getOffsetTop(),
-        width: getTotalInlineMargin(options.word.native),
-      };
+
+    if (letters.length === 0) {
+      throw new Error(
+        "Caret getTargetPositionAndWidth: no letters found in word",
+      );
+    }
+
+    let letter = letters[options.letterIndex] ?? letters[letters.length - 1];
+
+    if (!letter) {
+      throw new Error(
+        `Caret getTargetPositionAndWidth: letter not found for index ${options.letterIndex}`,
+      );
     }
 
     if (caretDebug) {

--- a/frontend/src/ts/elements/caret.ts
+++ b/frontend/src/ts/elements/caret.ts
@@ -395,12 +395,13 @@ export class Caret {
     isDirectionReversed: boolean;
   }): { left: number; top: number; width: number } {
     const letters = options.word?.qsa("letter");
-    let letter;
-    if (!letters?.length || !(letter = letters[options.letterIndex])) {
-      // maybe we should return null here instead of throwing
-      throw new Error(
-        "Caret getTargetPositionAndWidth: no letters found in word",
-      );
+    let letter = letters?.[options.letterIndex] ?? letters?.at(-1);
+    if (letter === undefined) {
+      return {
+        left: options.word.getOffsetLeft(),
+        top: options.word.getOffsetTop(),
+        width: getTotalInlineMargin(options.word.native),
+      };
     }
 
     if (caretDebug) {

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1841,7 +1841,6 @@ export function beforeTestWordChange(
   if (
     (Config.stopOnError === "letter" && (correct || correct === null)) ||
     nospaceEnabled ||
-    correct === false ||
     forceUpdateActiveWordLetters
   ) {
     void updateWordLetters({

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1841,6 +1841,7 @@ export function beforeTestWordChange(
   if (
     (Config.stopOnError === "letter" && (correct || correct === null)) ||
     nospaceEnabled ||
+    correct === false ||
     forceUpdateActiveWordLetters
   ) {
     void updateWordLetters({


### PR DESCRIPTION
Fixes #8180

## Summary
- Render incorrect committed words before word change UI updates
- Prevent caret positioning from throwing when target word has no rendered letters yet

## Testing
- Custom text: `a a`
- Typed `a`, space, `f`, space
- Confirmed console no longer throws `Caret getTargetPositionAndWidth: no letters found in word`