### PR TITLE
impr(regex-words-filter): allow patterns without slashes (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/components/modals/WordFilterModal.tsx
+++ b/frontend/src/ts/components/modals/WordFilterModal.tsx
@@ -131,18 +131,10 @@ function filterWordList(
   // Source - https://stackoverflow.com/a/874742
   // Retrieved 2026-06-23, License - CC BY-SA 3.0
   // Separates string into regex expression
-  let reglit = new RegExp("");
-  try {
-    const match = new RegExp("^/(?<pattern>.*?)/(?<flags>[gimy]*)$").exec(
-      value.regex,
-    ) ?? { groups: { pattern: value.regex, flags: "" } };
-    reglit = new RegExp(match.groups?.pattern ?? "", match.groups?.flags);
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      return { error: "Invalid Regex Expression" };
-    }
-    return { error: String(error) };
-  }
+  const match = new RegExp("^/(?<pattern>.*?)/(?<flags>[gimy]*)$").exec(
+    value.regex,
+  ) ?? { groups: { pattern: value.regex, flags: "" } };
+  const reglit = new RegExp(match.groups?.pattern ?? "", match.groups?.flags);
 
   let filterin = Misc.escapeRegExp(value.include.trim());
   filterin = filterin.replace(/\s+/gi, "|");

--- a/frontend/src/ts/components/modals/WordFilterModal.tsx
+++ b/frontend/src/ts/components/modals/WordFilterModal.tsx
@@ -133,13 +133,10 @@ function filterWordList(
   // Separates string into regex expression
   let reglit = new RegExp("");
   try {
-    let flags = "";
-    let pattern = value.regex;
-    if (/(?<!\\)\//.test(value.regex)) {
-      flags = value.regex.replace(/.*\/([gimy]*)$/, "$1");
-      pattern = value.regex.replace(new RegExp(`^/(.*?)/${flags}$`), "$1");
-    }
-    reglit = new RegExp(pattern, flags);
+    const match = new RegExp("^/(?<pattern>.*?)/(?<flags>[gimy]*)$").exec(
+      value.regex,
+    ) ?? { groups: { pattern: value.regex, flags: "" } };
+    reglit = new RegExp(match.groups?.pattern ?? "", match.groups?.flags);
   } catch (error) {
     if (error instanceof SyntaxError) {
       return { error: "Invalid Regex Expression" };

--- a/frontend/src/ts/components/modals/WordFilterModal.tsx
+++ b/frontend/src/ts/components/modals/WordFilterModal.tsx
@@ -131,7 +131,7 @@ function filterWordList(
   // Source - https://stackoverflow.com/a/874742
   // Retrieved 2026-06-23, License - CC BY-SA 3.0
   // Separates string into regex expression
-  const match = new RegExp("^/(?<pattern>.*?)/(?<flags>[gimy]*)$").exec(
+  const match = new RegExp("^/(?<pattern>.*?)/(?<flags>[gimydsuv]*)$").exec(
     value.regex,
   ) ?? { groups: { pattern: value.regex, flags: "" } };
   const reglit = new RegExp(match.groups?.pattern ?? "", match.groups?.flags);

--- a/frontend/src/ts/components/modals/WordFilterModal.tsx
+++ b/frontend/src/ts/components/modals/WordFilterModal.tsx
@@ -135,7 +135,7 @@ function filterWordList(
   try {
     let flags = "";
     let pattern = value.regex;
-    if (value.regex.startsWith("/")) {
+    if (/(?<!\\)\//.test(value.regex)) {
       flags = value.regex.replace(/.*\/([gimy]*)$/, "$1");
       pattern = value.regex.replace(new RegExp(`^/(.*?)/${flags}$`), "$1");
     }

--- a/frontend/src/ts/components/modals/WordFilterModal.tsx
+++ b/frontend/src/ts/components/modals/WordFilterModal.tsx
@@ -133,8 +133,12 @@ function filterWordList(
   // Separates string into regex expression
   let reglit = new RegExp("");
   try {
-    const flags = value.regex.replace(/.*\/([gimy]*)$/, "$1");
-    const pattern = value.regex.replace(new RegExp(`^/(.*?)/${flags}$`), "$1");
+    let flags = "";
+    let pattern = value.regex;
+    if (value.regex.startsWith("/")) {
+      flags = value.regex.replace(/.*\/([gimy]*)$/, "$1");
+      pattern = value.regex.replace(new RegExp(`^/(.*?)/${flags}$`), "$1");
+    }
     reglit = new RegExp(pattern, flags);
   } catch (error) {
     if (error instanceof SyntaxError) {


### PR DESCRIPTION
When the value entered in the regex word filter doesn't match the defined pattern (e.g., it omits the opening or closing `/`), fall back to creating a regex with the input as the pattern. For example, this allows for `a` to be entered, instead of requiring `/a/`.

Also adds support for more regex flags.