### PR TITLE
fix(live-stats): update progress after custom text change (@MohdMaaz000)

### DIFF
--- a/frontend/__tests__/states/live-stats.spec.ts
+++ b/frontend/__tests__/states/live-stats.spec.ts
@@ -1,0 +1,32 @@
+import { createRoot } from "solid-js";
+import { describe, expect, it } from "vitest";
+import { setConfigStore } from "../../src/ts/config/store";
+import { getTimerText } from "../../src/ts/states/live-stats";
+import { setIsTestRestarting } from "../../src/ts/states/test";
+import * as CustomText from "../../src/ts/test/custom-text";
+
+describe("live-stats", () => {
+  describe("getTimerText", () => {
+    it("updates progress text immediately when test is restarted after custom text limit change", () => {
+      createRoot((dispose) => {
+        setConfigStore("mode", "custom");
+        CustomText.setLimitMode("word");
+        CustomText.setLimitValue(9);
+
+        expect(getTimerText()).toBe("0/9");
+
+        // Update custom text limit (simulating custom text change to 2 words)
+        CustomText.setLimitValue(2);
+
+        // Trigger test restart signals (as occurs in restart())
+        setIsTestRestarting(true);
+        setIsTestRestarting(false);
+
+        // Progress text should immediately reflect the updated total without typing
+        expect(getTimerText()).toBe("0/2");
+
+        dispose();
+      });
+    });
+  });
+});

--- a/frontend/src/ts/states/live-stats.ts
+++ b/frontend/src/ts/states/live-stats.ts
@@ -13,6 +13,7 @@ import {
   getFocus,
   isResultCalculating,
   isTestActive,
+  isTestRestarting,
 } from "./test";
 
 /** Whether this test counts down a time limit rather than a number of words. */
@@ -105,6 +106,7 @@ export const getLiveBurstText = createMemo(() =>
 
 /** Countdown / word counter shown by the timer displays. */
 export const getTimerText = createMemo(() => {
+  isTestRestarting();
   if (isTimeLimitedTest()) {
     const limit = getTestTimeLimit();
     const seconds = currentLiveStats.seconds ?? 0;


### PR DESCRIPTION
### Description

When using Custom mode, changing the custom text through the command line could leave the live progress counter showing the previous text length until the first word was typed.

For example, if the previous text had 9 words and I changed it to `asdf asdf`, the progress would still show `0/9` immediately after confirming the new text. After typing, it would update to `0/2`.

I traced this to `getTimerText` not being notified when the test restarted. The custom text limit is stored outside SolidJS's reactive state, and the active word index was already `0`, so resetting it during the restart did not trigger the memo to recalculate.

I fixed this by making `getTimerText` react to `isTestRestarting()`. This causes the progress calculation to run again when the restart finishes and pick up the new custom text limit immediately.

I also added a regression test to make sure the progress changes from `0/9` to `0/2` without requiring a keystroke.

Closes #8334

