### PR TITLE
fix(languages): disable lazy mode for chinese simplified (@EnormousMush)

### DIFF
--- a/frontend/static/languages/chinese_simplified.json
+++ b/frontend/static/languages/chinese_simplified.json
@@ -1,6 +1,7 @@
 {
   "name": "chinese_simplified",
   "_comment": "Sourced from https://gist.github.com/indiejoseph/eae09c673460aa0b56db",
+  "noLazyMode": true,
   "bcp47": "zh-CN",
   "words": [
     "我们",

--- a/frontend/static/languages/chinese_simplified_10k.json
+++ b/frontend/static/languages/chinese_simplified_10k.json
@@ -1,6 +1,7 @@
 {
   "name": "chinese_simplified_10k",
   "_comment": "Sourced from https://gist.github.com/indiejoseph/eae09c673460aa0b56db",
+  "noLazyMode": true,
   "bcp47": "zh-CN",
   "words": [
     "我们",

--- a/frontend/static/languages/chinese_simplified_1k.json
+++ b/frontend/static/languages/chinese_simplified_1k.json
@@ -1,6 +1,7 @@
 {
   "name": "chinese_simplified_1k",
   "_comment": "Sourced from https://gist.github.com/indiejoseph/eae09c673460aa0b56db",
+  "noLazyMode": true,
   "bcp47": "zh-CN",
   "words": [
     "我们",

--- a/frontend/static/languages/chinese_simplified_50k.json
+++ b/frontend/static/languages/chinese_simplified_50k.json
@@ -1,6 +1,7 @@
 {
   "name": "chinese_simplified_50k",
   "_comment": "Sourced from https://gist.github.com/indiejoseph/eae09c673460aa0b56db",
+  "noLazyMode": true,
   "bcp47": "zh-CN",
   "words": [
     "我们",

--- a/frontend/static/languages/chinese_simplified_5k.json
+++ b/frontend/static/languages/chinese_simplified_5k.json
@@ -1,6 +1,7 @@
 {
   "name": "chinese_simplified_5k",
   "_comment": "Sourced from https://gist.github.com/indiejoseph/eae09c673460aa0b56db",
+  "noLazyMode": true,
   "bcp47": "zh-CN",
   "words": [
     "我们",


### PR DESCRIPTION
Chinese Simplified is the only CJK language missing `noLazyMode`.

Lazy mode strips diacritics — the accent table in `lazy-mode.ts` covers Latin, 
Arabic, Cyrillic and Greek only, so it can never transform a Han character. 
Every other CJK language already accounts for this: `chinese_traditional` 
(all 5 variants), `japanese_*` (4) and `korean_*` (3) set `noLazyMode: true`. 
The 5 `chinese_simplified*` files don't.

The project already draws this distinction correctly elsewhere: #1866 added 
tone-mark accents to `pinyin*`, where lazy mode *is* meaningful because the 
script is romanized (wǒ → wo, ü → v). Han-script languages take the other 
branch. Simplified Chinese currently takes neither.

This isn't only cosmetic. Personal bests are bucketed by `lazyMode` in 
`db.ts:getLocalPB()`, so a Simplified Chinese user with lazy mode on keeps a 
separate PB set from one with it off, for identical tests. Traditional Chinese 
avoids this because `noLazyMode` forces the setting off.

Scoped deliberately: several other languages have no accented characters in 
their current wordlists, but their scripts do support diacritics (e.g. Cyrillic 
ё), so `noLazyMode` would be wrong for them. Han script is the categorical case.

Verified locally with `pnpm dev-fe`: on Chinese Simplified, enabling lazy mode 
and restarting the test now shows the "does not support lazy mode" notice and 
forces the setting off, matching Chinese Traditional. Without the change, the 
setting stays enabled.