### PR TITLE
fix(settings): clear animation fps limit field on blur when invalid (@karnan7)

### DIFF
--- a/frontend/src/ts/components/ui/form/InputField.tsx
+++ b/frontend/src/ts/components/ui/form/InputField.tsx
@@ -70,7 +70,7 @@ export function InputField(props: {
         autocomplete={props.autocomplete}
         name={props.field().name as string}
         value={convertValueToString(props.field().state.value)}
-        onBlur={() => {
+        onBlur={(e) => {
           if (
             props.resetToDefaultIfEmptyOnBlur &&
             (props.field().state.value === undefined ||
@@ -83,6 +83,9 @@ export function InputField(props: {
           }
           shakeItIfYouWantIt();
           props.field().handleBlur();
+          e.currentTarget.value = convertValueToString(
+            props.field().state.value,
+          );
         }}
         onInput={(e) => {
           const value: unknown = convertStringToValue(


### PR DESCRIPTION
### Description

When you type letters into the animation fps limit input in Firefox, they stay in the box after you click away, as if they had been accepted. They have not been. Nothing stored or validated them, the text is just left behind on screen.

Firefox does not pass the typed letters to our code. For a number input with bad text it reports the value as empty, so the code thinks the field is empty. On blur the handler resets the field to its default, which for this setting is also empty when `native` is selected. The value did not change, so Solid skips writing it to the input and the letters remain visible.

On blur we now write the field's current value into the input directly, rather than depending on Solid noticing a change.

Tested by hand in Firefox.
Note on tests: jsdom sanitizes the value the same way Firefox does, so this case cannot be reproduced in a unit test. Verified manually instead.

Closes #8326
