### PR TITLE
fix(new-quotes): git guards never fire in add, get and refuse (@boergeson)

### DIFF
--- a/backend/__tests__/dal/new-quotes.spec.ts
+++ b/backend/__tests__/dal/new-quotes.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { ObjectId } from "mongodb";
+import * as NewQuotesDal from "../../src/dal/new-quotes";
+
+vi.mock("simple-git", () => ({
+  simpleGit: () => {
+    throw new Error("no repo");
+  },
+}));
+
+describe("NewQuotesDal", () => {
+  describe("without git", () => {
+    it("add fails", async () => {
+      await expect(
+        NewQuotesDal.add("text", "source", "english", "uid"),
+      ).rejects.toThrow("Git not available.");
+    });
+    it("get fails", async () => {
+      await expect(NewQuotesDal.get("all")).rejects.toThrow(
+        "Git not available.",
+      );
+    });
+    it("approve fails", async () => {
+      await expect(
+        NewQuotesDal.approve(
+          new ObjectId().toHexString(),
+          undefined,
+          undefined,
+          "name",
+        ),
+      ).rejects.toThrow("Git not available.");
+    });
+    it("refuse fails", async () => {
+      await expect(
+        NewQuotesDal.refuse(new ObjectId().toHexString()),
+      ).rejects.toThrow("Git not available.");
+    });
+  });
+});

--- a/backend/src/dal/new-quotes.ts
+++ b/backend/src/dal/new-quotes.ts
@@ -56,7 +56,7 @@ export async function add(
   language: string,
   uid: string,
 ): Promise<AddQuoteReturn | undefined> {
-  if (git === undefined) throw new MonkeyError(500, "Git not available.");
+  if (git === null) throw new MonkeyError(500, "Git not available.");
   const quote = {
     _id: new ObjectId(),
     text: text,
@@ -114,7 +114,7 @@ export async function add(
 }
 
 export async function get(language: Language | "all"): Promise<DBNewQuote[]> {
-  if (git === undefined) throw new MonkeyError(500, "Git not available.");
+  if (git === null) throw new MonkeyError(500, "Git not available.");
   const where: {
     approved: boolean;
     language?: Language;
@@ -232,6 +232,6 @@ export async function approve(
 }
 
 export async function refuse(quoteId: string): Promise<void> {
-  if (git === undefined) throw new MonkeyError(500, "Git not available.");
+  if (git === null) throw new MonkeyError(500, "Git not available.");
   await getNewQuoteCollection().deleteOne({ _id: new ObjectId(quoteId) });
 }


### PR DESCRIPTION
### Description

`tryCatchSync` returns `data: null` when the callback throws, so the git guards in `add`, `get` and `refuse` that compare against `undefined` never fire. Only `approve` was updated to `null` in #6492. With no quotes repo checked out those three just run as if git was there.

Changed the three checks to `=== null`. Added a spec that mocks `simple-git` to throw, on master add/get/refuse pass through, with this change all four throw the 500.

Note the issue describes it the other way round (says approve is the broken one), but `approve` is the only one that was right, see `packages/util/src/trycatch.ts`.

Closes #8364
