### PR TITLE
feat: add multiplayer typing races (@jhonsfranky17)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
     "prom-client": "15.1.3",
     "rate-limiter-flexible": "5.0.3",
     "simple-git": "3.36.0",
+    "socket.io": "4.8.3",
     "string-similarity": "4.0.4",
     "swagger-stats": "0.99.7",
     "ua-parser-js": "0.7.33",

--- a/backend/src/api/controllers/multiplayer.ts
+++ b/backend/src/api/controllers/multiplayer.ts
@@ -1,0 +1,41 @@
+import {
+  CreateRoomRequest,
+  CreateRoomResponse,
+  GetRoomPath,
+  GetRoomResponse,
+} from "@monkeytype/contracts/multiplayer";
+import { MonkeyRequest } from "../types";
+import { MonkeyResponse } from "../../utils/monkey-response";
+import MonkeyError from "../../utils/error";
+import * as UserDAL from "../../dal/user";
+import * as Multiplayer from "../../utils/multiplayer";
+
+export async function createRoom(
+  req: MonkeyRequest<undefined, CreateRoomRequest>,
+): Promise<CreateRoomResponse> {
+  const { uid } = req.ctx.decodedToken;
+  const { config } = req.body;
+
+  const { name } = await UserDAL.getPartialUser(
+    uid,
+    "create multiplayer room",
+    ["name"],
+  );
+
+  const room = await Multiplayer.createRoom(uid, name, config);
+
+  return new MonkeyResponse("Room created", room);
+}
+
+export async function getRoom(
+  req: MonkeyRequest<undefined, undefined, GetRoomPath>,
+): Promise<GetRoomResponse> {
+  const { roomCode } = req.params;
+
+  const room = await Multiplayer.getRoom(roomCode);
+  if (room === null) {
+    throw new MonkeyError(404, "Room not found");
+  }
+
+  return new MonkeyResponse("Room found", room);
+}

--- a/backend/src/api/routes/index.ts
+++ b/backend/src/api/routes/index.ts
@@ -16,6 +16,7 @@ import configuration from "./configuration";
 import { version } from "../../version";
 import leaderboards from "./leaderboards";
 import connections from "./connections";
