### PR TITLE
fix(quote-search): make quote search modal show german quotes for swiss german (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/components/modals/QuoteReportModal.tsx
+++ b/frontend/src/ts/components/modals/QuoteReportModal.tsx
@@ -3,7 +3,6 @@ import { createForm } from "@tanstack/solid-form";
 import { JSXElement, createSignal } from "solid-js";
 
 import Ape from "../../ape";
-import { Config } from "../../config/store";
 import QuotesController from "../../controllers/quotes-controller";
 import { hideLoaderBar, showLoaderBar } from "../../states/loader-bar";
 import { hideModalAndClearChain } from "../../states/modals";
@@ -13,6 +12,7 @@ import {
   showSuccessNotification,
 } from "../../states/notifications";
 import { quoteId } from "../../states/quote-report";
+import { getQuotesLanguage } from "../../utils/misc";
 import { removeLanguageSize } from "../../utils/strings";
 import { AnimatedModal } from "../common/AnimatedModal";
 import { Separator } from "../common/Separator";
@@ -34,7 +34,7 @@ export function QuoteReportModal(): JSXElement {
     },
     onSubmit: async ({ value }) => {
       const id = quoteId().toString();
-      const quoteLanguage = removeLanguageSize(Config.language);
+      const quoteLanguage = removeLanguageSize(getQuotesLanguage());
 
       if (value.captcha === "") {
         showNoticeNotification("Please complete the captcha");
@@ -93,8 +93,7 @@ export function QuoteReportModal(): JSXElement {
     });
     form.reset();
 
-    const language =
-      Config.language === "swiss_german" ? "german" : Config.language;
+    const language = getQuotesLanguage();
     const { quotes } = await QuotesController.getQuotes(language);
     const quote = quotes.find((q) => q.id === quoteId());
     setQuoteText(quote?.text ?? "");

--- a/frontend/src/ts/components/modals/QuoteSearchModal.tsx
+++ b/frontend/src/ts/components/modals/QuoteSearchModal.tsx
@@ -11,7 +11,6 @@ import { z } from "zod";
 
 import Ape from "../../ape";
 import { setConfig } from "../../config/setters";
-import { Config } from "../../config/store";
 import QuotesController, { Quote } from "../../controllers/quotes-controller";
 import * as DB from "../../db";
 import { createDebouncedEffectOn } from "../../hooks/effects";
@@ -274,7 +273,7 @@ export function QuoteSearchModal(): JSXElement {
     }
 
     const quoteSearchService = getSearchService<Quote>(
-      Config.language,
+      Misc.getQuotesLanguage(),
       allQuotes,
       (quote: Quote) => `${quote.text} ${quote.id} ${quote.source}`,
     );
@@ -390,10 +389,10 @@ export function QuoteSearchModal(): JSXElement {
   };
 
   const handleAfterShow = async (): Promise<void> => {
-    const quotesLanguage = await getLanguage(Config.language);
+    const quotesLanguage = await getLanguage(Misc.getQuotesLanguage());
     setIsRtl(quotesLanguage?.rightToLeft ?? false);
     const { quotes: fetchedQuotes } = await QuotesController.getQuotes(
-      Config.language,
+      Misc.getQuotesLanguage(),
     );
     setQuotes(fetchedQuotes);
     performSearch(form.state.values.searchText);

--- a/frontend/src/ts/components/modals/QuoteSubmitModal.tsx
+++ b/frontend/src/ts/components/modals/QuoteSubmitModal.tsx
@@ -4,7 +4,6 @@ import { createForm } from "@tanstack/solid-form";
 import { JSXElement } from "solid-js";
 
 import Ape from "../../ape";
-import { Config } from "../../config/store";
 import { LanguageGroupNames } from "../../constants/languages";
 import { hideLoaderBar, showLoaderBar } from "../../states/loader-bar";
 import { hideModalAndClearChain } from "../../states/modals";
@@ -13,6 +12,7 @@ import {
   showNoticeNotification,
   showSuccessNotification,
 } from "../../states/notifications";
+import { getQuotesLanguage } from "../../utils/misc";
 import { removeLanguageSize } from "../../utils/strings";
 import { AnimatedModal } from "../common/AnimatedModal";
 import { Captcha } from "../ui/form/Captcha";
@@ -35,7 +35,7 @@ export function QuoteSubmitModal(): JSXElement {
     text: g.replace(/_/g, " "),
   }));
 
-  const language = removeLanguageSize(Config.language) as string;
+  const language = removeLanguageSize(getQuotesLanguage()) as string;
 
   const form = createForm(() => ({
     defaultValues: {
@@ -78,7 +78,7 @@ export function QuoteSubmitModal(): JSXElement {
       defaultValues: {
         text: "",
         source: "",
-        language: removeLanguageSize(Config.language),
+        language: removeLanguageSize(getQuotesLanguage()),
         captcha: "",
       },
     });

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -521,9 +521,7 @@ async function getQuoteWordList(
       return currentWordset.words;
     }
   }
-  const languageToGet = language.name.startsWith("swiss_german")
-    ? "german"
-    : language.name;
+  const languageToGet = Misc.getQuotesLanguage(language.name);
 
   showLoaderBar();
   const quotesCollection = await QuotesController.getQuotes(

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -521,9 +521,7 @@ async function getQuoteWordList(
       return currentWordset.words;
     }
   }
-  const languageToGet = language.name.startsWith("swiss_german")
-    ? "german"
-    : language.name;
+  const languageToGet = Misc.getQuotesLanguage();
 
   showLoaderBar();
   const quotesCollection = await QuotesController.getQuotes(

--- a/frontend/src/ts/test/words-generator.ts
+++ b/frontend/src/ts/test/words-generator.ts
@@ -521,7 +521,9 @@ async function getQuoteWordList(
       return currentWordset.words;
     }
   }
-  const languageToGet = Misc.getQuotesLanguage();
+  const languageToGet = language.name.startsWith("swiss_german")
+    ? "german"
+    : language.name;
 
   showLoaderBar();
   const quotesCollection = await QuotesController.getQuotes(

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -1,9 +1,11 @@
 import { lastElementFromArray } from "./arrays";
-import { Config } from "@monkeytype/schemas/configs";
+import { Config as ConfigSchema } from "@monkeytype/schemas/configs";
+import { Config } from "../config/store";
 import { Mode, Mode2, PersonalBests } from "@monkeytype/schemas/shared";
 import { Result } from "@monkeytype/schemas/results";
 import { RankAndCount } from "@monkeytype/schemas/users";
 import { roundTo2 } from "@monkeytype/util/numbers";
+import { Language } from "@monkeytype/schemas/languages";
 import { animate, AnimationParams } from "animejs";
 import { ElementWithUtils } from "./dom";
 import { isDevEnvironment } from "./env";
@@ -235,7 +237,7 @@ export async function swapElements(
 }
 
 export function getMode2<M extends keyof PersonalBests>(
-  config: Config,
+  config: ConfigSchema,
   randomQuote: { id: number } | null,
 ): Mode2<M> {
   const mode = config.mode;
@@ -738,6 +740,12 @@ export function getTotalInlineMargin(element: HTMLElement): number {
   return (
     parseInt(computedStyle.marginRight) + parseInt(computedStyle.marginLeft)
   );
+}
+
+export function getQuotesLanguage(): Language {
+  return Config.language.startsWith("swiss_german")
+    ? "german"
+    : Config.language;
 }
 
 // DO NOT ALTER GLOBAL OBJECTSONSTRUCTOR, IT WILL BREAK RESULT HASHES

--- a/frontend/src/ts/utils/misc.ts
+++ b/frontend/src/ts/utils/misc.ts
@@ -742,10 +742,8 @@ export function getTotalInlineMargin(element: HTMLElement): number {
   );
 }
 
-export function getQuotesLanguage(): Language {
-  return Config.language.startsWith("swiss_german")
-    ? "german"
-    : Config.language;
+export function getQuotesLanguage(language = Config.language): Language {
+  return language.startsWith("swiss_german") ? "german" : language;
 }
 
 // DO NOT ALTER GLOBAL OBJECTSONSTRUCTOR, IT WILL BREAK RESULT HASHES


### PR DESCRIPTION
To reproduce:

1. Change `language` to `swiss_german`
2. Open the commandline, type `Search for quotes` and press enter
3. Notice how no quotes are shown

Now it will show german quotes, which is what swiss german uses when the user is in quotes mode.