### PR TITLE
fix: correct typo in "kailh box white" (@Leonabcd123)

### DIFF
--- a/frontend/src/ts/commandline/commandline-metadata.ts
+++ b/frontend/src/ts/commandline/commandline-metadata.ts
@@ -407,7 +407,7 @@ export const commandlineConfigMetadata: CommandlineConfigMetadataObject = {
           "20": "cherrymx blue abs",
           "21": "cherrymx blue pbt",
           "22": "cherrymx brown pbt",
-          "23": "kalih box white",
+          "23": "kailh box white",
           "24": "razer green",
           "25": "tealios v2",
           "26": "trust gxt",

--- a/frontend/src/ts/config/metadata.tsx
+++ b/frontend/src/ts/config/metadata.tsx
@@ -651,7 +651,7 @@ export const configMetadata: ConfigMetadataObject = {
       "20": { displayString: "cherrymx blue abs" },
       "21": { displayString: "cherrymx blue pbt" },
       "22": { displayString: "cherrymx brown pbt" },
-      "23": { displayString: "kalih box white" },
+      "23": { displayString: "kailh box white" },
       "24": { displayString: "razer green" },
       "25": { displayString: "tealios v2" },
       "26": { displayString: "trust gxt" },


### PR DESCRIPTION
`kalih` -> `kailh`