+import multiplayer from "./multiplayer";
 import addSwaggerMiddlewares from "./swagger";
 import { MonkeyResponse } from "../../utils/monkey-response";
 import {
@@ -60,6 +61,7 @@ const router = s.router(contract, {
   quotes,
   webhooks,
   connections,
+  multiplayer,
 });
 
 export function addApiRoutes(app: Application): void {

--- a/backend/src/api/routes/multiplayer.ts
+++ b/backend/src/api/routes/multiplayer.ts
@@ -1,0 +1,14 @@
+import { multiplayerContract } from "@monkeytype/contracts/multiplayer";
+import { initServer } from "@ts-rest/express";
+import * as MultiplayerController from "../controllers/multiplayer";
+import { callController } from "../ts-rest-adapter";
+
+const s = initServer();
+export default s.router(multiplayerContract, {
+  createRoom: {
+    handler: async (r) => callController(MultiplayerController.createRoom)(r),
+  },
+  getRoom: {
+    handler: async (r) => callController(MultiplayerController.getRoom)(r),
+  },
+});

--- a/backend/src/init/socket-auth.ts
+++ b/backend/src/init/socket-auth.ts
@@ -1,0 +1,34 @@
+import { Socket } from "socket.io";
+import { verifyIdToken } from "../utils/auth";
+import Logger from "../utils/logger";
+import { getErrorMessage } from "../utils/error";
+
+export type SocketData = {
+  uid: string;
+  email: string;
+  roomCode?: string;
+};
+
+export async function socketAuthMiddleware(
+  socket: Socket,
+  next: (err?: Error) => void,
+): Promise<void> {
+  const token = socket.handshake.auth["token"] as string | undefined;
+
+  if (token === undefined || token === "") {
+    next(new Error("unauthorized"));
+    return;
+  }
+
+  try {
+    const decoded = await verifyIdToken(token);
+    (socket.data as SocketData).uid = decoded.uid;
+    (socket.data as SocketData).email = decoded.email ?? "";
+    next();
+  } catch (error) {
+    Logger.warning(
+      `Rejected socket auth: ${getErrorMessage(error) ?? "unknown error"}`,
+    );
+    next(new Error("unauthorized"));
+  }
+}

--- a/backend/src/init/socket.ts
+++ b/backend/src/init/socket.ts
@@ -1,0 +1,69 @@
+import { Server as HttpServer } from "http";
+import { Server as SocketIOServer } from "socket.io";
+import { RateLimiterMemory, RateLimiterRedis } from "rate-limiter-flexible";
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "@monkeytype/schemas/multiplayer-events";
+import * as RedisClient from "./redis";
+import { socketAuthMiddleware, SocketData } from "./socket-auth";
+import { registerRoomHandlers } from "../sockets/room-handlers";
+import Logger from "../utils/logger";
+
+export type MultiplayerIO = SocketIOServer<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  Record<string, never>,
+  SocketData
+>;
+
+let io: MultiplayerIO | undefined;
+
+const GENERAL_EVENT_LIMIT_PER_SECOND = 20;
+
+export function attachSocketServer(httpServer: HttpServer): MultiplayerIO {
+  io = new SocketIOServer(httpServer, {
+    cors: { origin: true, credentials: true },
+  });
+
+  const connection = RedisClient.getConnection();
+  const generalLimiter = connection
+    ? new RateLimiterRedis({
+        storeClient: connection,
+        keyPrefix: "multiplayer-rl-general",
+        points: GENERAL_EVENT_LIMIT_PER_SECOND,
+        duration: 1,
+      })
+    : new RateLimiterMemory({
+        points: GENERAL_EVENT_LIMIT_PER_SECOND,
+        duration: 1,
+      });
+
+  io.use(socketAuthMiddleware);
+
+  io.on("connection", (socket) => {
+    Logger.info(`Multiplayer socket connected: ${socket.data.uid}`);
+
+    socket.use((event, next) => {
+      generalLimiter
+        .consume(socket.data.uid)
+        .then(() => next())
+        .catch(() => {
+          // rate limited: silently drop the event rather than disconnecting,
+          // since a burst is likely a slow client tab, not abuse
+          next(new Error("rate limited"));
+        });
+    });
+
+    registerRoomHandlers(io as MultiplayerIO, socket);
+  });
+
+  return io;
+}
+
+export function getIO(): MultiplayerIO {
+  if (!io) {
+    throw new Error("Socket.IO server has not been attached yet");
+  }
+  return io;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,7 +6,8 @@ import {
   updateFromConfigurationFile,
 } from "./init/configuration";
 import app from "./app";
-import { Server } from "http";
+import { createServer, Server } from "http";
+import { attachSocketServer } from "./init/socket";
 import { version } from "./version";
 import { recordServerVersion } from "./utils/prometheus";
 import * as RedisClient from "./init/redis";
@@ -89,7 +90,10 @@ async function bootServer(port: number): Promise<Server> {
     return process.exit(1);
   }
 
-  return app.listen(port, () => {
+  const httpServer = createServer(app);
+  attachSocketServer(httpServer);
+
+  return httpServer.listen(port, () => {
     Logger.success(`API server listening on port ${port}`);
   });
 }

--- a/backend/src/sockets/room-handlers.ts
+++ b/backend/src/sockets/room-handlers.ts
@@ -1,0 +1,289 @@
+import { Socket } from "socket.io";
+import * as UserDAL from "../dal/user";
+import * as Multiplayer from "../utils/multiplayer";
+import Logger from "../utils/logger";
+import { getErrorMessage } from "../utils/error";
+import { RaceConfigSchema } from "@monkeytype/schemas/multiplayer";
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "@monkeytype/schemas/multiplayer-events";
+import { MultiplayerIO } from "../init/socket";
+import { SocketData } from "../init/socket-auth";
+
+export type RoomSocket = Socket<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  Record<string, never>,
+  SocketData
+>;
+
+const COUNTDOWN_SECONDS = 10;
+const RACE_FINISH_TIMEOUT_BUFFER_MS = 60_000;
+const RACE_FINISH_TIMEOUT_MAX_MS = 5 * 60_000;
+
+// per-room, in-memory only: the finish-timeout handle for the room.
+const finishTimeoutByRoom = new Map<string, NodeJS.Timeout>();
+
+async function getDisplayName(uid: string): Promise<string> {
+  try {
+    const user = await UserDAL.getPartialUser(uid, "multiplayer", ["name"]);
+    return user.name;
+  } catch {
+    return "unknown";
+  }
+}
+
+function clearRoomTimers(roomCode: string): void {
+  const timeout = finishTimeoutByRoom.get(roomCode);
+  if (timeout) {
+    clearTimeout(timeout);
+    finishTimeoutByRoom.delete(roomCode);
+  }
+}
+
+async function finishRaceIfDone(
+  io: MultiplayerIO,
+  roomCode: string,
+): Promise<void> {
+  const room = await Multiplayer.getRoom(roomCode);
+  if (room === null || room.status === "finished") {
+    return;
+  }
+
+  if (!Multiplayer.allConnectedPlayersFinished(room)) {
+    return;
+  }
+
+  room.status = "finished";
+  await Multiplayer.saveRoom(room);
+  clearRoomTimers(roomCode);
+  io.to(roomCode).emit("race:results", { players: room.players });
+}
+
+export function registerRoomHandlers(
+  io: MultiplayerIO,
+  socket: RoomSocket,
+): void {
+  const uid = socket.data.uid;
+
+  socket.on("room:join", (payload, ack) => {
+    void (async () => {
+      try {
+        const room = await Multiplayer.getRoom(payload.roomCode);
+        if (room === null) {
+          ack({ status: "error", message: "Room not found" });
+          return;
+        }
+
+        const name = await getDisplayName(uid);
+        const updated = Multiplayer.addPlayer(room, uid, name);
+        await Multiplayer.saveRoom(updated);
+
+        await socket.join(updated.roomCode);
+        socket.data.roomCode = updated.roomCode;
+
+        const player = updated.players.find((it) => it.uid === uid);
+        if (player) {
+          socket.to(updated.roomCode).emit("room:playerJoined", player);
+        }
+
+        ack({ status: "ok", data: updated });
+      } catch (error) {
+        Logger.error(`room:join failed: ${getErrorMessage(error)}`);
+        ack({ status: "error", message: "Failed to join room" });
+      }
+    })();
+  });
+
+  socket.on("room:leave", (payload) => {
+    void handleLeave(io, socket, payload.roomCode);
+  });
+
+  socket.on("disconnect", () => {
+    const roomCode = socket.data.roomCode;
+    if (roomCode !== undefined && roomCode !== "") {
+      void handleLeave(io, socket, roomCode);
+    }
+  });
+
+  socket.on("room:updateConfig", (payload) => {
+    void (async () => {
+      const room = await Multiplayer.getRoom(payload.roomCode);
+      if (room === null || room.hostUid !== uid || room.status !== "lobby") {
+        return;
+      }
+
+      const parsed = RaceConfigSchema.safeParse(payload.config);
+      if (!parsed.success) {
+        socket.emit("room:error", {
+          message: "Invalid race config",
+          code: "invalid_config",
+        });
+        return;
+      }
+
+      room.config = parsed.data;
+      await Multiplayer.saveRoom(room);
+      io.to(room.roomCode).emit("room:state", room);
+    })();
+  });
+
+  socket.on("room:setReady", (payload) => {
+    void (async () => {
+      const room = await Multiplayer.getRoom(payload.roomCode);
+      if (room === null) return;
+
+      const player = room.players.find((it) => it.uid === uid);
+      if (!player) return;
+
+      player.isReady = payload.isReady;
+      await Multiplayer.saveRoom(room);
+      io.to(room.roomCode).emit("room:state", room);
+    })();
+  });
+
+  socket.on("room:rematch", (payload) => {
+    void (async () => {
+      const room = await Multiplayer.getRoom(payload.roomCode);
+      if (room === null || room.hostUid !== uid || room.status !== "finished") {
+        return;
+      }
+
+      room.status = "lobby";
+      room.wordList = null;
+      room.raceStartedAt = null;
+      for (const player of room.players) {
+        player.isReady = false;
+        player.finalResult = null;
+      }
+
+      await Multiplayer.saveRoom(room);
+      io.to(room.roomCode).emit("room:state", room);
+    })();
+  });
+
+  socket.on("room:start", (payload) => {
+    void (async () => {
+      const room = await Multiplayer.getRoom(payload.roomCode);
+      if (room === null || room.hostUid !== uid || room.status !== "lobby") {
+        return;
+      }
+
+      const connectedPlayers = room.players.filter(
+        (player) => player.status === "connected",
+      );
+      const allReady = connectedPlayers.every((player) => player.isReady);
+      if (!allReady || payload.wordList.length === 0) {
+        socket.emit("room:error", {
+          message: "All players must be ready to start",
+          code: "not_ready",
+        });
+        return;
+      }
+
+      room.status = "countdown";
+      room.wordList = payload.wordList;
+      await Multiplayer.saveRoom(room);
+
+      const startsAtServerTime = Date.now() + COUNTDOWN_SECONDS * 1000;
+      io.to(room.roomCode).emit("room:countdown", {
+        startsAtServerTime,
+        wordList: payload.wordList,
+        seconds: COUNTDOWN_SECONDS,
+      });
+
+      setTimeout(() => {
+        void (async () => {
+          const startedRoom = await Multiplayer.getRoom(room.roomCode);
+          if (startedRoom?.status !== "countdown") {
+            return;
+          }
+          startedRoom.status = "racing";
+          startedRoom.raceStartedAt = Date.now();
+          await Multiplayer.saveRoom(startedRoom);
+
+          io.to(room.roomCode).emit("room:raceStarted", {
+            wordList: startedRoom.wordList ?? [],
+            raceStartedAt: startedRoom.raceStartedAt,
+          });
+
+          const finishTimeoutMs = Math.min(
+            startedRoom.config.mode === "time"
+              ? startedRoom.config.time * 1000 * 2
+              : RACE_FINISH_TIMEOUT_BUFFER_MS * 2,
+            RACE_FINISH_TIMEOUT_MAX_MS,
+          );
+          const timeout = setTimeout(() => {
+            void finishRaceIfDone(io, room.roomCode);
+          }, finishTimeoutMs);
+          finishTimeoutByRoom.set(room.roomCode, timeout);
+        })();
+      }, COUNTDOWN_SECONDS * 1000);
+    })();
+  });
+
+  socket.on("race:finish", (payload) => {
+    void (async () => {
+      const room = await Multiplayer.getRoom(payload.roomCode);
+      if (room === null) return;
+
+      const finalResult = {
+        wpm: payload.wpm,
+        rawWpm: payload.rawWpm,
+        acc: payload.acc,
+        consistency: payload.consistency,
+        charStats: payload.charStats,
+        finishedAt: Date.now(),
+      };
+
+      const updated = Multiplayer.recordFinalResult(room, uid, finalResult);
+      await Multiplayer.saveRoom(updated);
+
+      io.to(payload.roomCode).emit("race:playerFinished", {
+        uid,
+        finalResult,
+      });
+
+      await finishRaceIfDone(io, payload.roomCode);
+    })();
+  });
+}
+
+async function handleLeave(
+  io: MultiplayerIO,
+  socket: RoomSocket,
+  roomCode: string,
+): Promise<void> {
+  const uid = socket.data.uid;
+  await socket.leave(roomCode);
+
+  const room = await Multiplayer.getRoom(roomCode);
+  if (room === null) return;
+
+  const updated = Multiplayer.markPlayerStatus(room, uid, "disconnected");
+
+  // host disconnected pre-race: promote the next connected player
+  if (
+    updated.hostUid === uid &&
+    updated.status === "lobby" &&
+    updated.players.some((p) => p.status === "connected" && p.uid !== uid)
+  ) {
+    const newHost = updated.players.find(
+      (p) => p.status === "connected" && p.uid !== uid,
+    );
+    if (newHost) {
+      updated.hostUid = newHost.uid;
+      newHost.isHost = true;
+      const oldHost = updated.players.find((p) => p.uid === uid);
+      if (oldHost) oldHost.isHost = false;
+    }
+  }
+
+  await Multiplayer.saveRoom(updated);
+  io.to(roomCode).emit("room:playerLeft", { uid });
+
+  if (updated.status === "racing") {
+    await finishRaceIfDone(io, roomCode);
+  }
+}

--- a/backend/src/utils/multiplayer.ts
+++ b/backend/src/utils/multiplayer.ts
@@ -1,0 +1,178 @@
+import crypto from "crypto";
+import * as RedisClient from "../init/redis";
+import {
+  RaceConfig,
+  RaceFinalResult,
+  RacePlayer,
+  RaceRoom,
+} from "@monkeytype/schemas/multiplayer";
+
+const NAMESPACE = "monkeytype:multiplayer";
+const ROOM_TTL_SECONDS = 2 * 60 * 60; // 2 hours, while a room is active
+const FINISHED_ROOM_TTL_SECONDS = 10 * 60; // 10 minutes, once a race is over
+const ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // no 0/O/1/I
+const ROOM_CODE_LENGTH = 6;
+const ROOM_CODE_MAX_ATTEMPTS = 10;
+
+function roomKey(roomCode: string): string {
+  return `${NAMESPACE}:room:${roomCode}`;
+}
+
+function userCodesKey(uid: string): string {
+  return `${NAMESPACE}:usercodes:${uid}`;
+}
+
+function generateRoomCode(): string {
+  let code = "";
+  for (let i = 0; i < ROOM_CODE_LENGTH; i++) {
+    code += ROOM_CODE_ALPHABET[crypto.randomInt(ROOM_CODE_ALPHABET.length)];
+  }
+  return code;
+}
+
+async function reserveUniqueRoomCode(): Promise<string> {
+  const connection = RedisClient.getConnection();
+  if (!connection) {
+    throw new Error("Redis connection not available");
+  }
+
+  for (let attempt = 0; attempt < ROOM_CODE_MAX_ATTEMPTS; attempt++) {
+    const code = generateRoomCode();
+    // "reserve" the key with a placeholder value; the caller overwrites it
+    // with the real room JSON immediately after. NX makes the check + claim atomic.
+    const reserved = await connection.set(
+      roomKey(code),
+      "",
+      "EX",
+      ROOM_TTL_SECONDS,
+      "NX",
+    );
+    if (reserved === "OK") {
+      return code;
+    }
+  }
+
+  throw new Error("Failed to generate a unique room code");
+}
+
+export async function createRoom(
+  hostUid: string,
+  hostName: string,
+  config: RaceConfig,
+): Promise<RaceRoom> {
+  const roomCode = await reserveUniqueRoomCode();
+
+  const room: RaceRoom = {
+    roomCode,
+    hostUid,
+    status: "lobby",
+    config,
+    wordList: null,
+    players: [
+      {
+        uid: hostUid,
+        name: hostName,
+        isHost: true,
+        isReady: false,
+        status: "connected",
+        finalResult: null,
+      },
+    ],
+    createdAt: Date.now(),
+    raceStartedAt: null,
+  };
+
+  await saveRoom(room);
+  await addUserRoomCode(hostUid, roomCode);
+
+  return room;
+}
+
+export async function getRoom(roomCode: string): Promise<RaceRoom | null> {
+  const connection = RedisClient.getConnection();
+  if (!connection) {
+    return null;
+  }
+
+  const raw = await connection.get(roomKey(roomCode));
+  if (raw === null || raw === "") {
+    return null;
+  }
+
+  return JSON.parse(raw) as RaceRoom;
+}
+
+export async function saveRoom(room: RaceRoom): Promise<void> {
+  const connection = RedisClient.getConnection();
+  if (!connection) {
+    throw new Error("Redis connection not available");
+  }
+
+  const ttl =
+    room.status === "finished" ? FINISHED_ROOM_TTL_SECONDS : ROOM_TTL_SECONDS;
+
+  await connection.set(roomKey(room.roomCode), JSON.stringify(room), "EX", ttl);
+}
+
+async function addUserRoomCode(uid: string, roomCode: string): Promise<void> {
+  const connection = RedisClient.getConnection();
+  if (!connection) {
+    return;
+  }
+
+  await connection.sadd(userCodesKey(uid), roomCode);
+  await connection.expire(userCodesKey(uid), ROOM_TTL_SECONDS);
+}
+
+export function addPlayer(room: RaceRoom, uid: string, name: string): RaceRoom {
+  const existing = room.players.find((player) => player.uid === uid);
+  if (existing) {
+    existing.status = "connected";
+    return room;
+  }
+
+  room.players.push({
+    uid,
+    name,
+    isHost: false,
+    isReady: false,
+    status: "connected",
+    finalResult: null,
+  });
+
+  return room;
+}
+
+export function markPlayerStatus(
+  room: RaceRoom,
+  uid: string,
+  status: RacePlayer["status"],
+): RaceRoom {
+  const player = room.players.find((it) => it.uid === uid);
+  if (player) {
+    player.status = status;
+  }
+  return room;
+}
+
+export function recordFinalResult(
+  room: RaceRoom,
+  uid: string,
+  result: RaceFinalResult,
+): RaceRoom {
+  const player = room.players.find((it) => it.uid === uid);
+  if (player) {
+    player.finalResult = result;
+  }
+  return room;
+}
+
+export function allConnectedPlayersFinished(room: RaceRoom): boolean {
+  const relevantPlayers = room.players.filter(
+    (player) => player.status === "connected",
+  );
+  if (relevantPlayers.length === 0) {
+    return true;
+  }
+  return relevantPlayers.every((player) => player.finalResult !== null);
+}

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -4,7 +4,7 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
-        "source": "/@(test|settings|account|about|login|profile|friends|account-settings|leaderboards){,/**}",
+        "source": "/@(test|settings|account|about|login|profile|friends|account-settings|leaderboards|multiplayer){,/**}",
         "destination": "/index.html"
       },
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "modern-screenshot": "4.6.8",
     "object-hash": "3.0.0",
     "slim-select": "2.9.2",
+    "socket.io-client": "4.8.3",
     "stemmer": "2.0.1",
     "tailwind-merge": "3.6.0",
     "throttle-debounce": "5.0.2",

--- a/frontend/src/html/pages/test.html
+++ b/frontend/src/html/pages/test.html
@@ -41,6 +41,7 @@
         spellcheck="false"
       ></textarea>
       <mount data-component="outoffocuswarning" class="contents"></mount>
+      <mount data-component="racecountdownoverlay" class="contents"></mount>
       <div id="paceCaret" class="full-width default hidden"></div>
       <div id="caret" class="full-width default"></div>
       <div id="words" class="full-width"></div>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -68,6 +68,10 @@
         <div class="page pageLeaderboards hidden" id="pageLeaderboards">
           <mount data-component="leaderboardpage"></mount>
         </div>
+
+        <div class="page pageMultiplayer hidden" id="pageMultiplayer">
+          <mount data-component="multiplayerpage"></mount>
+        </div>
       </main>
       <mount data-component="footer"></mount>
       <div

--- a/frontend/src/ts/components/layout/header/Nav.tsx
+++ b/frontend/src/ts/components/layout/header/Nav.tsx
@@ -16,7 +16,7 @@ import {
   prefetchLeaderboardPage,
 } from "../../../queries/prefetch";
 import { getServerConfigurationQueryOptions } from "../../../queries/server-configuration";
-import { getActivePage } from "../../../states/core";
+import { getActivePage, isAuthenticated } from "../../../states/core";
 import {
   getAccountButtonSpinner,
   getAnimatedLevel,
@@ -113,6 +113,21 @@ export function Nav(): JSXElement {
           prefetchLeaderboardPage();
         }}
       />
+      <Show when={isAuthenticated()}>
+        <Button
+          variant="text"
+          fa={{
+            icon: "fa-bolt",
+            fixedWidth: true,
+          }}
+          router-link
+          dataset={{
+            "data-nav-item": "multiplayer",
+          }}
+          class={buttonClass()}
+          href="/multiplayer"
+        />
+      </Show>
       <Button
         variant="text"
         fa={{

--- a/frontend/src/ts/components/mount.tsx
+++ b/frontend/src/ts/components/mount.tsx
@@ -19,6 +19,8 @@ import { MyProfile } from "./pages/account/MyProfile";
 import { FriendsPage } from "./pages/connections/FriendsPage";
 import { LeaderboardPage } from "./pages/leaderboard/LeaderboardPage";
 import { LoginPage } from "./pages/login/LoginPage";
+import { MultiplayerPage } from "./pages/multiplayer/MultiplayerPage";
+import { RaceCountdownOverlay } from "./pages/multiplayer/RaceCountdownOverlay";
 import { ProfilePage } from "./pages/profile/ProfilePage";
 import { ProfileSearchPage } from "./pages/profile/ProfileSearchPage";
 import { SettingsPage } from "./pages/settings/SettingsPage";
@@ -58,6 +60,8 @@ const components: Record<string, () => JSXElement> = {
   capswarning: () => <CapsWarning />,
   compositiondisplay: () => <CompositionDisplay />,
   friendspage: () => <FriendsPage />,
+  multiplayerpage: () => <MultiplayerPage />,
+  racecountdownoverlay: () => <RaceCountdownOverlay />,
   notfoundpage: () => <NotFoundPage />,
   accountsettingspage: () => <AccountSettingsPage />,
   keymap: () => <Keymap />,

--- a/frontend/src/ts/components/pages/multiplayer/CreateOrJoinRoom.tsx
+++ b/frontend/src/ts/components/pages/multiplayer/CreateOrJoinRoom.tsx
@@ -1,0 +1,92 @@
+import type { RaceConfig } from "@monkeytype/schemas/multiplayer";
+
+import { useQuery } from "@tanstack/solid-query";
+import { createSignal, Show } from "solid-js";
+
+import { navigate } from "../../../controllers/route-controller";
+import { createAndJoinRoom } from "../../../multiplayer/actions";
+import { getFriendsListQuery } from "../../../queries/friends";
+import { showErrorNotification } from "../../../states/notifications";
+import { Button } from "../../common/Button";
+import { H2, H3 } from "../../common/Headers";
+
+const DEFAULT_RACE_CONFIG: RaceConfig = {
+  mode: "words",
+  words: 25,
+  time: 30,
+  language: "english",
+  punctuation: false,
+  numbers: false,
+  difficulty: "normal",
+};
+
+export function CreateOrJoinRoom() {
+  const [joinCode, setJoinCode] = createSignal("");
+  const [isCreating, setIsCreating] = createSignal(false);
+
+  const friendsQuery = useQuery(() => getFriendsListQuery());
+
+  const create = async (): Promise<void> => {
+    setIsCreating(true);
+    try {
+      await createAndJoinRoom(DEFAULT_RACE_CONFIG);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const join = async (): Promise<void> => {
+    const code = joinCode().trim().toUpperCase();
+    if (code.length === 0) {
+      showErrorNotification("Enter a room code");
+      return;
+    }
+    await navigate(`/multiplayer/${code}`);
+  };
+
+  return (
+    <div class="content-grid grid gap-8">
+      <div>
+        <H2 text="Multiplayer" fa={{ icon: "fa-bolt", fixedWidth: true }} />
+        <div class="flex flex-wrap gap-4">
+          <Button
+            text="Create a room"
+            fa={{ icon: "fa-plus", fixedWidth: true }}
+            onClick={() => void create()}
+            disabled={isCreating()}
+          />
+          <div class="flex items-center gap-2">
+            <input
+              class="rounded bg-sub-alt p-[0.5em] text-text"
+              placeholder="room code"
+              value={joinCode()}
+              maxLength={6}
+              onInput={(e) => setJoinCode(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void join();
+              }}
+            />
+            <Button
+              text="Join"
+              fa={{ icon: "fa-sign-in-alt", fixedWidth: true }}
+              onClick={() => void join()}
+            />
+          </div>
+        </div>
+      </div>
+
+      <Show when={(friendsQuery.data?.length ?? 0) > 0}>
+        <div>
+          <H3
+            text="Racing tip"
+            fa={{ icon: "fa-user-friends", fixedWidth: true }}
+          />
+          <div class="text-sub">
+            Create a room, then share the room code or link with your friends
+            from the friends list to invite them to race.
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/ts/components/pages/multiplayer/MultiplayerPage.tsx
+++ b/frontend/src/ts/components/pages/multiplayer/MultiplayerPage.tsx
@@ -1,0 +1,24 @@
+import { Show } from "solid-js";
+
+import { getRoom, getRaceResults } from "../../../states/multiplayer";
+import { Page } from "../../common/Page";
+import { CreateOrJoinRoom } from "./CreateOrJoinRoom";
+import { RaceResultsPage } from "./RaceResultsPage";
+import { RoomLobby } from "./RoomLobby";
+
+export function MultiplayerPage() {
+  return (
+    <Page id="multiplayer" needsAuthentication>
+      <Show
+        when={getRaceResults() !== null}
+        fallback={
+          <Show when={getRoom() !== null} fallback={<CreateOrJoinRoom />}>
+            <RoomLobby />
+          </Show>
+        }
+      >
+        <RaceResultsPage />
+      </Show>
+    </Page>
+  );
+}

--- a/frontend/src/ts/components/pages/multiplayer/RaceCountdownOverlay.tsx
+++ b/frontend/src/ts/components/pages/multiplayer/RaceCountdownOverlay.tsx
@@ -1,0 +1,34 @@
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+
+import { getRaceCountdown } from "../../../states/multiplayer";
+
+export function RaceCountdownOverlay() {
+  const [secondsLeft, setSecondsLeft] = createSignal<number | null>(null);
+
+  createEffect(() => {
+    const countdown = getRaceCountdown();
+    if (countdown === null) {
+      setSecondsLeft(null);
+      return;
+    }
+
+    const tick = (): void => {
+      const remainingMs = countdown.startsAtServerTime - Date.now();
+      setSecondsLeft(Math.max(0, Math.ceil(remainingMs / 1000)));
+    };
+    tick();
+
+    const interval = setInterval(tick, 100);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  return (
+    <Show when={getRaceCountdown() !== null}>
+      <div class="pointer-events-none absolute z-999 flex h-full w-full place-content-center items-center gap-2 text-center select-none">
+        <div class="text-[4em] font-bold text-main">
+          {secondsLeft() === 0 ? "go!" : secondsLeft()}
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/frontend/src/ts/components/pages/multiplayer/RaceResultsPage.tsx
+++ b/frontend/src/ts/components/pages/multiplayer/RaceResultsPage.tsx
@@ -1,0 +1,68 @@
+import { createMemo, For, Show } from "solid-js";
+
+import { getAuthenticatedUser } from "../../../firebase";
+import { rematch, leaveCurrentRoom } from "../../../multiplayer/actions";
+import { getRoom, getRaceResults } from "../../../states/multiplayer";
+import { Button } from "../../common/Button";
+import { H2 } from "../../common/Headers";
+
+export function RaceResultsPage() {
+  const myUid = () => getAuthenticatedUser()?.uid;
+  const isHost = () => getRoom()?.hostUid === myUid();
+
+  const ranked = createMemo(() =>
+    [...(getRaceResults() ?? [])].sort((a, b) => {
+      if (a.finalResult === null) return 1;
+      if (b.finalResult === null) return -1;
+      return b.finalResult.wpm - a.finalResult.wpm;
+    }),
+  );
+
+  return (
+    <div class="content-grid grid gap-8">
+      <H2
+        text="Race results"
+        fa={{ icon: "fa-flag-checkered", fixedWidth: true }}
+      />
+
+      <div class="grid gap-2">
+        <For each={ranked()}>
+          {(player, index) => (
+            <div class="flex items-center gap-4 rounded bg-sub-alt p-[0.5em]">
+              <span class="w-6 text-center text-sub">#{index() + 1}</span>
+              <span class="flex-1">{player.name}</span>
+              <Show
+                when={player.finalResult}
+                fallback={<span class="text-sub">did not finish</span>}
+              >
+                {(finalResult) => (
+                  <>
+                    <span>{Math.round(finalResult().wpm)} wpm</span>
+                    <span class="text-sub">
+                      {Math.round(finalResult().acc)}% acc
+                    </span>
+                  </>
+                )}
+              </Show>
+            </div>
+          )}
+        </For>
+      </div>
+
+      <div class="flex gap-4">
+        <Show when={isHost()}>
+          <Button
+            text="Play again"
+            fa={{ icon: "fa-redo-alt", fixedWidth: true }}
+            onClick={() => rematch()}
+          />
+        </Show>
+        <Button
+          text="Leave room"
+          fa={{ icon: "fa-door-open", fixedWidth: true }}
+          onClick={() => leaveCurrentRoom()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ts/components/pages/multiplayer/RoomLobby.tsx
+++ b/frontend/src/ts/components/pages/multiplayer/RoomLobby.tsx
@@ -1,0 +1,210 @@
+import type { RaceConfig } from "@monkeytype/schemas/multiplayer";
+
+import { useQuery } from "@tanstack/solid-query";
+import { createMemo, For, Show } from "solid-js";
+
+import { getAuthenticatedUser } from "../../../firebase";
+import {
+  setReady,
+  updateRaceConfig,
+  startRace,
+  leaveCurrentRoom,
+} from "../../../multiplayer/actions";
+import { getFriendsListQuery } from "../../../queries/friends";
+import { getRoom } from "../../../states/multiplayer";
+import {
+  showSuccessNotification,
+  showErrorNotification,
+} from "../../../states/notifications";
+import { Button } from "../../common/Button";
+import { H2, H3 } from "../../common/Headers";
+
+export function RoomLobby() {
+  const room = createMemo(() => getRoom());
+  const myUid = () => getAuthenticatedUser()?.uid;
+  const isHost = () => room()?.hostUid === myUid();
+  const me = () => room()?.players.find((player) => player.uid === myUid());
+
+  const friendsQuery = useQuery(() => getFriendsListQuery());
+
+  const shareLink = (): string =>
+    `${window.location.origin}/multiplayer/${room()?.roomCode ?? ""}`;
+
+  const copyLink = async (): Promise<void> => {
+    await navigator.clipboard.writeText(shareLink());
+    showSuccessNotification("Room link copied to clipboard", {
+      durationMs: 2000,
+    });
+  };
+
+  const connectedPlayers = createMemo(
+    () =>
+      room()?.players.filter((player) => player.status === "connected") ?? [],
+  );
+  const allReady = createMemo(
+    () =>
+      connectedPlayers().length > 0 &&
+      connectedPlayers().every((player) => player.isReady),
+  );
+
+  const setConfigField = <K extends keyof RaceConfig>(
+    key: K,
+    value: RaceConfig[K],
+  ): void => {
+    const current = room()?.config;
+    if (current === undefined) return;
+    updateRaceConfig({ ...current, [key]: value });
+  };
+
+  return (
+    <div class="content-grid grid gap-8">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <H2
+          text={`Room ${room()?.roomCode ?? ""}`}
+          fa={{ icon: "fa-bolt", fixedWidth: true }}
+        />
+        <div class="flex gap-2">
+          <Button
+            text="Copy invite link"
+            fa={{ icon: "fa-link", fixedWidth: true }}
+            onClick={() => void copyLink()}
+          />
+          <Button
+            text="Leave room"
+            fa={{ icon: "fa-door-open", fixedWidth: true }}
+            danger
+            onClick={() => leaveCurrentRoom()}
+          />
+        </div>
+      </div>
+
+      <div>
+        <H3 text="Players" fa={{ icon: "fa-users", fixedWidth: true }} />
+        <div class="grid gap-2">
+          <For each={room()?.players ?? []}>
+            {(player) => (
+              <div class="flex items-center gap-2 rounded bg-sub-alt p-[0.5em]">
+                <span class="flex-1">
+                  {player.name}
+                  <Show when={player.isHost}> (host)</Show>
+                  <Show when={player.status === "disconnected"}>
+                    {" "}
+                    (disconnected)
+                  </Show>
+                </span>
+                <span class={player.isReady ? "text-main" : "text-sub"}>
+                  {player.isReady ? "ready" : "not ready"}
+                </span>
+              </div>
+            )}
+          </For>
+        </div>
+      </div>
+
+      <Show when={isHost()}>
+        <div>
+          <H3 text="Race settings" fa={{ icon: "fa-cog", fixedWidth: true }} />
+          <div class="flex flex-wrap items-center gap-4">
+            <Button
+              text="words"
+              active={room()?.config.mode === "words"}
+              onClick={() => setConfigField("mode", "words")}
+            />
+            <Button
+              text="time"
+              active={room()?.config.mode === "time"}
+              onClick={() => setConfigField("mode", "time")}
+            />
+            <Show when={room()?.config.mode === "words"}>
+              <input
+                type="number"
+                class="w-20 rounded bg-sub-alt p-[0.5em] text-text"
+                value={room()?.config.words ?? 25}
+                min={10}
+                max={200}
+                onChange={(e) =>
+                  setConfigField("words", Number(e.currentTarget.value))
+                }
+              />
+            </Show>
+            <Show when={room()?.config.mode === "time"}>
+              <input
+                type="number"
+                class="w-20 rounded bg-sub-alt p-[0.5em] text-text"
+                value={room()?.config.time ?? 30}
+                min={15}
+                max={300}
+                onChange={(e) =>
+                  setConfigField("time", Number(e.currentTarget.value))
+                }
+              />
+            </Show>
+            <label class="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={room()?.config.punctuation ?? false}
+                onChange={(e) =>
+                  setConfigField("punctuation", e.currentTarget.checked)
+                }
+              />
+              punctuation
+            </label>
+            <label class="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={room()?.config.numbers ?? false}
+                onChange={(e) =>
+                  setConfigField("numbers", e.currentTarget.checked)
+                }
+              />
+              numbers
+            </label>
+          </div>
+        </div>
+      </Show>
+
+      <div class="flex flex-wrap gap-4">
+        <Button
+          text={me()?.isReady ? "not ready" : "ready"}
+          fa={{ icon: "fa-check", fixedWidth: true }}
+          onClick={() => setReady(!(me()?.isReady ?? false))}
+        />
+        <Show when={isHost()}>
+          <Button
+            text="Start race"
+            fa={{ icon: "fa-play", fixedWidth: true }}
+            disabled={!allReady()}
+            onClick={() => {
+              void startRace().catch(() =>
+                showErrorNotification("Failed to start race"),
+              );
+            }}
+          />
+        </Show>
+      </div>
+
+      <Show when={(friendsQuery.data?.length ?? 0) > 0}>
+        <div>
+          <H3
+            text="Invite friends"
+            fa={{ icon: "fa-user-friends", fixedWidth: true }}
+          />
+          <div class="grid gap-2">
+            <For each={friendsQuery.data ?? []}>
+              {(friend) => (
+                <div class="flex items-center gap-2 rounded bg-sub-alt p-[0.5em]">
+                  <span class="flex-1">{friend.name}</span>
+                  <Button
+                    text="copy link"
+                    fa={{ icon: "fa-link", fixedWidth: true }}
+                    onClick={() => void copyLink()}
+                  />
+                </div>
+              )}
+            </For>
+          </div>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/frontend/src/ts/controllers/page-controller.ts
+++ b/frontend/src/ts/controllers/page-controller.ts
@@ -37,6 +37,7 @@ import {
   AccountSettingsUrlParamsSchema,
   readAccountSettingsGetParameters,
 } from "../states/account-settings";
+import * as MultiplayerActions from "../multiplayer/actions";
 
 type ChangeOptions = {
   force?: boolean;
@@ -132,6 +133,18 @@ const pages = {
           text: "Downloading friend requests...",
         },
       ],
+    },
+  }),
+  multiplayer: solidPage("multiplayer", {
+    beforeShow: async (options) => {
+      const roomCode = options.params?.["roomCode"];
+      if (roomCode !== undefined && roomCode !== "") {
+        try {
+          await MultiplayerActions.joinRoomByCode(roomCode);
+        } catch {
+          // error notification already shown by joinRoomByCode
+        }
+      }
     },
   }),
   accountSettings: solidPage("accountSettings", {

--- a/frontend/src/ts/controllers/route-controller.ts
+++ b/frontend/src/ts/controllers/route-controller.ts
@@ -155,6 +155,43 @@ const routes: Route[] = [
       await PageController.change("friends", options);
     },
   },
+  {
+    path: "/multiplayer",
+    load: async (_params, options) => {
+      if (!isAuthAvailable()) {
+        await navigate("/", options);
+        return;
+      }
+      if (!isAuthenticated()) {
+        await navigate("/login", options);
+        return;
+      }
+
+      await PageController.change("multiplayer", options);
+    },
+  },
+  {
+    path: "/multiplayer/:roomCode",
+    load: async (params, options) => {
+      if (!isAuthAvailable()) {
+        await navigate("/", options);
+        return;
+      }
+      if (!isAuthenticated()) {
+        await navigate("/login", options);
+        return;
+      }
+
+      await PageController.change("multiplayer", {
+        ...options,
+        force: true,
+        params: {
+          roomCode: params["roomCode"] as string,
+        },
+        data: options.data,
+      });
+    },
+  },
 ];
 
 export async function navigate(

--- a/frontend/src/ts/input/handlers/before-insert-text.ts
+++ b/frontend/src/ts/input/handlers/before-insert-text.ts
@@ -15,6 +15,7 @@ import { shouldGoToNextWord } from "../helpers/validation";
 import { getCommitCharacterType, normalizeData } from "../helpers/util";
 import { getCurrentInput } from "../../test/events/data";
 import { isSpace } from "../../utils/strings";
+import { getRaceCountdown } from "../../states/multiplayer";
 
 /**
  * Handles logic before inserting text into the input element.
@@ -22,6 +23,12 @@ import { isSpace } from "../../utils/strings";
  * @returns Whether to prevent the default insertion behavior.
  */
 export function onBeforeInsertText(data: string): boolean {
+  // multiplayer race hasn't started yet: words are visible (blurred) but
+  // typing shouldn't count, or start the timer, until the synchronized "go"
+  if (getRaceCountdown() !== null) {
+    return true;
+  }
+
   if (isTestRestarting()) {
     return true;
   }

--- a/frontend/src/ts/input/listeners/composition.ts
+++ b/frontend/src/ts/input/listeners/composition.ts
@@ -11,6 +11,7 @@ import {
   isTestActive,
   setCompositionText,
 } from "../../states/test";
+import { getRaceCountdown } from "../../states/multiplayer";
 
 const inputEl = getInputElement();
 
@@ -22,7 +23,13 @@ inputEl.addEventListener("compositionstart", (event) => {
 
   const now = performance.now();
 
-  if (isTestRestarting() || isResultCalculating()) return;
+  if (
+    isTestRestarting() ||
+    isResultCalculating() ||
+    getRaceCountdown() !== null
+  ) {
+    return;
+  }
   CompositionState.setComposing(true);
   CompositionState.setData("");
   setLastInsertCompositionTextData("");
@@ -42,7 +49,13 @@ inputEl.addEventListener("compositionupdate", (event) => {
     data: event.data,
   });
 
-  if (isTestRestarting() || isResultCalculating()) return;
+  if (
+    isTestRestarting() ||
+    isResultCalculating() ||
+    getRaceCountdown() !== null
+  ) {
+    return;
+  }
   CompositionState.setData(event.data);
   setCompositionText(event.data);
 
@@ -58,7 +71,13 @@ inputEl.addEventListener("compositionupdate", (event) => {
 inputEl.addEventListener("compositionend", async (event) => {
   console.debug("wordsInput event compositionend", { event, data: event.data });
 
-  if (isTestRestarting() || isResultCalculating()) return;
+  if (
+    isTestRestarting() ||
+    isResultCalculating() ||
+    getRaceCountdown() !== null
+  ) {
+    return;
+  }
   CompositionState.setComposing(false);
   CompositionState.setData("");
   setCompositionText("");

--- a/frontend/src/ts/multiplayer/actions.ts
+++ b/frontend/src/ts/multiplayer/actions.ts
@@ -1,0 +1,164 @@
+import Ape from "../ape";
+import * as TestLogic from "../test/test-logic";
+import * as WordsGenerator from "../test/words-generator";
+import * as JSONData from "../utils/json-data";
+import { setConfig } from "../config/setters";
+import { navigationEvent } from "../events/navigation";
+import { showErrorNotification } from "../states/notifications";
+import { connect as connectSocket, getSocket } from "./socket-client";
+import {
+  getRoom,
+  setRoom,
+  setRoomError,
+  initMultiplayerListeners,
+  leaveRoom,
+} from "../states/multiplayer";
+import type { RaceConfig } from "@monkeytype/schemas/multiplayer";
+
+let raceListenersRegistered = false;
+
+export async function ensureConnected(): Promise<void> {
+  await connectSocket();
+  initMultiplayerListeners();
+  registerRaceListeners();
+}
+
+function registerRaceListeners(): void {
+  if (raceListenersRegistered) return;
+  raceListenersRegistered = true;
+
+  // As soon as the countdown starts (well before "go"), jump to the test
+  // page and load the race words there. The words render blurred with a
+  // countdown overlay on top (RaceCountdownOverlay.tsx / test-ui.ts) so
+  // players can see the game but not read ahead or type early.
+  getSocket().on("room:countdown", () => {
+    void (async () => {
+      applyRaceConfigToLocalConfig();
+      navigationEvent.dispatch({ url: "/", options: { force: true } });
+      await TestLogic.restart({ noAnim: true, isRaceStart: true });
+    })();
+  });
+
+  // "go": force every player's timer to start at the exact same instant
+  // instead of waiting for each one's own first keystroke, which is what
+  // normally starts a test but would let players drift out of sync here.
+  getSocket().on("room:raceStarted", () => {
+    TestLogic.startTest(performance.now());
+  });
+}
+
+function applyRaceConfigToLocalConfig(): void {
+  const room = getRoom();
+  if (room === null) return;
+  const { config } = room;
+
+  setConfig("mode", config.mode);
+  if (config.mode === "words") {
+    setConfig("words", config.words);
+  } else {
+    setConfig("time", config.time);
+  }
+  setConfig("language", config.language);
+  setConfig("punctuation", config.punctuation);
+  setConfig("numbers", config.numbers);
+  setConfig("difficulty", config.difficulty);
+  // funbox isn't supported in race mode configs, but a funbox left active
+  // from a previous solo session could still alter word selection and
+  // desync players, so make sure it's off for the duration of the race
+  setConfig("funbox", []);
+}
+
+export async function createAndJoinRoom(config: RaceConfig): Promise<void> {
+  await ensureConnected();
+
+  const response = await Ape.multiplayer.createRoom({ body: { config } });
+  if (response.status !== 200) {
+    showErrorNotification(response.body.message);
+    return;
+  }
+
+  await joinRoomByCode(response.body.data.roomCode);
+  navigationEvent.dispatch({
+    url: `/multiplayer/${response.body.data.roomCode}`,
+    options: {},
+  });
+}
+
+export async function joinRoomByCode(roomCode: string): Promise<void> {
+  await ensureConnected();
+
+  return new Promise((resolve, reject) => {
+    getSocket().emit("room:join", { roomCode }, (ack) => {
+      if (ack.status === "ok") {
+        setRoom(ack.data);
+        resolve();
+      } else {
+        setRoomError(ack.message);
+        showErrorNotification(ack.message);
+        reject(new Error(ack.message));
+      }
+    });
+  });
+}
+
+export function setReady(isReady: boolean): void {
+  const room = getRoom();
+  if (room === null) return;
+  getSocket().emit("room:setReady", { roomCode: room.roomCode, isReady });
+}
+
+export function updateRaceConfig(config: RaceConfig): void {
+  const room = getRoom();
+  if (room === null) return;
+  getSocket().emit("room:updateConfig", { roomCode: room.roomCode, config });
+}
+
+// Generous WPM ceiling used to size the word pool for "time" mode races, so
+// a fast typist doesn't visibly exhaust it and wrap back to the start.
+const TIME_MODE_WORDS_PER_SECOND_CEILING = 6;
+
+export async function startRace(): Promise<void> {
+  const room = getRoom();
+  if (room === null) return;
+
+  applyRaceConfigToLocalConfig();
+
+  const { config } = room;
+  const targetWordCount =
+    config.mode === "words"
+      ? config.words
+      : config.time * TIME_MODE_WORDS_PER_SECOND_CEILING;
+
+  const language = await JSONData.getLanguage(config.language);
+
+  // generateWords() caps each call at 100 words regardless of how many were
+  // asked for, so batch multiple calls together for longer races
+  const words: string[] = [];
+  while (words.length < targetWordCount) {
+    const generated = await WordsGenerator.generateWords(language);
+    if (generated.words.length === 0) break;
+    words.push(...generated.words);
+  }
+
+  const wordList =
+    config.mode === "words" ? words.slice(0, targetWordCount) : words;
+
+  getSocket().emit("room:start", {
+    roomCode: room.roomCode,
+    wordList,
+  });
+}
+
+export function rematch(): void {
+  const room = getRoom();
+  if (room === null) return;
+  getSocket().emit("room:rematch", { roomCode: room.roomCode });
+}
+
+export function leaveCurrentRoom(): void {
+  const room = getRoom();
+  if (room !== null) {
+    getSocket().emit("room:leave", { roomCode: room.roomCode });
+  }
+  leaveRoom();
+}

--- a/frontend/src/ts/multiplayer/socket-client.ts
+++ b/frontend/src/ts/multiplayer/socket-client.ts
@@ -1,0 +1,41 @@
+import { io, Socket } from "socket.io-client";
+import { envConfig } from "virtual:env-config";
+import { getIdToken } from "../firebase";
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "@monkeytype/schemas/multiplayer-events";
+
+type MultiplayerSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+let socket: MultiplayerSocket | null = null;
+
+export async function connect(): Promise<MultiplayerSocket> {
+  if (socket !== null) {
+    return socket;
+  }
+
+  socket = io(envConfig.backendUrl, {
+    autoConnect: true,
+    // function form: re-invoked on every (re)connection attempt, so a
+    // refreshed Firebase token is always used instead of a stale one.
+    auth: async (cb) => {
+      const token = await getIdToken();
+      cb({ token: token ?? "" });
+    },
+  });
+
+  return socket;
+}
+
+export function getSocket(): MultiplayerSocket {
+  if (socket === null) {
+    throw new Error("Multiplayer socket is not connected");
+  }
+  return socket;
+}
+
+export function disconnect(): void {
+  socket?.disconnect();
+  socket = null;
+}

--- a/frontend/src/ts/pages/page.ts
+++ b/frontend/src/ts/pages/page.ts
@@ -17,7 +17,8 @@ export type PageName =
   | "404"
   | "accountSettings"
   | "leaderboards"
-  | "friends";
+  | "friends"
+  | "multiplayer";
 
 type Options<T> = {
   params?: Record<string, string>;

--- a/frontend/src/ts/states/multiplayer.ts
+++ b/frontend/src/ts/states/multiplayer.ts
@@ -1,0 +1,119 @@
+import { createSignal } from "solid-js";
+import type { RaceRoom, RacePlayer } from "@monkeytype/schemas/multiplayer";
+import type { ServerToClientEvents } from "@monkeytype/schemas/multiplayer-events";
+import { getSocket } from "../multiplayer/socket-client";
+import { navigationEvent } from "../events/navigation";
+
+export const [getRoom, setRoom] = createSignal<RaceRoom | null>(null);
+export const [isRaceModeActive, setRaceModeActive] = createSignal(false);
+export const [getRaceWordList, setRaceWordList] = createSignal<string[] | null>(
+  null,
+);
+export const [getRaceCountdown, setRaceCountdown] = createSignal<{
+  startsAtServerTime: number;
+  seconds: number;
+  wordList: string[];
+} | null>(null);
+export const [getRaceResults, setRaceResults] = createSignal<
+  RacePlayer[] | null
+>(null);
+export const [getRoomError, setRoomError] = createSignal<string | null>(null);
+
+export function resetRaceState(): void {
+  setRaceModeActive(false);
+  setRaceWordList(null);
+  setRaceCountdown(null);
+  setRaceResults(null);
+}
+
+export function leaveRoom(): void {
+  setRoom(null);
+  resetRaceState();
+}
+
+let listenersInitialized = false;
+
+export function initMultiplayerListeners(): void {
+  if (listenersInitialized) return;
+  listenersInitialized = true;
+
+  const socket = getSocket();
+
+  const on = <K extends keyof ServerToClientEvents>(
+    event: K,
+    handler: ServerToClientEvents[K],
+  ): void => {
+    socket.on(event, handler as never);
+  };
+
+  on("room:state", (room) => {
+    setRoom(room);
+    if (room.status === "lobby") {
+      setRaceResults(null);
+    }
+  });
+
+  on("room:playerJoined", (player) => {
+    setRoom((room) => {
+      if (room === null) return room;
+      const players = room.players.filter((it) => it.uid !== player.uid);
+      return { ...room, players: [...players, player] };
+    });
+  });
+
+  on("room:playerLeft", ({ uid }) => {
+    setRoom((room) => {
+      if (room === null) return room;
+      return {
+        ...room,
+        players: room.players.map((player) =>
+          player.uid === uid ? { ...player, status: "disconnected" } : player,
+        ),
+      };
+    });
+  });
+
+  on("room:countdown", (payload) => {
+    setRaceCountdown(payload);
+    // set the word list and flip race mode on as soon as the countdown
+    // starts (not when it ends), so every client can navigate to the test
+    // page, warm up language data, and generate the (blurred) test words
+    // ahead of the actual "go" moment
+    setRaceWordList(payload.wordList);
+    setRaceModeActive(true);
+  });
+
+  on("room:raceStarted", () => {
+    // clears the countdown overlay/blur; race mode itself stays active
+    setRaceCountdown(null);
+  });
+
+  on("race:playerFinished", ({ uid, finalResult }) => {
+    setRoom((room) => {
+      if (room === null) return room;
+      return {
+        ...room,
+        players: room.players.map((player) =>
+          player.uid === uid ? { ...player, finalResult } : player,
+        ),
+      };
+    });
+  });
+
+  on("race:results", ({ players }) => {
+    setRaceResults(players);
+    setRaceModeActive(false);
+
+    const roomCode = getRoom()?.roomCode;
+    if (roomCode !== undefined) {
+      navigationEvent.dispatch({
+        url: `/multiplayer/${roomCode}`,
+        options: { force: true },
+      });
+    }
+  });
+
+  on("room:error", ({ message }) => {
+    setRoomError(message);
+  });
+}

--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -61,6 +61,12 @@ import {
   getResultVisible,
 } from "../states/test";
 import { restartTestEvent } from "../events/test";
+import {
+  isRaceModeActive,
+  setRaceModeActive,
+  getRoom,
+} from "../states/multiplayer";
+import { getSocket } from "../multiplayer/socket-client";
 import * as TestWords from "./test-words";
 import * as WordsGenerator from "./words-generator";
 import * as PageTransition from "../legacy-states/page-transition";
@@ -171,6 +177,9 @@ type RestartOptions = {
   practiseMissed?: boolean;
   noAnim?: boolean;
   isQuickRestart?: boolean;
+  /** internal: set only by the multiplayer race-start trigger itself, so the
+   * mid-race restart guard below doesn't also block the legitimate one */
+  isRaceStart?: boolean;
 };
 
 export async function restart(options = {} as RestartOptions): Promise<void> {
@@ -190,6 +199,17 @@ export async function restart(options = {} as RestartOptions): Promise<void> {
   if (isTestActive() && noQuit) {
     showNoticeNotification(
       "No quit funbox is active. Please finish the test.",
+      {
+        important: true,
+      },
+    );
+    options.event?.preventDefault();
+    return;
+  }
+
+  if (isRaceModeActive() && isTestActive() && !options.isRaceStart) {
+    showNoticeNotification(
+      "You can't restart or change the test during a multiplayer race.",
       {
         important: true,
       },
@@ -1041,7 +1061,23 @@ export async function finish(difficultyFailed = false): Promise<void> {
   let savingResultPromise: ReturnType<typeof saveResult> =
     Promise.resolve(null);
   const user = getAuthenticatedUser();
-  if (user !== null) {
+  if (isRaceModeActive()) {
+    // Multiplayer race: never touch the real results/PB/XP pipeline. Report
+    // the final summary to the room over the socket instead of saving.
+    const room = getRoom();
+    if (room !== null) {
+      getSocket().emit("race:finish", {
+        roomCode: room.roomCode,
+        wpm: completedEvent.wpm,
+        rawWpm: completedEvent.rawWpm,
+        acc: completedEvent.acc,
+        consistency: completedEvent.consistency,
+        charStats: completedEvent.charStats,
+      });
+    }
+    setRaceModeActive(false);
+    dontSave = true;
+  } else if (user !== null) {
     // logged in
     if (dontSave) {
       void AnalyticsController.log("testCompletedInvalid");

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -77,6 +77,7 @@ import {
 } from "./events/stats";
 import * as ConnectionState from "../legacy-states/connection";
 import * as TestInitFailed from "../elements/test-init-failed";
+import { getRaceCountdown } from "../states/multiplayer";
 
 export const updateHintsPositionDebounced = Misc.debounceUntilResolved(
   updateHintsPosition,
@@ -94,8 +95,10 @@ let lineTransition = false;
 
 // #words is still vanilla; the warning itself is Solid (OutOfFocusWarning.tsx).
 // show/hideOutOfFocus live in states/test so commandline needn't import test-ui.
+// Also blurred during a multiplayer race countdown (RaceCountdownOverlay.tsx)
+// so players can't read ahead before the synchronized start.
 createEffect(() => {
-  if (showOutOfFocusWarning()) {
+  if (showOutOfFocusWarning() || getRaceCountdown() !== null) {
     wordsEl.setStyle({ transition: "0.25s" })?.addClass("blurred");
   } else {
     wordsEl.setStyle({ transition: "none" })?.removeClass("blurred");

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -25,6 +25,7 @@ import {
 import { WordGenError } from "../utils/word-gen-error";
 
 import { showLoaderBar, hideLoaderBar } from "../states/loader-bar";
+import { isRaceModeActive, getRaceWordList } from "../states/multiplayer";
 import { PolyglotWordset } from "./funbox/funbox-functions";
 import { LanguageObject } from "@monkeytype/schemas/languages";
 import {
@@ -640,7 +641,9 @@ export async function generateWords(
   console.debug("Word order", wordOrder);
 
   let wordList = language.words;
-  if (Config.mode === "custom") {
+  if (isRaceModeActive() && getRaceWordList() !== null) {
+    wordList = getRaceWordList() as string[];
+  } else if (Config.mode === "custom") {
     wordList = CustomText.getText();
   } else if (Config.mode === "quote") {
     wordList = await getQuoteWordList(language, wordOrder);
@@ -824,6 +827,10 @@ export async function getNextWord(
     const funboxSection = await getFunboxSection();
 
     if (Config.mode === "quote") {
+      randomWord = currentWordset.nextWord();
+    } else if (isRaceModeActive() && getRaceWordList() !== null) {
+      // race mode: every player must see the exact same sequence, so pull
+      // words off the shared list in order rather than sampling randomly
       randomWord = currentWordset.nextWord();
     } else if (Config.mode === "custom" && CustomText.getMode() === "repeat") {
       randomWord = currentWordset.nextWord();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,6 +13,7 @@ import { usersContract } from "./users";
 import { quotesContract } from "./quotes";
 import { webhooksContract } from "./webhooks";
 import { connectionsContract } from "./connections";
+import { multiplayerContract } from "./multiplayer";
 
 const c = initContract();
 
@@ -31,6 +32,7 @@ export const contract = c.router({
   quotes: quotesContract,
   webhooks: webhooksContract,
   connections: connectionsContract,
+  multiplayer: multiplayerContract,
 });
 
 /**

--- a/packages/contracts/src/multiplayer.ts
+++ b/packages/contracts/src/multiplayer.ts
@@ -1,0 +1,70 @@
+import { initContract } from "@ts-rest/core";
+import { z } from "zod";
+import {
+  CommonResponses,
+  meta,
+  MonkeyClientError,
+  responseWithData,
+} from "./util/api";
+import {
+  RaceConfigSchema,
+  RaceRoomSchema,
+  RoomCodeSchema,
+} from "@monkeytype/schemas/multiplayer";
+
+export const CreateRoomRequestSchema = z.object({
+  config: RaceConfigSchema,
+});
+export type CreateRoomRequest = z.infer<typeof CreateRoomRequestSchema>;
+
+export const CreateRoomResponseSchema = responseWithData(RaceRoomSchema);
+export type CreateRoomResponse = z.infer<typeof CreateRoomResponseSchema>;
+
+export const GetRoomPathSchema = z.object({
+  roomCode: RoomCodeSchema,
+});
+export type GetRoomPath = z.infer<typeof GetRoomPathSchema>;
+
+export const GetRoomResponseSchema = responseWithData(RaceRoomSchema);
+export type GetRoomResponse = z.infer<typeof GetRoomResponseSchema>;
+
+const c = initContract();
+export const multiplayerContract = c.router(
+  {
+    createRoom: {
+      summary: "create a multiplayer race room",
+      description: "Creates a new room and makes the caller its host",
+      method: "POST",
+      path: "/room",
+      body: CreateRoomRequestSchema.strict(),
+      responses: {
+        200: CreateRoomResponseSchema,
+      },
+      metadata: meta({
+        rateLimit: "multiplayerCreateRoom",
+      }),
+    },
+    getRoom: {
+      summary: "get a multiplayer race room",
+      description: "Gets a room by its shareable code, used before joining",
+      method: "GET",
+      path: "/room/:roomCode",
+      pathParams: GetRoomPathSchema,
+      responses: {
+        200: GetRoomResponseSchema,
+        404: MonkeyClientError.describe("Room not found"),
+      },
+      metadata: meta({
+        rateLimit: "multiplayerGetRoom",
+      }),
+    },
+  },
+  {
+    pathPrefix: "/multiplayer",
+    strictStatusCodes: true,
+    metadata: meta({
+      openApiTags: "multiplayer",
+    }),
+    commonResponses: CommonResponses,
+  },
+);

--- a/packages/contracts/src/rate-limit/index.ts
+++ b/packages/contracts/src/rate-limit/index.ts
@@ -386,6 +386,17 @@ export const limits = {
     window: "hour",
     max: 60,
   },
+
+  // Multiplayer Routing
+  multiplayerCreateRoom: {
+    window: "minute",
+    max: 5,
+  },
+
+  multiplayerGetRoom: {
+    window: "minute",
+    max: 60,
+  },
 } satisfies Record<string, RateLimitOptions>;
 
 export type RateLimiterId = keyof typeof limits;

--- a/packages/contracts/src/util/api.ts
+++ b/packages/contracts/src/util/api.ts
@@ -16,7 +16,8 @@ export type OpenApiTag =
   | "users"
   | "quotes"
   | "webhooks"
-  | "connections";
+  | "connections"
+  | "multiplayer";
 
 export type PermissionId =
   | "quoteMod"

--- a/packages/schemas/src/multiplayer-events.ts
+++ b/packages/schemas/src/multiplayer-events.ts
@@ -1,0 +1,53 @@
+import type {
+  RaceConfig,
+  RaceRoom,
+  RacePlayer,
+  RaceFinalResult,
+} from "./multiplayer";
+
+export type AckResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "error"; message: string };
+
+export type RaceFinishPayload = {
+  roomCode: string;
+} & Omit<RaceFinalResult, "finishedAt">;
+
+/** Events sent from the browser to the server. */
+export type ClientToServerEvents = {
+  "room:join": (
+    payload: { roomCode: string },
+    ack: (res: AckResult<RaceRoom>) => void,
+  ) => void;
+  "room:leave": (payload: { roomCode: string }) => void;
+  "room:updateConfig": (payload: {
+    roomCode: string;
+    config: RaceConfig;
+  }) => void;
+  "room:setReady": (payload: { roomCode: string; isReady: boolean }) => void;
+  "room:start": (payload: { roomCode: string; wordList: string[] }) => void;
+  "room:rematch": (payload: { roomCode: string }) => void;
+  "race:finish": (payload: RaceFinishPayload) => void;
+};
+
+/** Events sent from the server to the browser. */
+export type ServerToClientEvents = {
+  "room:state": (room: RaceRoom) => void;
+  "room:playerJoined": (player: RacePlayer) => void;
+  "room:playerLeft": (payload: { uid: string }) => void;
+  "room:countdown": (payload: {
+    startsAtServerTime: number;
+    seconds: number;
+    wordList: string[];
+  }) => void;
+  "room:raceStarted": (payload: {
+    wordList: string[];
+    raceStartedAt: number;
+  }) => void;
+  "race:playerFinished": (payload: {
+    uid: string;
+    finalResult: RaceFinalResult;
+  }) => void;
+  "race:results": (payload: { players: RacePlayer[] }) => void;
+  "room:error": (payload: { message: string; code: string }) => void;
+};

--- a/packages/schemas/src/multiplayer.ts
+++ b/packages/schemas/src/multiplayer.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { IdSchema, PercentageSchema, WpmSchema, token } from "./util";
+import { LanguageSchema } from "./languages";
+import { DifficultySchema } from "./shared";
+import { CharStatsSchema } from "./results";
+
+export const RoomCodeSchema = token().length(6);
+export type RoomCode = z.infer<typeof RoomCodeSchema>;
+
+export const RaceConfigSchema = z.object({
+  mode: z.enum(["words", "time"]),
+  words: z.number().int().min(10).max(200),
+  time: z.number().int().min(15).max(300),
+  language: LanguageSchema,
+  punctuation: z.boolean(),
+  numbers: z.boolean(),
+  difficulty: DifficultySchema,
+});
+export type RaceConfig = z.infer<typeof RaceConfigSchema>;
+
+export const RoomStatusSchema = z.enum([
+  "lobby",
+  "countdown",
+  "racing",
+  "finished",
+]);
+export type RoomStatus = z.infer<typeof RoomStatusSchema>;
+
+export const RacePlayerStatusSchema = z.enum(["connected", "disconnected"]);
+export type RacePlayerStatus = z.infer<typeof RacePlayerStatusSchema>;
+
+export const RaceFinalResultSchema = z.object({
+  wpm: WpmSchema,
+  rawWpm: WpmSchema,
+  acc: PercentageSchema,
+  consistency: PercentageSchema,
+  charStats: CharStatsSchema,
+  finishedAt: z.number().int().nonnegative(),
+});
+export type RaceFinalResult = z.infer<typeof RaceFinalResultSchema>;
+
+export const RacePlayerSchema = z.object({
+  uid: IdSchema,
+  name: z.string(),
+  isHost: z.boolean(),
+  isReady: z.boolean(),
+  status: RacePlayerStatusSchema,
+  finalResult: RaceFinalResultSchema.nullable(),
+});
+export type RacePlayer = z.infer<typeof RacePlayerSchema>;
+
+export const RaceRoomSchema = z.object({
+  roomCode: RoomCodeSchema,
+  hostUid: IdSchema,
+  status: RoomStatusSchema,
+  config: RaceConfigSchema,
+  wordList: z.array(z.string()).nullable(),
+  players: z.array(RacePlayerSchema),
+  createdAt: z.number().int().nonnegative(),
+  raceStartedAt: z.number().int().nonnegative().nullable(),
+});
+export type RaceRoom = z.infer<typeof RaceRoomSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       simple-git:
         specifier: 3.36.0
         version: 3.36.0
+      socket.io:
+        specifier: 4.8.3
+        version: 4.8.3
       string-similarity:
         specifier: 4.0.4
         version: 4.0.4
@@ -402,6 +405,9 @@ importers:
       slim-select:
         specifier: 2.9.2
         version: 2.9.2
+      socket.io-client:
+        specifier: 4.8.3
+        version: 4.8.3
       stemmer:
         specifier: 2.0.1
         version: 2.0.1
@@ -677,7 +683,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@24.9.1)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@types/node@24.9.1)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/contracts:
     dependencies:
@@ -825,7 +831,7 @@ importers:
     dependencies:
       tsup:
         specifier: 8.4.0
-        version: 8.4.0(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)
+        version: 8.4.0(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@7.0.2)(yaml@2.8.3)
     devDependencies:
       '@monkeytype/typescript-config':
         specifier: workspace:*
@@ -4148,6 +4154,9 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     hasBin: true
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@solid-devtools/debugger@0.28.1':
     resolution: {integrity: sha512-6qIUI6VYkXoRnL8oF5bvh2KgH71qlJ18hNw/mwSyY6v48eb80ZR48/5PDXufUa3q+MBSuYa1uqTMwLewpay9eg==}
     peerDependencies:
@@ -5782,6 +5791,10 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
+
   baseline-browser-mapping@2.11.12:
     resolution: {integrity: sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==}
     engines: {node: '>=6.0.0'}
@@ -6885,6 +6898,17 @@ packages:
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.17.1:
     resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
@@ -10657,6 +10681,21 @@ packages:
     resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   socks-proxy-agent@8.0.4:
     resolution: {integrity: sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==}
     engines: {node: '>= 14'}
@@ -11427,11 +11466,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -12077,6 +12111,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -15442,6 +15480,8 @@ snapshots:
       ignore: 5.3.2
       p-map: 4.0.0
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@solid-devtools/debugger@0.28.1(solid-js@1.9.13)':
     dependencies:
       '@nothing-but/utils': 0.17.0
@@ -16749,14 +16789,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@24.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.0(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.70.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -17240,6 +17272,8 @@ snapshots:
     optional: true
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.11.12: {}
 
@@ -18411,6 +18445,37 @@ snapshots:
   end-of-stream@1.4.4:
     dependencies:
       once: 1.4.0
+
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.9:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 24.9.1
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.17.1:
     dependencies:
@@ -23044,6 +23109,47 @@ snapshots:
 
   smob@1.6.2: {}
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socks-proxy-agent@8.0.4:
     dependencies:
       agent-base: 7.1.1
@@ -23875,33 +23981,6 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.4.0(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.0)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.0
-      debug: 4.4.1
-      esbuild: 0.25.0
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.3)
-      resolve-from: 5.0.0
-      rollup: 4.40.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.13
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.8
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.4.0(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@7.0.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.0)
@@ -24010,9 +24089,6 @@ snapshots:
       is-typedarray: 1.0.0
 
   typescript@5.9.3: {}
-
-  typescript@6.0.2:
-    optional: true
 
   typescript@7.0.2:
     optionalDependencies:
@@ -24312,26 +24388,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.9.1
-      esbuild: 0.25.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      sass: 1.98.0
-      terser: 5.49.0
-      tsx: 4.21.0
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.7.0)(sass@1.70.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -24455,35 +24511,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.9.1
       '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.2(@types/node@24.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.0)
-      happy-dom: 20.8.9
-      jsdom: 27.4.0
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@types/node@24.9.1)(happy-dom@20.8.9)(jsdom@27.4.0)(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.5(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@24.9.1)(esbuild@0.25.0)(jiti@2.7.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.9.1
       happy-dom: 20.8.9
       jsdom: 27.4.0
     transitivePeerDependencies:
@@ -24880,6 +24907,8 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- Real-time multiplayer racing: create a private room, share the room code/link, race the same word list live against friends, and see ranked results at the end
- Socket.IO layer attached to the existing Express server, authenticated via the existing Firebase token verification (`verifyIdToken`)
- Room/player state lives in Redis, fully isolated from the results/PB/XP pipeline — races never affect real stats or leaderboards
- Every player sees the identical word sequence (host generates it once, server relays it verbatim), a blurred in-game countdown overlay before the race starts, and a synchronized timer start (forced at "go" instead of each player's own first keystroke)
- New `/multiplayer` and `/multiplayer/:roomCode` pages, socket client, and Solid state module on the frontend; new `packages/schemas`/`packages/contracts` multiplayer definitions on the shared side; new Socket.IO + Redis layer on the backend

## Out of scope / follow-ups
- Public matchmaking, spectator mode, rematch brackets beyond the current room reset
- Horizontal-scaling Redis pub/sub adapter for Socket.IO (fine for a single backend instance)
- Production-grade anti-cheat on live progress (matches the existing solo-test posture, where real anti-cheat is a private module not in this repo)
- Automated test coverage for the new Redis room logic and socket auth

## Test plan
- [x] `tsc --noEmit` and `oxlint --type-aware --type-check` clean across `schemas`, `contracts`, `backend`, and `frontend`
- [x] Exercised the REST endpoints directly (create room, get room, 404/422/401 paths) against a local Mongo+Redis backend
- [x] Exercised the socket auth layer (missing/invalid token rejection)
- [x] Manually tested the full flow end-to-end in two browser sessions with real Firebase accounts: create room → invite link → join → ready up → synchronized countdown → race → ranked results → rematch