### PR TITLE
fix(test): apply settings changed while the test is restarting (@boergeson)

### DIFF
--- a/frontend/src/ts/test/test-logic.ts
+++ b/frontend/src/ts/test/test-logic.ts
@@ -200,6 +200,9 @@ export async function restart(options = {} as RestartOptions): Promise<void> {
 
   if (isTestRestarting() || isResultCalculating()) {
     options.event?.preventDefault();
+    if (isTestRestarting() && !options.isQuickRestart) {
+      queuedRestart = { ...options, event: undefined };
+    }
     return;
   }
   if (isTestActive()) {
@@ -332,6 +335,7 @@ export async function restart(options = {} as RestartOptions): Promise<void> {
 
   if (!initResult) {
     setIsTestRestarting(false);
+    runQueuedRestart();
     return;
   }
 
@@ -345,6 +349,17 @@ export async function restart(options = {} as RestartOptions): Promise<void> {
 
   await TestUI.fadeInAfterRestart(noAnim);
   setIsTestRestarting(false);
+  runQueuedRestart();
+}
+
+let queuedRestart: RestartOptions | null = null;
+
+// config changed while a restart was running, run again so the new settings apply
+function runQueuedRestart(): void {
+  if (queuedRestart === null) return;
+  const options = queuedRestart;
+  queuedRestart = null;
+  void restart(options);
 }
 
 let lastInitError: Error | null = null;


### PR DESCRIPTION
### Description

`restart()` returns early when a restart is already running. If you change the mode (or any other setting that restarts the test) while the previous restart is fading in, the new value ends up in the config but the test on screen is still the old one. Thats what happens in #8333 when going time -> words -> quote quickly.

Now a restart that comes in while another one is running is queued and run again once the first one is done, so the latest settings always end up on screen. Quick restarts (tab/esc mashing) are still dropped like before.

Reproduced with playwright by clicking `words` and then `quote` with a 130 to 250ms gap between the clicks. Before: config says quote, 25 plain words on screen. After: a quote every time.

### Checks

- [x] Check if any open issues are related to this PR; if so, be sure to tag them below.
- [x] Make sure the PR title follows the Conventional Commits standard. (https://www.conventionalcommits.org for more info)
- [x] Make sure to include your GitHub username prefixed with @ inside parentheses at the end of the PR title.

Closes #8333
