### PR TITLE
fix(funbox): skip wikipedia section fetch when leaving the test page (@henrikhhag)

### DIFF
--- a/frontend/__tests__/test/words-generator.spec.ts
+++ b/frontend/__tests__/test/words-generator.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { LanguageObject } from "@monkeytype/schemas/languages";
+
+vi.mock("../../src/ts/test/wikipedia", () => ({
+  getSection: vi.fn(async () => ({
+    title: "Mock",
+    author: "Mock",
+    words: ["fetched", "wikipedia", "words"],
+  })),
+}));
+
+import { Config } from "../../src/ts/config/store";
+import { generateWords } from "../../src/ts/test/words-generator";
+import { getSection } from "../../src/ts/test/wikipedia";
+
+const testLanguage: LanguageObject = {
+  name: "english",
+  words: ["the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog"],
+};
+
+describe("words-generator", () => {
+  describe("generateWords", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      Config.mode = "words";
+      Config.words = 5;
+      Config.funbox = ["wikipedia"];
+    });
+
+    it("does not pull the funbox section when skipFunboxSection is true", async () => {
+      const result = await generateWords(testLanguage, {
+        skipFunboxSection: true,
+      });
+
+      expect(getSection).not.toHaveBeenCalled();
+      expect(result.words.length).toBeGreaterThan(0);
+    });
+
+    it("pulls the funbox section when skipFunboxSection is not set", async () => {
+      await generateWords(testLanguage);
+
+      expect(getSection).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/ts/pages/test.ts
+++ b/frontend/src/ts/pages/test.ts
@@ -16,6 +16,7 @@ export const page = new Page({
   afterHide: async (): Promise<void> => {
     void TestLogic.restart({
       noAnim: true,
+      skipFunboxSection: true,
     });
     void Funbox.clear();
     updateFooterAndVerticalAds(true);

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -171,6 +171,7 @@ type RestartOptions = {
   practiseMissed?: boolean;
   noAnim?: boolean;
   isQuickRestart?: boolean;
+  skipFunboxSection?: boolean;
 };
 
 export async function restart(options = {} as RestartOptions): Promise<void> {
@@ -328,7 +329,9 @@ export async function restart(options = {} as RestartOptions): Promise<void> {
 
   await Funbox.rememberSettings();
 
-  const initResult = await init();
+  const initResult = await init({
+    skipFunboxSection: options.skipFunboxSection,
+  });
 
   if (!initResult) {
     setIsTestRestarting(false);
@@ -351,7 +354,9 @@ let lastInitError: Error | null = null;
 let showedLazyModeNotification: boolean = false;
 let testReinitCount = 0;
 
-async function init(): Promise<boolean> {
+async function init(options?: {
+  skipFunboxSection?: boolean;
+}): Promise<boolean> {
   console.debug("Initializing test");
   testReinitCount++;
   if (testReinitCount > 3) {
@@ -380,7 +385,7 @@ async function init(): Promise<boolean> {
   }
 
   if (!language || language.name !== Config.language) {
-    return await init();
+    return await init(options);
   }
 
   if (getActivePage() === "test") {
@@ -479,7 +484,9 @@ async function init(): Promise<boolean> {
   let generatedWords: string[] = [];
   let generatedSectionIndexes: number[] = [];
   try {
-    const gen = await WordsGenerator.generateWords(language);
+    const gen = await WordsGenerator.generateWords(language, {
+      skipFunboxSection: options?.skipFunboxSection,
+    });
     generatedWords = gen.words;
     generatedSectionIndexes = gen.sectionIndexes;
     wordsHaveTab = gen.hasTab;
@@ -504,7 +511,7 @@ async function init(): Promise<boolean> {
       });
     }
 
-    return await init();
+    return await init(options);
   }
 
   let hasNumbers = false;

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -330,7 +330,11 @@ function getFunboxWordsFrequency(): FunboxWordsFrequency | undefined {
 }
 
 async function getFunboxSection(): Promise<string[]> {
-  const ret = [];
+  const ret: string[] = [];
+
+  if (skipFunboxSection) {
+    return ret;
+  }
 
   const funbox = findSingleActiveFunboxWithFunction("pullSection");
 
@@ -600,6 +604,7 @@ async function getQuoteWordList(
 let currentWordset: Wordset | null = null;
 let currentLanguage: LanguageObject | null = null;
 let isCurrentlyUsingFunboxSection = false;
+let skipFunboxSection = false;
 
 type GenerateWordsReturn = {
   words: string[];
@@ -614,7 +619,9 @@ let previousRandomQuote: QuoteWithTextSplit | null = null;
 
 export async function generateWords(
   language: LanguageObject,
+  options?: { skipFunboxSection?: boolean },
 ): Promise<GenerateWordsReturn> {
+  skipFunboxSection = options?.skipFunboxSection ?? false;
   if (!isRepeated()) {
     previousGetNextWordReturns = [];
   }
@@ -634,7 +641,8 @@ export async function generateWords(
     allJoiningScript: language.joiningScript ?? false,
   };
 
-  isCurrentlyUsingFunboxSection = isFunboxActiveWithFunction("pullSection");
+  isCurrentlyUsingFunboxSection =
+    !skipFunboxSection && isFunboxActiveWithFunction("pullSection");
 
   const wordOrder = getWordOrder();
   console.debug("Word order", wordOrder);


### PR DESCRIPTION
Problem: every time you leave the test page, the app runs a background-restart of the test, and if the wikipedia-funbox is active, then the restart makes a unnecessary network call to Wikipedia in the background. And if that call fails, then the global loading indicator will just stand there without anyone seeing why.

https://github.com/monkeytypegame/monkeytype/issues/8032
From the issue #8032, in comments section, @Leonabcd123 traces the issue directly to the afterHide-hook

The fix is to make a new flag (skipFunboxSection) that lets this specific background-restart jump over the network, while normal use of test page is unchanged.

For testing I wrote a Vitest-test that confirms the network call doesn't happen with the flag, and continues without it. Also ran the full frontend test suite (1047 tests) to check for regressions — all passing.

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

Closes #8032 
