### PR TITLE
fix(friends page): Fixed a loader position which is position next to heading "Friends" (@self-yash)

### DIFF
--- a/frontend/src/ts/components/pages/connections/FriendsList.tsx
+++ b/frontend/src/ts/components/pages/connections/FriendsList.tsx
@@ -44,7 +44,7 @@ export function FriendsList() {
 
   return (
     <div>
-      <div class="items-bottom flex">
+      <div class="flex items-center">
         <H2 text="Friends" fa={{ icon: "fa-user-friends", fixedWidth: true }} />
         <Show when={query.isRefetching}>
           <LoadingCircle />


### PR DESCRIPTION
### Description

Problem:
- The circular loader on the Friends page was positioned too close and not exactly centered to the "Friends" heading, causing it to touch the last letter.

Solution:
- Adjusted the loader's positioning to provide proper spacing and improve the visual alignment next to the heading.

Scope:
- UI-only change. No functional behavior was modified.

Attached an image of the issue:
<img width="472" height="157" alt="image" src="https://github.com/user-attachments/assets/2038db7f-b91f-4e8d-87b6-ea4ed97ac85d" />
