### PR TITLE
fix(ttl-cache): concurrent calls during the first fetch get undefined (@boergeson)

### DIFF
--- a/backend/__tests__/utils/ttl-cache.spec.ts
+++ b/backend/__tests__/utils/ttl-cache.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cacheWithTTL } from "../../src/utils/ttl-cache";
+
+describe("cacheWithTTL", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("refetches after the ttl", async () => {
+    const fn = vi.fn(async () => Date.now());
+    const cache = cacheWithTTL(1000, fn);
+
+    expect(await cache()).toBe(10_000);
+    vi.advanceTimersByTime(500);
+    expect(await cache()).toBe(10_000);
+    vi.advanceTimersByTime(600);
+    expect(await cache()).toBe(11_100);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the stale value until the ttl when the fetch fails", async () => {
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("first")
+      .mockRejectedValueOnce(new Error("down"))
+      .mockResolvedValueOnce("third");
+    const cache = cacheWithTTL(1000, fn);
+
+    expect(await cache()).toBe("first");
+    vi.advanceTimersByTime(1100);
+    await expect(cache()).rejects.toThrow("down");
+    expect(await cache()).toBe("first");
+    expect(fn).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1100);
+    expect(await cache()).toBe("third");
+  });
+
+  it("shares one fetch between concurrent calls", async () => {
+    let resolve!: (value: string) => void;
+    const fn = vi.fn(
+      async () =>
+        new Promise<string>((res) => {
+          resolve = res;
+        }),
+    );
+    const cache = cacheWithTTL(1000, fn);
+
+    const a = cache();
+    const b = cache();
+    resolve("value");
+
+    expect(await a).toBe("value");
+    expect(await b).toBe("value");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/utils/ttl-cache.ts
+++ b/backend/src/utils/ttl-cache.ts
@@ -16,12 +16,21 @@ export function cacheWithTTL<T>(
 ): () => Promise<T | undefined> {
   let lastFetchTime = 0;
   let cache: T | undefined;
+  let pending: Promise<T> | undefined;
 
   return async () => {
-    if (lastFetchTime < Date.now() - ttlMs) {
+    if (pending === undefined && lastFetchTime < Date.now() - ttlMs) {
       lastFetchTime = Date.now();
-      cache = await fn();
+      pending = fn()
+        .then((data) => {
+          cache = data;
+          return data;
+        })
+        .finally(() => {
+          pending = undefined;
+        });
     }
+    await pending;
     return cache;
   };
 }


### PR DESCRIPTION
### Description

Concurrent calls to a `cacheWithTTL` function while the first fetch is still running each got `undefined` back, since the cache was marked fresh before the data arrived. Now the first call starts the fetch and later calls wait on the same promise, so there is only one fetch and everyone gets the value.

A failed fetch still marks the cache fresh, so the stale value keeps being served until the ttl passes. That part is unchanged on purpose, the cache also throttles the database.

Closes #8363
