### PR TITLE
fix: handle live stats correctly during test restart

### DIFF
--- a/frontend/src/ts/states/live-stats.ts
+++ b/frontend/src/ts/states/live-stats.ts
@@ -13,6 +13,7 @@ import {
   getFocus,
   isResultCalculating,
   isTestActive,
+  isTestRestarting,
 } from "./test";
 
 /** Whether this test counts down a time limit rather than a number of words. */
@@ -105,6 +106,7 @@ export const getLiveBurstText = createMemo(() =>
 
 /** Countdown / word counter shown by the timer displays. */
 export const getTimerText = createMemo(() => {
+  isTestRestarting();
   if (isTimeLimitedTest()) {
     const limit = getTestTimeLimit();
     const seconds = currentLiveStats.seconds ?? 0;


### PR DESCRIPTION
##Description

Fixes live stats handling during test restarts by ensuring the timer logic respects the restart state before updating the displayed value.

##Changes
- Added restart-state handling to the live timer logic.
- Prevented stale state from affecting live stats after a restart.
- Preserved existing time-limited test behavior.
- Verified the fix with custom text tests.

## Testing
- Ran the type-aware Ox lint check.
- Result: **0 warnings, 0 errors. **
- Tested the change locally with test restarts.