### PR TITLE
fix(result-word-highlight): input ending in < shows a broken entity (@boergeson)

### DIFF
--- a/frontend/src/ts/elements/result-word-highlight.ts
+++ b/frontend/src/ts/elements/result-word-highlight.ts
@@ -311,12 +311,12 @@ async function init(): Promise<boolean> {
 
       // Calculate inputWordEl properties relative to inputWordsContainerEl
       inputWordEl.style.left = `${wordEl.offsetLeft + PADDING_OFFSET_X - RTL_offset}px`;
-      inputWordEl.innerHTML = userInputString
-        .replace(/\t/g, "_")
-        .replace(/\n/g, "_")
-        .replace(/</g, "&lt")
-        .replace(/>/g, "&gt")
-        .slice(0, wordEl.childElementCount);
+      inputWordEl.innerHTML = Misc.escapeHTML(
+        userInputString
+          .replace(/\t/g, "_")
+          .replace(/\n/g, "_")
+          .slice(0, wordEl.childElementCount),
+      );
 
       inputWordEl.className = "inputWord";
       inputWordsContainerEl.append(inputWordEl);

--- a/frontend/src/ts/test/test-ui.ts
+++ b/frontend/src/ts/test/test-ui.ts
@@ -1402,11 +1402,7 @@ async function loadWordsHistory(): Promise<boolean> {
         "beforeend",
         `<div class="wordInputHighlight withSpeed">
           <div class="text">
-          ${input
-            .replace(/\t/g, "_")
-            .replace(/\n/g, "_")
-            .replace(/</g, "&lt")
-            .replace(/>/g, "&gt")}
+          ${Misc.escapeHTML(input.replace(/\t/g, "_").replace(/\n/g, "_"))}
           </div>
           <div class="speed">
           ${isNaN(burst) || burst >= 1000 ? "Infinite" : Format.typingSpeed(burst, { showDecimalPlaces: false })}


### PR DESCRIPTION
### Description

The result word highlight escaped `<` and `>` as `&lt`/`&gt` and then sliced the string to the word length, so an input ending in `<` got cut in the middle of the entity. Hovering the chart then showed `abc&` for a typed `abc<`.

Slice first, then run it through `Misc.escapeHTML`. Same helper is now used for the words history hover, that one was fine in practice since it isnt sliced, but it had the same handwritten replace chain.

Checked with playwright against vite dev, custom text `xyz` typed as `abc<`: master shows `abc&` in the chart highlight, this branch shows `abc<`.

Closes #8365
