### PR TITLE
feat(theme): add Tokyo Night theme (@jazz-crab)

### DIFF
--- a/frontend/src/ts/constants/themes.ts
+++ b/frontend/src/ts/constants/themes.ts
@@ -2174,6 +2174,18 @@ export const themes: Record<ThemeName, Theme> = {
     colorfulError: "#e9632d",
     colorfulErrorExtra: "#e9632d",
   },
+  tokyo_night: {
+    bg: "#1a1b26",
+    caret: "#c0caf5",
+    main: "#7aa2f7",
+    sub: "#565f89",
+    subAlt: "#24283b",
+    text: "#a9b1d6",
+    error: "#f7768e",
+    errorExtra: "#db4b4b",
+    colorfulError: "#f7768e",
+    colorfulErrorExtra: "#e0af68",
+  },
   trackday: {
     bg: "#464d66",
     caret: "#475782",

--- a/packages/schemas/src/themes.ts
+++ b/packages/schemas/src/themes.ts
@@ -176,6 +176,7 @@ export const ThemeNameSchema = z.enum(
     "terrazzo",
     "terror_below",
     "tiramisu",
+    "tokyo_night",
     "trackday",
     "trance",
     "tron_orange",


### PR DESCRIPTION
## Description

Adds **Tokyo Night** dark theme based on [enkia/tokyo-night-vscode-theme](https://github.com/enkia/tokyo-night-vscode-theme) (VS Code marketplace: 4M+ installs).

Nord is already present, but Tokyo Night offers a different aesthetic -- slightly warmer, with more colorful accents (blue, purple, cyan, green, yellow, orange, red) while maintaining excellent readability.

## Color Mapping

| Property | Color | Usage |
|----------|-------|-------|
| `bg` | `#1a1b26` | Main background |
| `main` | `#7aa2f7` | Primary accent (blue) |
| `caret` | `#c0caf5` | Typing cursor |
| `text` | `#a9b1d6` | Primary text |
| `sub` | `#565f89` | Secondary UI elements |
| `subAlt` | `#24283b` | Alternate secondary |
| `error` | `#f7768e` | Error text (red) |
| `errorExtra` | `#db4b4b` | Additional error styling |
| `colorfulError` | `#f7768e` | Colorful mode error |
| `colorfulErrorExtra` | `#e0af68` | Colorful mode extra (yellow) |

## Changes

- `packages/schemas/src/themes.ts` -- added `"tokyo_night"` to theme name enum
- `frontend/src/ts/constants/themes.ts` -- added theme color definition (10 properties)

No custom CSS file needed -- pure color theme, similar to `nord`.

## Color Source

All colors from the official [enkia/tokyo-night-vscode-theme](https://github.com/enkia/tokyo-night-vscode-theme) palette.

Closes #8350