### PR TITLE
fix(result): incomplete test xp lost when the next result is zen (@boergeson)

### DIFF
--- a/backend/__tests__/api/controllers/result.spec.ts
+++ b/backend/__tests__/api/controllers/result.spec.ts
@@ -687,6 +687,28 @@ describe("result controller test", () => {
         15.1 + 2 - 5, //duration + incompleteTestSeconds-afk
       );
     });
+    it("should keep incomplete xp for zen", async () => {
+      //GIVEN
+      await enableUsersXpGain(true, 1);
+      const completedEvent = buildCompletedEvent({
+        mode: "zen",
+        mode2: "zen",
+      });
+
+      //WHEN
+      const { body } = await mockApp
+        .post("/results")
+        .set("Authorization", `Bearer ${uid}`)
+        .send({
+          result: completedEvent,
+        })
+        .expect(200);
+
+      //THEN
+      expect(body.data.xp).toEqual(5);
+      expect(body.data.xpBreakdown).toEqual({ incomplete: 5 });
+      expect(userIncrementXpMock).toHaveBeenCalledWith(uid, 5);
+    });
     it("should fail if result saving is disabled", async () => {
       //GIVEN
       await enableResultsSaving(false);
@@ -882,9 +904,17 @@ async function enableResultsSaving(enabled: boolean): Promise<void> {
     mockConfig,
   );
 }
-async function enableUsersXpGain(enabled: boolean): Promise<void> {
+async function enableUsersXpGain(
+  enabled: boolean,
+  gainMultiplier = 0,
+): Promise<void> {
   const mockConfig = await configuration;
-  mockConfig.users.xp = { ...mockConfig.users.xp, enabled, funboxBonus: 1 };
+  mockConfig.users.xp = {
+    ...mockConfig.users.xp,
+    enabled,
+    funboxBonus: 1,
+    gainMultiplier,
+  };
 
   vi.spyOn(Configuration, "getCachedConfiguration").mockResolvedValue(
     mockConfig,

--- a/backend/src/api/controllers/result.ts
+++ b/backend/src/api/controllers/result.ts
@@ -734,13 +734,37 @@ async function calculateXp(
     funboxBonus: funboxBonusConfiguration,
   } = xpConfiguration;
 
-  if (mode === "zen" || !enabled) {
+  if (!enabled) {
     return {
       xp: 0,
     };
   }
 
   const breakdown: XpBreakdown = {};
+
+  let incompleteXp = 0;
+  if (incompleteTests !== undefined && incompleteTests.length > 0) {
+    incompleteTests.forEach((it: { acc: number; seconds: number }) => {
+      let mod = (it.acc - 50) / 50;
+      if (mod < 0) mod = 0;
+      incompleteXp += Math.round(it.seconds * mod);
+    });
+    breakdown.incomplete = incompleteXp;
+  } else if (incompleteTestSeconds && incompleteTestSeconds > 0) {
+    incompleteXp = Math.round(incompleteTestSeconds);
+    breakdown.incomplete = incompleteXp;
+  }
+
+  if (gainMultiplier !== 1) {
+    breakdown.configMultiplier = gainMultiplier;
+  }
+
+  if (mode === "zen") {
+    return {
+      xp: Math.round(incompleteXp * gainMultiplier),
+      breakdown,
+    };
+  }
 
   const baseXp = Math.round((testDuration - afkDuration) * 2);
   breakdown.base = baseXp;
@@ -807,19 +831,6 @@ async function calculateXp(
     }
   }
 
-  let incompleteXp = 0;
-  if (incompleteTests !== undefined && incompleteTests.length > 0) {
-    incompleteTests.forEach((it: { acc: number; seconds: number }) => {
-      let mod = (it.acc - 50) / 50;
-      if (mod < 0) mod = 0;
-      incompleteXp += Math.round(it.seconds * mod);
-    });
-    breakdown.incomplete = incompleteXp;
-  } else if (incompleteTestSeconds && incompleteTestSeconds > 0) {
-    incompleteXp = Math.round(incompleteTestSeconds);
-    breakdown.incomplete = incompleteXp;
-  }
-
   const accuracyModifier = (acc - 50) / 50;
 
   let dailyBonus = 0;
@@ -843,14 +854,6 @@ async function calculateXp(
 
   const totalXp =
     Math.round((xpAfterAccuracy + incompleteXp) * gainMultiplier) + dailyBonus;
-
-  if (gainMultiplier !== 1) {
-    // breakdown.push([
-    //   "configMultiplier",
-    //   Math.round((xpAfterAccuracy + incompleteXp) * (gainMultiplier - 1)),
-    // ]);
-    breakdown.configMultiplier = gainMultiplier;
-  }
 
   const isAwardingDailyBonus = dailyBonus > 0;
 


### PR DESCRIPTION
### Description

Abandoned tests are pushed to `incompleteTests` and sent with the next saved result. If that next result is a zen test the backend returns 0 xp straight away, but the frontend still clears the list after saving, so the xp for the abandoned tests is just gone. Thats what the reporter sees: quit a custom test, finish a zen test, no incomplete xp, and none on the next words/time test either.

Zen still gets no xp for the test itself, but the incomplete part is now awarded. The list cant just be carried over on the frontend because the result spacing check counts `incompleteTestSeconds`.

Added a spec, on master it gets 0, here it gets the 5 xp from the incomplete test in the fixture.

Closes #8170
