### PR TITLE
fix(backwards): backwards funbox breaks emojis (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -348,6 +348,8 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
   },
   backwards: {
     alterText(word: string): string {
+      if (!("Segmenter" in Intl)) return [...word].reverse().join("");
+
       const segmenter = new Intl.Segmenter();
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
       const emojiRegex = /\p{Emoji}/u;

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -351,12 +351,13 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const segmenter = new Intl.Segmenter();
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
 
+      const emojiRegex = /\p{Emoji}/u;
       const emojiComponentRegex = /\p{Emoji_Component}/u;
 
       const units = [];
       for (const g of graphemes) {
         // Handles emojis that have ZWJs and regional indicators
-        if (emojiComponentRegex.test(g)) {
+        if (emojiRegex.test(g) && emojiComponentRegex.test(g)) {
           units.push(g);
           continue;
         }

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -354,7 +354,7 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
       const emojiRegex = /\p{Emoji}/u;
 
-      // The codepoints making up an emoji aren't reversed, everything else is split
+      // The codepoints making up an emoji sequence aren't reversed, everything else is split
       // and reversed.
       const units = graphemes.flatMap((g) =>
         emojiRegex.test(g) ? [g] : [...g],

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -350,17 +350,12 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
     alterText(word: string): string {
       const segmenter = new Intl.Segmenter();
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
-
       const emojiRegex = /\p{Emoji}/u;
 
-      const units = [];
-      for (const g of graphemes) {
-        if (emojiRegex.test(g)) {
-          units.push(g);
-        } else {
-          units.push(...g);
-        }
-      }
+      const units = graphemes.flatMap((g) =>
+        emojiRegex.test(g) ? [g] : [...g],
+      );
+
       return units.reverse().join("");
     },
   },

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -354,7 +354,7 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
       const emojiRegex = /\p{Emoji}/u;
 
-      // Emoji sequences aren't reversed, everything else is.
+      // Emojis aren't reversed, everything else is.
       const units = graphemes.flatMap((g) =>
         emojiRegex.test(g) ? [g] : [...g],
       );

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -348,7 +348,9 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
   },
   backwards: {
     alterText(word: string): string {
-      return word.split("").reverse().join("");
+      // @ts-expect-error - v flag is only supported in es2024+, need to consider alternatives
+      const regex = /\p{RGI_Emoji}|\p{Any}/gv;
+      return (word.match(regex) ?? []).reverse().join("");
     },
   },
   capitals: {

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -354,6 +354,8 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
       const emojiRegex = /\p{Emoji}/u;
 
+      // The codepoints making up an emoji aren't reversed, everything else is split
+      // and reversed.
       const units = graphemes.flatMap((g) =>
         emojiRegex.test(g) ? [g] : [...g],
       );

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -348,9 +348,22 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
   },
   backwards: {
     alterText(word: string): string {
-      // @ts-expect-error - v flag is only supported in es2024+, need to consider alternatives
-      const regex = /\p{RGI_Emoji}|\p{Any}/gv;
-      return (word.match(regex) ?? []).reverse().join("");
+      const segmenter = new Intl.Segmenter();
+      const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
+
+      const emojiComponentRegex = /\p{Emoji_Component}/u;
+
+      const units = [];
+      for (const g of graphemes) {
+        // Handles emojis that have ZWJs and regional indicators
+        if (emojiComponentRegex.test(g)) {
+          units.push(g);
+          continue;
+        }
+
+        units.push(...g);
+      }
+      return units.reverse().join("");
     },
   },
   capitals: {

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -354,8 +354,7 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
       const emojiRegex = /\p{Emoji}/u;
 
-      // The codepoints making up an emoji sequence aren't reversed, everything else is split
-      // and reversed.
+      // Emoji sequences aren't reversed, everything else is.
       const units = graphemes.flatMap((g) =>
         emojiRegex.test(g) ? [g] : [...g],
       );

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -352,12 +352,10 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       const graphemes = [...segmenter.segment(word)].map((s) => s.segment);
 
       const emojiRegex = /\p{Emoji}/u;
-      const emojiComponentRegex = /\p{Emoji_Component}/u;
 
       const units = [];
       for (const g of graphemes) {
-        // Handles emojis that have ZWJs and regional indicators
-        if (emojiRegex.test(g) && emojiComponentRegex.test(g)) {
+        if (emojiRegex.test(g)) {
           units.push(g);
           continue;
         }

--- a/frontend/src/ts/test/funbox/funbox-functions.ts
+++ b/frontend/src/ts/test/funbox/funbox-functions.ts
@@ -357,10 +357,9 @@ const list: Partial<Record<FunboxName, FunboxFunctions>> = {
       for (const g of graphemes) {
         if (emojiRegex.test(g)) {
           units.push(g);
-          continue;
+        } else {
+          units.push(...g);
         }
-
-        units.push(...g);
       }
       return units.reverse().join("");
     },


### PR DESCRIPTION
To reproduce:

1. Change mode to `custom`
2. Set the custom text to `🏳️‍🌈`
3. Enable the `backwards` funbox
4. Notice how the character breaks