### PR TITLE
fix(quote): correcting source of quote (@Technet8394)

### DIFF
--- a/frontend/static/quotes/english.json
+++ b/frontend/static/quotes/english.json
@@ -105,7 +105,7 @@
     },
     {
       "text": "And in the end, the love you take is equal to the love you make.",
-      "source": "The End",
+      "source": "The End - The Beatles",
       "id": 18,
       "length": 64
     },


### PR DESCRIPTION
### Description

Fixed an attribution in a Quote not being specific, "The End" could have multiple different sources
### Checks

Not applicable

Closes #

None