### PR TITLE
fix(quotes): prevent wrong quote length when moderator edits quote (@HmonWutt)

### DIFF
--- a/backend/src/dal/new-quotes.ts
+++ b/backend/src/dal/new-quotes.ts
@@ -159,10 +159,12 @@ export async function approve(
     );
   }
   const language = targetQuote.language;
+
+  const approvedText = editQuote ?? targetQuote.text;
   const quote: ApproveQuote = {
-    text: editQuote ?? targetQuote.text,
+    text: approvedText,
     source: editSource ?? targetQuote.source,
-    length: targetQuote.text.length,
+    length: approvedText.length,
     approvedBy: name,
     id: -1,
   };


### PR DESCRIPTION
### Description

When a moderator edits a quote, the length of quote was calculated from the original (unedited) text instead of the new (edited) quote text.