### PR TITLE
fix: last word with only commit character is invisible (@Leonabcd123)

### DIFF
--- a/frontend/__tests__/test/test-words.spec.ts
+++ b/frontend/__tests__/test/test-words.spec.ts
@@ -61,7 +61,7 @@ describe("test-words", () => {
       expect(words.get()).toEqual([]);
     });
 
-    it("does not remove the last word when it's only a newline", () => {
+    it("does not empty the last word when it's only a newline", () => {
       words.push("word\n", 0);
       words.push("\n", 0);
       words.removeCommitCharacterFromLastWord();

--- a/frontend/__tests__/test/test-words.spec.ts
+++ b/frontend/__tests__/test/test-words.spec.ts
@@ -60,5 +60,15 @@ describe("test-words", () => {
       expect(() => words.removeCommitCharacterFromLastWord()).not.toThrow();
       expect(words.get()).toEqual([]);
     });
+
+    it("does not remove the last word when it's only a newline", () => {
+      words.push("word\n", 0);
+      words.push("\n", 0);
+      words.removeCommitCharacterFromLastWord();
+      expect(words.get().map((w) => w.textWithCommit)).toEqual([
+        "word\n",
+        "\n",
+      ]);
+    });
   });
 });

--- a/frontend/src/ts/test/test-words.ts
+++ b/frontend/src/ts/test/test-words.ts
@@ -79,7 +79,7 @@ class Words {
   removeCommitCharacterFromLastWord(): void {
     if (this.length === 0) return;
     const lastWord = this.list[this.length - 1];
-    if (lastWord === undefined) return;
+    if (lastWord === undefined || lastWord.text === "") return;
     if (lastWord.commit === " " || lastWord.commit === "\n") {
       lastWord.commit = "";
       lastWord.textWithCommit = lastWord.text;


### PR DESCRIPTION
To reproduce:

1. Change mode to `custom`
2. Enter the following as the custom text:

```
asdf


```
3. Notice how the test says there are two words, but only one is visible. The second one (that should be just a newline) is invisible.