### PR TITLE
feat(theme): add per-color reset button to Theme picker (@Ammarfrfr)

### DIFF
--- a/frontend/src/ts/components/pages/settings/custom-setting/Theme.tsx
+++ b/frontend/src/ts/components/pages/settings/custom-setting/Theme.tsx
@@ -516,6 +516,16 @@ function ThemeButton(props: { theme: ThemeWithName }): JSXElement {
 function Picker(props: { color: ColorName }): JSXElement {
   let colorInputRef: HTMLInputElement | undefined = undefined;
 
+  const resetColor = () => {
+    const presetTheme = ThemesList.find(
+      (theme) => theme.name === getConfig.theme,
+    );
+    const fallbackColor = getTheme()[props.color];
+    const nextColor = presetTheme?.[props.color] ?? fallbackColor;
+
+    updateThemeColor(props.color, nextColor);
+  };
+
   const text = () => {
     if (props.color === "bg") return "background";
     if (props.color === "main") return "main";
@@ -554,7 +564,7 @@ function Picker(props: { color: ColorName }): JSXElement {
 
   return (
     <div
-      class="grid w-full grid-cols-[1fr_1fr_min-content] items-center gap-2"
+      class="grid w-full grid-cols-[1fr_1fr_auto_min-content] items-center gap-2"
       style={{
         "--picker-bg": getTheme().bg,
         "--picker-main": getTheme().main,
@@ -581,6 +591,18 @@ function Picker(props: { color: ColorName }): JSXElement {
             return;
           }
           updateThemeColor(props.color, value);
+        }}
+      />
+      <Button
+        variant="text"
+        fa={{
+          icon: "fa-undo",
+          fixedWidth: true,
+        }}
+        class="p-1"
+        onClick={resetColor}
+        balloon={{
+          text: "Reset this color to the current preset value",
         }}
       />
       <div class="grid">


### PR DESCRIPTION

<img width="2784" height="1534" alt="Screen Recording 2026-07-28 at 6 58 45 PM" src="https://github.com/user-attachments/assets/123483f3-a0de-480a-8486-520da9c6681b" />
**Summary**
Adds a small per-color reset (undo) button next to each color input in Settings → Theme → Custom that resets only that color to the currently selected preset value.

**Motivation**
Users often tweak individual colors and want to revert one value without losing the rest of their custom theme.

**Approach**
Added resetColor() in Picker which finds the current preset (getConfig.theme) and falls back to the current theme color; calls updateThemeColor() to apply.
Added an undo Button with a tooltip (balloon.text) next to the hex input and kept the existing color input/palette flow for live preview.

How to test locally
``` js
cd frontend
pnpm dev
# Open the app at the Vite URL -> Settings → Theme → Custom
# Change a color and click the undo (fa-undo) button next to that color
# Only that color should revert to the preset value
```

**Files changed**
[Theme.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Checklist**
- [ ]  Lints pass (pnpm run lint / pnpm run lint-fe)
- [ ]  Type checks pass (pnpm run ts-check)
- [ ]  Manual verification completed