### PR TITLE
fix: reset mode 2 when unchecking mode (@AzureNightlock)

### DIFF
--- a/frontend/src/ts/components/modals/ShareTestSettings.tsx
+++ b/frontend/src/ts/components/modals/ShareTestSettings.tsx
@@ -103,6 +103,7 @@ export function ShareTestSettings(): JSXElement {
           onChange: ({ value }) => {
             if (!value) {
               form.setFieldValue("mode2", false);
+              form.setFieldValue("customText", false);
             }
           },
         }}

--- a/frontend/src/ts/components/modals/ShareTestSettings.tsx
+++ b/frontend/src/ts/components/modals/ShareTestSettings.tsx
@@ -97,7 +97,16 @@ export function ShareTestSettings(): JSXElement {
 
   return (
     <AnimatedModal id="ShareTestSettings" title="Share test settings">
-      <form.Field name="mode">
+      <form.Field
+        name="mode"
+        listeners={{
+          onChange: ({ value }) => {
+            if (!value) {
+              form.setFieldValue("mode2", false);
+            }
+          },
+        }}
+      >
         {(field) => (
           <Checkbox
             field={() => field()}


### PR DESCRIPTION
### Description
This PR: Fixes ShareTestSettings.tsx when both mode and mode 2 is checked and only mode is unchecked, it resets mode 2 aswell

### Checks
- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

Closes #8357