### PR TITLE
fix(monkey-power): shake reset never cancelled, spark colors not padded (@boergeson)

### DIFF
--- a/frontend/__tests__/elements/monkey-power.spec.ts
+++ b/frontend/__tests__/elements/monkey-power.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as MonkeyPower from "../../src/ts/elements/monkey-power";
+
+vi.mock("../../src/ts/config/store", () => ({
+  Config: { monkeyPowerLevel: "3", blindMode: false },
+}));
+vi.mock("../../src/ts/legacy-states/slow-timer", () => ({
+  get: () => false,
+}));
+vi.mock("../../src/ts/states/theme", () => ({
+  getTheme: () => ({ caret: "#fff", error: "#f00" }),
+}));
+vi.mock("../../src/ts/utils/debounced-animation-frame", () => ({
+  requestDebouncedAnimationFrame: (_id: string, cb: () => void) => cb(),
+}));
+
+describe("monkey-power", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reset cancels the pending shake reset", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockReturnValue(
+      42 as unknown as NodeJS.Timeout,
+    );
+    const clear = vi.spyOn(globalThis, "clearTimeout");
+    await MonkeyPower.addPower();
+    MonkeyPower.reset();
+    expect(clear).toHaveBeenCalledWith(42);
+  });
+
+  it("randomColor pads every channel", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(MonkeyPower.__testing.randomColor()).toBe("#000000");
+  });
+});

--- a/frontend/src/ts/elements/monkey-power.ts
+++ b/frontend/src/ts/elements/monkey-power.ts
@@ -196,10 +196,11 @@ function startRender(): void {
 }
 
 function randomColor(): string {
-  const r = Math.floor(Math.random() * 256).toString(16);
-  const g = Math.floor(Math.random() * 256).toString(16);
-  const b = Math.floor(Math.random() * 256).toString(16);
-  return `#${r}${g}${b}`;
+  const hex = (): string =>
+    Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${hex()}${hex()}${hex()}`;
 }
 
 /**
@@ -252,3 +253,5 @@ export async function addPower(good = true, extra = false): Promise<void> {
     startRender();
   });
 }
+
+export const __testing = { randomColor };

--- a/frontend/src/ts/elements/monkey-power.ts
+++ b/frontend/src/ts/elements/monkey-power.ts
@@ -170,9 +170,9 @@ function render(): void {
 
 export function reset(immediate = false): void {
   if (!isSafeNumber(ctx.resetTimeOut)) return;
+  clearTimeout(ctx.resetTimeOut);
   delete ctx.resetTimeOut;
 
-  clearTimeout(ctx.resetTimeOut);
   body.setStyle({
     transition: "all .25s, transform 0.8s",
     transform: "translate(0,0)",


### PR DESCRIPTION
### Description

Two small things in monkey power:

- `reset()` deleted `ctx.resetTimeOut` and then called `clearTimeout` with it, so the 2s shake reset from `addPower` was never cancelled. Swapped the two lines.
- `randomColor()` built the hex string without padding, so any channel under 16 gave a 3 to 5 char color like `#fa2` that isnt what was meant. Channels are now padded to two digits.

Added a spec for both, `randomColor` is exposed through `__testing` like a few other modules do. Both tests fail on master and pass here.

Closes #8362
